### PR TITLE
Improve state synchronization between server and client. #136

### DIFF
--- a/rpc/src/main/java/com/navercorp/pinpoint/rpc/client/ConnectFuture.java
+++ b/rpc/src/main/java/com/navercorp/pinpoint/rpc/client/ConnectFuture.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2014 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.rpc.client;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author Taejin Koo
+ */
+public class ConnectFuture {
+
+    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+    
+    private final CountDownLatch latch;
+    private final AtomicReference<Result> resultReference;
+
+    public static enum Result {
+        SUCCESS, FAIL
+    }
+
+    public ConnectFuture() {
+        this.latch = new CountDownLatch(1);
+        this.resultReference = new AtomicReference<ConnectFuture.Result>();
+    }
+
+    public Result getResult() {
+        return this.resultReference.get();
+    }
+    
+    void setResult(Result connectResult) {
+        Result result = this.resultReference.get();
+
+        if (result == null) {
+            if (this.resultReference.compareAndSet(null, connectResult)) {
+                latch.countDown();
+            }
+        }
+    }
+
+    public void await() throws InterruptedException {
+        latch.await();
+    }
+
+    public boolean await(long timeout, TimeUnit timeUnit) throws InterruptedException {
+        return latch.await(timeout, timeUnit);
+    }
+
+    public void awaitUninterruptibly() {
+        while (true) {
+            try {
+                await();
+                return;
+            } catch (InterruptedException e) {
+                logger.debug(e.getMessage(), e);
+            }
+        }
+    }
+
+}

--- a/rpc/src/main/java/com/navercorp/pinpoint/rpc/client/ReconnectStateSocketHandler.java
+++ b/rpc/src/main/java/com/navercorp/pinpoint/rpc/client/ReconnectStateSocketHandler.java
@@ -20,6 +20,7 @@ import com.navercorp.pinpoint.rpc.DefaultFuture;
 import com.navercorp.pinpoint.rpc.Future;
 import com.navercorp.pinpoint.rpc.PinpointSocketException;
 import com.navercorp.pinpoint.rpc.ResponseMessage;
+import com.navercorp.pinpoint.rpc.client.ConnectFuture.Result;
 import com.navercorp.pinpoint.rpc.stream.ClientStreamChannelContext;
 import com.navercorp.pinpoint.rpc.stream.ClientStreamChannelMessageListener;
 import com.navercorp.pinpoint.rpc.stream.StreamChannelContext;
@@ -32,14 +33,13 @@ import java.net.SocketAddress;
  */
 public class ReconnectStateSocketHandler implements SocketHandler {
 
-
-    @Override
-    public void setConnectSocketAddress(SocketAddress connectSocketAddress) {
+    private static final ConnectFuture failedConnectFuture = new ConnectFuture();
+    static {
+        failedConnectFuture.setResult(Result.FAIL);
     }
 
     @Override
-    public void open() {
-        throw new IllegalStateException();
+    public void setConnectSocketAddress(SocketAddress connectSocketAddress) {
     }
 
     @Override
@@ -47,6 +47,11 @@ public class ReconnectStateSocketHandler implements SocketHandler {
         //To change body of implemented methods use File | Settings | File Templates.
     }
 
+    @Override
+    public ConnectFuture getConnectFuture() {
+        return failedConnectFuture;
+    }
+    
     @Override
     public void setPinpointSocket(PinpointSocket pinpointSocket) {
     }

--- a/rpc/src/main/java/com/navercorp/pinpoint/rpc/client/SocketHandler.java
+++ b/rpc/src/main/java/com/navercorp/pinpoint/rpc/client/SocketHandler.java
@@ -32,10 +32,10 @@ public interface SocketHandler {
 
     void setConnectSocketAddress(SocketAddress address);
 
-    void open();
-
     void initReconnect();
 
+    ConnectFuture getConnectFuture();
+    
     void setPinpointSocket(PinpointSocket pinpointSocket);
 
     void sendSync(byte[] bytes);

--- a/rpc/src/test/java/com/navercorp/pinpoint/rpc/client/ConnectFutureTest.java
+++ b/rpc/src/test/java/com/navercorp/pinpoint/rpc/client/ConnectFutureTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2014 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.rpc.client;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.navercorp.pinpoint.rpc.client.ConnectFuture.Result;
+
+/**
+ * @author Taejin Koo
+ */
+public class ConnectFutureTest {
+
+    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+    
+    @Test
+    public void setResultTest() {
+        ConnectFuture future = new ConnectFuture();
+        future.setResult(Result.FAIL);
+        future.setResult(Result.SUCCESS);
+        Assert.assertEquals(Result.FAIL, future.getResult());
+
+        future = new ConnectFuture();
+        future.setResult(Result.SUCCESS);
+        future.setResult(Result.FAIL);
+        Assert.assertEquals(Result.SUCCESS, future.getResult());
+    }
+
+    @Test
+    public void awaitTest1() throws InterruptedException {
+        ConnectFuture future = new ConnectFuture();
+        long waitTime = 100;
+        
+        Thread thread = new Thread(new SetResultRunnable(future, waitTime));
+        thread.start();
+        
+        future.await();
+        
+        Assert.assertEquals(Result.SUCCESS, future.getResult());
+    }
+    
+    @Test
+    public void awaitTest2() throws InterruptedException {
+        ConnectFuture future = new ConnectFuture();
+        long waitTime = 100;
+        
+        Thread thread = new Thread(new SetResultRunnable(future, waitTime));
+        thread.start();
+        
+        future.awaitUninterruptibly();
+        
+        Assert.assertEquals(Result.SUCCESS, future.getResult());
+    }
+    
+    @Test
+    public void awaitTest3() throws InterruptedException {
+        ConnectFuture future = new ConnectFuture();
+        long waitTime = 100;
+        
+        Thread thread = new Thread(new SetResultRunnable(future, waitTime));
+        thread.start();
+        
+        future.await(waitTime * 2, TimeUnit.MILLISECONDS);
+        
+        Assert.assertEquals(Result.SUCCESS, future.getResult());
+    }
+    
+    @Test
+    public void awaitTest4() throws InterruptedException {
+        ConnectFuture future = new ConnectFuture();
+        long waitTime = 100;
+        
+        Thread thread = new Thread(new SetResultRunnable(future, waitTime));
+        thread.start();
+        
+        boolean isReady = future.await(waitTime/2, TimeUnit.MILLISECONDS);
+        Assert.assertFalse(isReady);
+        Assert.assertEquals(null, future.getResult());
+
+        isReady = future.await(waitTime, TimeUnit.MILLISECONDS);
+        Assert.assertTrue(isReady);
+        Assert.assertEquals(Result.SUCCESS, future.getResult());
+    }
+
+    class SetResultRunnable implements Runnable {
+        private final ConnectFuture future;
+        private final long waitTime;
+
+        public SetResultRunnable(ConnectFuture future, long waitTime) {
+            this.future = future;
+            this.waitTime = waitTime;
+        }
+
+        @Override
+        public void run() {
+            try {
+                Thread.sleep(waitTime);
+                future.setResult(Result.SUCCESS);
+            } catch (InterruptedException e) {
+                logger.warn(e.getMessage(), e);
+            }
+        }
+
+    }
+
+}


### PR DESCRIPTION
Use netty's channelConnected method instead of SocketHandler's open
method. 
(Netty manage channel's lifecycle. So we can manage
PinpointSocketHandler state more precisely.)