### PR TITLE
[#76] Add profiling status code for httpclient 4

### DIFF
--- a/profiler/src/main/java/com/navercorp/pinpoint/profiler/modifier/connector/httpclient4/interceptor/AbstractHttpRequestExecute.java
+++ b/profiler/src/main/java/com/navercorp/pinpoint/profiler/modifier/connector/httpclient4/interceptor/AbstractHttpRequestExecute.java
@@ -72,6 +72,8 @@ public abstract class AbstractHttpRequestExecute implements TraceContextSupport,
     abstract NameIntValuePair<String> getHost(Object[] args);
 
     abstract HttpRequest getHttpRequest(Object[] args);
+    
+    abstract Integer getStatusCode(Object result);
 
     @Override
     public void before(Object target, Object[] args) {
@@ -156,6 +158,13 @@ public abstract class AbstractHttpRequestExecute implements TraceContextSupport,
 
                 recordHttpRequest(trace, httpRequest, throwable);
             }
+
+            Integer statusCode = getStatusCode(result);
+            
+            if (statusCode != null) {
+                trace.recordAttribute(AnnotationKey.HTTP_STATUS_CODE, statusCode);
+            }
+            
             trace.recordApi(descriptor);
             trace.recordException(throwable);
 

--- a/profiler/src/main/java/com/navercorp/pinpoint/profiler/modifier/connector/httpclient4/interceptor/AsyncClientExecuteInterceptor.java
+++ b/profiler/src/main/java/com/navercorp/pinpoint/profiler/modifier/connector/httpclient4/interceptor/AsyncClientExecuteInterceptor.java
@@ -71,4 +71,9 @@ public class AsyncClientExecuteInterceptor extends AbstractHttpRequestExecute im
             return null;
         }
     }
+
+    @Override
+    Integer getStatusCode(Object result) {
+        return null;
+    }
 }

--- a/profiler/src/main/java/com/navercorp/pinpoint/profiler/modifier/connector/httpclient4/interceptor/AsyncInternalClientExecuteInterceptor.java
+++ b/profiler/src/main/java/com/navercorp/pinpoint/profiler/modifier/connector/httpclient4/interceptor/AsyncInternalClientExecuteInterceptor.java
@@ -116,4 +116,9 @@ public class AsyncInternalClientExecuteInterceptor extends AbstractHttpRequestEx
             return null;
         }
     }
+
+    @Override
+    Integer getStatusCode(Object result) {
+        return null;
+    }
 }

--- a/profiler/src/main/java/com/navercorp/pinpoint/profiler/modifier/connector/httpclient4/interceptor/HttpRequestExecuteInterceptor.java
+++ b/profiler/src/main/java/com/navercorp/pinpoint/profiler/modifier/connector/httpclient4/interceptor/HttpRequestExecuteInterceptor.java
@@ -21,6 +21,7 @@ import com.navercorp.pinpoint.bootstrap.pair.NameIntValuePair;
 
 import org.apache.http.HttpHost;
 import org.apache.http.HttpRequest;
+import org.apache.http.HttpResponse;
 
 /**
  * MethodInfo interceptor
@@ -61,6 +62,19 @@ public class HttpRequestExecuteInterceptor extends AbstractHttpRequestExecute im
         if (arg instanceof HttpRequest) {
             return (HttpRequest) arg;
         }
+        return null;
+    }
+    
+    @Override
+    Integer getStatusCode(Object result) {
+        if (result instanceof HttpResponse) {
+            HttpResponse response = (HttpResponse)result;
+            
+            if (response.getStatusLine() != null) {
+                return response.getStatusLine().getStatusCode(); 
+            }
+        }
+        
         return null;
     }
 

--- a/profiler/src/main/java/com/navercorp/pinpoint/profiler/modifier/connector/httpclient4/interceptor/HttpUriRequestExecuteInterceptor.java
+++ b/profiler/src/main/java/com/navercorp/pinpoint/profiler/modifier/connector/httpclient4/interceptor/HttpUriRequestExecuteInterceptor.java
@@ -22,6 +22,7 @@ import com.navercorp.pinpoint.bootstrap.interceptor.TargetClassLoader;
 import com.navercorp.pinpoint.bootstrap.pair.NameIntValuePair;
 
 import org.apache.http.HttpRequest;
+import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpUriRequest;
 
 /**
@@ -124,6 +125,19 @@ public class HttpUriRequestExecuteInterceptor extends AbstractHttpRequestExecute
             }
         }
         return target;
+    }
+    
+    @Override
+    Integer getStatusCode(Object result) {
+        if (result instanceof HttpResponse) {
+            HttpResponse response = (HttpResponse)result;
+            
+            if (response.getStatusLine() != null) {
+                return response.getStatusLine().getStatusCode(); 
+            }
+        }
+        
+        return null;
     }
 
 }


### PR DESCRIPTION
Can collect status code infomation 
But, not yet collect when call call back method 
ex) Mthod public <T> T execute(final HttpUriRequest request,final ResponseHandler<? extends T> responseHandler, final HttpContext context)

One of these days I will commit code which be able to profiling status code for call back method.