### PR TITLE
Added support for older Oracle jdbc drivers - fixes #193

### DIFF
--- a/bootstrap/src/main/java/com/navercorp/pinpoint/bootstrap/instrument/ByteCodeInstrumentor.java
+++ b/bootstrap/src/main/java/com/navercorp/pinpoint/bootstrap/instrument/ByteCodeInstrumentor.java
@@ -26,6 +26,8 @@ import com.navercorp.pinpoint.bootstrap.interceptor.Interceptor;
 public interface ByteCodeInstrumentor {
 
     InstrumentClass getClass(ClassLoader classLoader, String jvmClassName, byte[] classFileBuffer) throws InstrumentException;
+    
+    boolean findClass(ClassLoader classLoader, String javassistClassName);
 
     Scope getScope(String scopeName);
 

--- a/profiler/src/main/java/com/navercorp/pinpoint/profiler/interceptor/bci/JavaAssistByteCodeInstrumentor.java
+++ b/profiler/src/main/java/com/navercorp/pinpoint/profiler/interceptor/bci/JavaAssistByteCodeInstrumentor.java
@@ -30,8 +30,8 @@ import com.navercorp.pinpoint.bootstrap.interceptor.TargetClassLoader;
 import com.navercorp.pinpoint.profiler.interceptor.GlobalInterceptorRegistryBinder;
 import com.navercorp.pinpoint.profiler.interceptor.InterceptorRegistryBinder;
 import com.navercorp.pinpoint.profiler.util.ScopePool;
-
 import com.navercorp.pinpoint.profiler.util.ThreadLocalScopePool;
+
 import javassist.*;
 
 import org.slf4j.Logger;
@@ -260,6 +260,12 @@ public class JavaAssistByteCodeInstrumentor implements ByteCodeInstrumentor {
             return false;
         }
         return true;
+    }
+
+    @Override
+    public boolean findClass(ClassLoader classLoader, String javassistClassName) {
+        ClassPool classPool = findClassPool(classLoader);
+        return findClass(javassistClassName, classPool);
     }
 
     @Override

--- a/profiler/src/main/java/com/navercorp/pinpoint/profiler/modifier/AbstractModifierDelegate.java
+++ b/profiler/src/main/java/com/navercorp/pinpoint/profiler/modifier/AbstractModifierDelegate.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2015 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.profiler.modifier;
+
+import com.navercorp.pinpoint.bootstrap.instrument.ByteCodeInstrumentor;
+
+/**
+ * @author HyunGil Jeong
+ */
+public abstract class AbstractModifierDelegate implements ModifierDelegate {
+    
+    protected final ByteCodeInstrumentor byteCodeInstrumentor;
+    
+    public AbstractModifierDelegate(ByteCodeInstrumentor byteCodeInstrumentor) {
+        this.byteCodeInstrumentor = byteCodeInstrumentor;
+    }
+    
+}

--- a/profiler/src/main/java/com/navercorp/pinpoint/profiler/modifier/DefaultModifierRegistry.java
+++ b/profiler/src/main/java/com/navercorp/pinpoint/profiler/modifier/DefaultModifierRegistry.java
@@ -61,7 +61,9 @@ import com.navercorp.pinpoint.profiler.modifier.db.mysql.MySQLPreparedStatementJ
 import com.navercorp.pinpoint.profiler.modifier.db.mysql.MySQLPreparedStatementModifier;
 import com.navercorp.pinpoint.profiler.modifier.db.mysql.MySQLStatementModifier;
 import com.navercorp.pinpoint.profiler.modifier.db.oracle.OracleDriverModifier;
+import com.navercorp.pinpoint.profiler.modifier.db.oracle.OraclePreparedStatementModifier;
 import com.navercorp.pinpoint.profiler.modifier.db.oracle.OraclePreparedStatementWrapperModifier;
+import com.navercorp.pinpoint.profiler.modifier.db.oracle.OracleStatementModifier;
 import com.navercorp.pinpoint.profiler.modifier.db.oracle.OracleStatementWrapperModifier;
 import com.navercorp.pinpoint.profiler.modifier.db.oracle.PhysicalConnectionModifier;
 import com.navercorp.pinpoint.profiler.modifier.method.MethodModifier;
@@ -75,15 +77,9 @@ import com.navercorp.pinpoint.profiler.modifier.redis.JedisModifier;
 import com.navercorp.pinpoint.profiler.modifier.redis.JedisMultiKeyPipelineBaseModifier;
 import com.navercorp.pinpoint.profiler.modifier.redis.JedisPipelineBaseModifier;
 import com.navercorp.pinpoint.profiler.modifier.redis.JedisPipelineModifier;
-import com.navercorp.pinpoint.profiler.modifier.servlet.HttpServletModifier;
 import com.navercorp.pinpoint.profiler.modifier.servlet.SpringFrameworkServletModifier;
 import com.navercorp.pinpoint.profiler.modifier.spring.beans.AbstractAutowireCapableBeanFactoryModifier;
 import com.navercorp.pinpoint.profiler.modifier.spring.orm.ibatis.SqlMapClientTemplateModifier;
-import com.navercorp.pinpoint.profiler.modifier.tomcat.RequestFacadeModifier;
-import com.navercorp.pinpoint.profiler.modifier.tomcat.StandardHostValveInvokeModifier;
-import com.navercorp.pinpoint.profiler.modifier.tomcat.StandardServiceModifier;
-import com.navercorp.pinpoint.profiler.modifier.tomcat.TomcatConnectorModifier;
-import com.navercorp.pinpoint.profiler.modifier.tomcat.WebappLoaderModifier;
 
 /**
  * @author emeroad
@@ -321,11 +317,15 @@ public class DefaultModifierRegistry implements ModifierRegistry {
         AbstractModifier oracleConnectionModifier = new PhysicalConnectionModifier(byteCodeInstrumentor, agent);
         addModifier(oracleConnectionModifier);
 
-        AbstractModifier oraclePreparedStatementModifier = new OraclePreparedStatementWrapperModifier(byteCodeInstrumentor, agent);
+        AbstractModifier oraclePreparedStatementWrapperModifier = new OraclePreparedStatementWrapperModifier(byteCodeInstrumentor, agent);
+        addModifier(oraclePreparedStatementWrapperModifier);
+        AbstractModifier oraclePreparedStatementModifier = new OraclePreparedStatementModifier(byteCodeInstrumentor, agent);
         addModifier(oraclePreparedStatementModifier);
 
-        AbstractModifier oracleStatement = new OracleStatementWrapperModifier(byteCodeInstrumentor, agent);
-        addModifier(oracleStatement);
+        AbstractModifier oracleStatementWrapperModifier = new OracleStatementWrapperModifier(byteCodeInstrumentor, agent);
+        addModifier(oracleStatementWrapperModifier);
+        AbstractModifier oracleStatementModifier = new OracleStatementModifier(byteCodeInstrumentor, agent);
+        addModifier(oracleStatementModifier);
         //
         // Modifier oracleResultSetModifier = new OracleResultSetModifier(byteCodeInstrumentor, agent);
         // addModifier(oracleResultSetModifier);

--- a/profiler/src/main/java/com/navercorp/pinpoint/profiler/modifier/ModifierDelegate.java
+++ b/profiler/src/main/java/com/navercorp/pinpoint/profiler/modifier/ModifierDelegate.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2015 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.profiler.modifier;
+
+/**
+ * @author HyunGil Jeong
+ */
+public interface ModifierDelegate extends Modifier {
+
+}

--- a/profiler/src/main/java/com/navercorp/pinpoint/profiler/modifier/db/interceptor/PreparedStatementCreateInterceptor.java
+++ b/profiler/src/main/java/com/navercorp/pinpoint/profiler/modifier/db/interceptor/PreparedStatementCreateInterceptor.java
@@ -76,9 +76,10 @@ public class PreparedStatementCreateInterceptor extends SpanEventSimpleAroundInt
 
     @Override
     public void doInAfterTrace(RecordableTrace trace, Object target, Object[] args, Object result, Throwable throwable) {
-
-        ParsingResult parsingResult = ((ParsingResultTraceValue) result)._$PINPOINT$_getTraceParsingResult();
-        trace.recordSqlParsingResult(parsingResult);
+        if (result instanceof ParsingResultTraceValue) {
+            ParsingResult parsingResult = ((ParsingResultTraceValue) result)._$PINPOINT$_getTraceParsingResult();
+            trace.recordSqlParsingResult(parsingResult);
+        }
         trace.recordException(throwable);
         trace.recordApi(getMethodDescriptor());
 

--- a/profiler/src/main/java/com/navercorp/pinpoint/profiler/modifier/db/oracle/OracleClassConstants.java
+++ b/profiler/src/main/java/com/navercorp/pinpoint/profiler/modifier/db/oracle/OracleClassConstants.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2015 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.profiler.modifier.db.oracle;
+
+/**
+ * @author HyunGil Jeong
+ */
+public class OracleClassConstants {
+
+    private OracleClassConstants() {}
+    
+    public static final String ORACLE_STATEMENT = "oracle/jdbc/driver/OracleStatement";
+    public static final String ORACLE_STATEMENT_WRAPPER = "oracle/jdbc/driver/OracleStatementWrapper";
+    
+    public static final String ORACLE_PREPARED_STATEMENT = "oracle/jdbc/driver/OraclePreparedStatement";
+    public static final String ORACLE_PREPARED_STATEMENT_WRAPPER = "oracle/jdbc/driver/OraclePreparedStatementWrapper";
+    
+}

--- a/profiler/src/main/java/com/navercorp/pinpoint/profiler/modifier/db/oracle/OraclePreparedStatementModifier.java
+++ b/profiler/src/main/java/com/navercorp/pinpoint/profiler/modifier/db/oracle/OraclePreparedStatementModifier.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2015 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.profiler.modifier.db.oracle;
+
+import java.security.ProtectionDomain;
+
+import com.navercorp.pinpoint.bootstrap.Agent;
+import com.navercorp.pinpoint.bootstrap.instrument.ByteCodeInstrumentor;
+import com.navercorp.pinpoint.profiler.modifier.AbstractModifier;
+import com.navercorp.pinpoint.profiler.modifier.ModifierDelegate;
+
+/**
+ * For ojdbc library without OraclePreparedStatementWrapper.
+ * eg. ojdbc-10.0.x
+ * 
+ * @author HyunGil Jeong
+ */
+public class OraclePreparedStatementModifier extends AbstractModifier {
+
+    private final ModifierDelegate delegate;
+
+    public OraclePreparedStatementModifier(ByteCodeInstrumentor byteCodeInstrumentor, Agent agent) {
+        super(byteCodeInstrumentor, agent);
+        this.delegate = new OraclePreparedStatementModifierDelegate(byteCodeInstrumentor);
+    }
+
+    @Override
+    public String getTargetClass() {
+        return OracleClassConstants.ORACLE_PREPARED_STATEMENT;
+    }
+
+    @Override
+    public byte[] modify(ClassLoader classLoader, String javassistClassName, ProtectionDomain protectedDomain, byte[] classFileBuffer) {
+        // Do not modify if wrapper exists
+        if (byteCodeInstrumentor.findClass(classLoader, OracleClassConstants.ORACLE_PREPARED_STATEMENT_WRAPPER)) {
+            return null;
+        }
+        return this.delegate.modify(classLoader, javassistClassName, protectedDomain, classFileBuffer);
+    }
+
+}

--- a/profiler/src/main/java/com/navercorp/pinpoint/profiler/modifier/db/oracle/OraclePreparedStatementModifierDelegate.java
+++ b/profiler/src/main/java/com/navercorp/pinpoint/profiler/modifier/db/oracle/OraclePreparedStatementModifierDelegate.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2015 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.profiler.modifier.db.oracle;
+
+import java.lang.reflect.Method;
+import java.security.ProtectionDomain;
+import java.util.Arrays;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.navercorp.pinpoint.bootstrap.instrument.ByteCodeInstrumentor;
+import com.navercorp.pinpoint.bootstrap.instrument.InstrumentClass;
+import com.navercorp.pinpoint.bootstrap.instrument.InstrumentException;
+import com.navercorp.pinpoint.bootstrap.instrument.NotFoundInstrumentException;
+import com.navercorp.pinpoint.bootstrap.instrument.Scope;
+import com.navercorp.pinpoint.bootstrap.interceptor.Interceptor;
+import com.navercorp.pinpoint.bootstrap.interceptor.tracevalue.BindValueTraceValue;
+import com.navercorp.pinpoint.bootstrap.interceptor.tracevalue.DatabaseInfoTraceValue;
+import com.navercorp.pinpoint.bootstrap.interceptor.tracevalue.ParsingResultTraceValue;
+import com.navercorp.pinpoint.profiler.interceptor.ScopeDelegateStaticInterceptor;
+import com.navercorp.pinpoint.profiler.modifier.AbstractModifierDelegate;
+import com.navercorp.pinpoint.profiler.modifier.db.interceptor.PreparedStatementBindVariableInterceptor;
+import com.navercorp.pinpoint.profiler.modifier.db.interceptor.PreparedStatementExecuteQueryInterceptor;
+import com.navercorp.pinpoint.profiler.util.JavaAssistUtils;
+import com.navercorp.pinpoint.profiler.util.PreparedStatementUtils;
+
+/**
+ * @author HyunGil Jeong
+ */
+public class OraclePreparedStatementModifierDelegate extends AbstractModifierDelegate {
+    
+    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+    
+    public OraclePreparedStatementModifierDelegate(ByteCodeInstrumentor byteCodeInstrumentor) {
+        super(byteCodeInstrumentor);
+    }
+
+    @Override
+    public byte[] modify(ClassLoader classLoader, String className, ProtectionDomain protectedDomain, byte[] classFileBuffer) {
+        if (logger.isInfoEnabled()) {
+            logger.info("Modifying. {}", className);
+        }
+        try {
+            InstrumentClass preparedStatement = byteCodeInstrumentor.getClass(classLoader, className, classFileBuffer);
+
+            Interceptor execute = new PreparedStatementExecuteQueryInterceptor();
+            preparedStatement.addScopeInterceptor("execute", null, execute, OracleScope.SCOPE_NAME);
+            Interceptor executeQuery = new PreparedStatementExecuteQueryInterceptor();
+            preparedStatement.addScopeInterceptor("executeQuery", null, executeQuery, OracleScope.SCOPE_NAME);
+            Interceptor executeUpdate = new PreparedStatementExecuteQueryInterceptor();
+            preparedStatement.addScopeInterceptor("executeUpdate", null, executeUpdate, OracleScope.SCOPE_NAME);
+
+            preparedStatement.addTraceValue(DatabaseInfoTraceValue.class);
+            preparedStatement.addTraceValue(ParsingResultTraceValue.class);
+            preparedStatement.addTraceValue(BindValueTraceValue.class, "new java.util.HashMap();");
+            bindVariableIntercept(preparedStatement, classLoader, protectedDomain);
+
+            return preparedStatement.toBytecode();
+        } catch (InstrumentException e) {
+            if (logger.isWarnEnabled()) {
+                logger.warn("{} modify fail. Cause:{}", this.getClass().getSimpleName(), e.getMessage(), e);
+            }
+            return null;
+        }
+    }
+
+    private void bindVariableIntercept(InstrumentClass preparedStatement, ClassLoader classLoader, ProtectionDomain protectedDomain) throws InstrumentException {
+        List<Method> bindMethod = PreparedStatementUtils.findBindVariableSetMethod();
+        final Scope scope = byteCodeInstrumentor.getScope(OracleScope.SCOPE_NAME);
+        Interceptor interceptor = new ScopeDelegateStaticInterceptor(new PreparedStatementBindVariableInterceptor(), scope);
+        int interceptorId = -1;
+        for (Method method : bindMethod) {
+            String methodName = method.getName();
+            String[] parameterType = JavaAssistUtils.getParameterType(method.getParameterTypes());
+            try {
+                if (interceptorId == -1) {
+                    interceptorId = preparedStatement.addInterceptor(methodName, parameterType, interceptor);
+                } else {
+                    preparedStatement.reuseInterceptor(methodName, parameterType, interceptorId);
+                }
+            } catch (NotFoundInstrumentException e) {
+                // Cannot find bind variable setter method. This is not an error. logging will be enough.
+                if (logger.isDebugEnabled()) {
+                    logger.debug("bindVariable api not found. method:{} param:{} Cause:{}", methodName, Arrays.toString(parameterType), e.getMessage());
+                }
+            }
+        }
+    }
+
+}

--- a/profiler/src/main/java/com/navercorp/pinpoint/profiler/modifier/db/oracle/OraclePreparedStatementWrapperModifier.java
+++ b/profiler/src/main/java/com/navercorp/pinpoint/profiler/modifier/db/oracle/OraclePreparedStatementWrapperModifier.java
@@ -16,96 +16,32 @@
 
 package com.navercorp.pinpoint.profiler.modifier.db.oracle;
 
+import java.security.ProtectionDomain;
+
 import com.navercorp.pinpoint.bootstrap.Agent;
 import com.navercorp.pinpoint.bootstrap.instrument.ByteCodeInstrumentor;
-import com.navercorp.pinpoint.bootstrap.instrument.InstrumentClass;
-import com.navercorp.pinpoint.bootstrap.instrument.InstrumentException;
-import com.navercorp.pinpoint.bootstrap.instrument.NotFoundInstrumentException;
-import com.navercorp.pinpoint.bootstrap.instrument.Scope;
-import com.navercorp.pinpoint.bootstrap.interceptor.Interceptor;
-import com.navercorp.pinpoint.bootstrap.interceptor.tracevalue.BindValueTraceValue;
-import com.navercorp.pinpoint.bootstrap.interceptor.tracevalue.DatabaseInfoTraceValue;
-import com.navercorp.pinpoint.bootstrap.interceptor.tracevalue.ParsingResultTraceValue;
-import com.navercorp.pinpoint.profiler.interceptor.ScopeDelegateStaticInterceptor;
 import com.navercorp.pinpoint.profiler.modifier.AbstractModifier;
-import com.navercorp.pinpoint.profiler.modifier.db.interceptor.*;
-import com.navercorp.pinpoint.profiler.util.JavaAssistUtils;
-import com.navercorp.pinpoint.profiler.util.PreparedStatementUtils;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.lang.reflect.Method;
-import java.security.ProtectionDomain;
-import java.util.Arrays;
-import java.util.List;
+import com.navercorp.pinpoint.profiler.modifier.ModifierDelegate;
 
 /**
  * @author emeroad
  */
 public class OraclePreparedStatementWrapperModifier extends AbstractModifier {
-    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+
+    private final ModifierDelegate delegate;
 
     public OraclePreparedStatementWrapperModifier(ByteCodeInstrumentor byteCodeInstrumentor, Agent agent) {
         super(byteCodeInstrumentor, agent);
+        this.delegate = new OraclePreparedStatementModifierDelegate(byteCodeInstrumentor);
     }
 
     public String getTargetClass() {
-        return "oracle/jdbc/driver/OraclePreparedStatementWrapper";
+        return OracleClassConstants.ORACLE_PREPARED_STATEMENT_WRAPPER;
     }
 
+    @Override
     public byte[] modify(ClassLoader classLoader, String javassistClassName, ProtectionDomain protectedDomain, byte[] classFileBuffer) {
-        if (logger.isInfoEnabled()) {
-            logger.info("Modifing. {}", javassistClassName);
-        }
-
-        try {
-            InstrumentClass preparedStatement = byteCodeInstrumentor.getClass(classLoader, javassistClassName, classFileBuffer);
-
-            Interceptor execute = new PreparedStatementExecuteQueryInterceptor();
-            preparedStatement.addScopeInterceptor("execute", null, execute, OracleScope.SCOPE_NAME);
-            Interceptor executeQuery = new PreparedStatementExecuteQueryInterceptor();
-            preparedStatement.addScopeInterceptor("executeQuery", null, executeQuery, OracleScope.SCOPE_NAME);
-            Interceptor executeUpdate = new PreparedStatementExecuteQueryInterceptor();
-            preparedStatement.addScopeInterceptor("executeUpdate", null, executeUpdate, OracleScope.SCOPE_NAME);
-
-            preparedStatement.addTraceValue(DatabaseInfoTraceValue.class);
-            preparedStatement.addTraceValue(ParsingResultTraceValue.class);
-            preparedStatement.addTraceValue(BindValueTraceValue.class, "new java.util.HashMap();");
-            bindVariableIntercept(preparedStatement, classLoader, protectedDomain);
-
-            return preparedStatement.toBytecode();
-        } catch (InstrumentException e) {
-            if (logger.isWarnEnabled()) {
-                logger.warn("{} modify fail. Cause:{}", this.getClass().getSimpleName(), e.getMessage(), e);
-            }
-            return null;
-        }
-
-    }
-
-    private void bindVariableIntercept(InstrumentClass preparedStatement, ClassLoader classLoader, ProtectionDomain protectedDomain) throws InstrumentException {
-        List<Method> bindMethod = PreparedStatementUtils.findBindVariableSetMethod();
-        final Scope scope = byteCodeInstrumentor.getScope(OracleScope.SCOPE_NAME);
-        Interceptor interceptor = new ScopeDelegateStaticInterceptor(new PreparedStatementBindVariableInterceptor(), scope);
-        int interceptorId = -1;
-        for (Method method : bindMethod) {
-            String methodName = method.getName();
-            String[] parameterType = JavaAssistUtils.getParameterType(method.getParameterTypes());
-            try {
-                if (interceptorId == -1) {
-                    interceptorId = preparedStatement.addInterceptor(methodName, parameterType, interceptor);
-                } else {
-                    preparedStatement.reuseInterceptor(methodName, parameterType, interceptorId);
-                }
-            } catch (NotFoundInstrumentException e) {
-                // Cannot find bind variable setter method. This is not an error. logging will be enough.
-                if (logger.isDebugEnabled()) {
-                    logger.debug("bindVariable api not found. method:{} param:{} Cause:{}", methodName, Arrays.toString(parameterType), e.getMessage());
-                }
-            }
-        }
-
+        return this.delegate.modify(classLoader, javassistClassName, protectedDomain, classFileBuffer);
     }
 
 }

--- a/profiler/src/main/java/com/navercorp/pinpoint/profiler/modifier/db/oracle/OracleStatementModifier.java
+++ b/profiler/src/main/java/com/navercorp/pinpoint/profiler/modifier/db/oracle/OracleStatementModifier.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2015 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.profiler.modifier.db.oracle;
+
+import java.security.ProtectionDomain;
+
+import com.navercorp.pinpoint.bootstrap.Agent;
+import com.navercorp.pinpoint.bootstrap.instrument.ByteCodeInstrumentor;
+import com.navercorp.pinpoint.profiler.modifier.AbstractModifier;
+import com.navercorp.pinpoint.profiler.modifier.ModifierDelegate;
+
+/**
+ * For ojdbc library without OracleStatementWrapper.
+ * eg. ojdbc-10.0.x
+ * 
+ * @author HyunGil Jeong
+ */
+public class OracleStatementModifier extends AbstractModifier {
+
+    private final ModifierDelegate delegate;
+    
+    public OracleStatementModifier(ByteCodeInstrumentor byteCodeInstrumentor, Agent agent) {
+        super(byteCodeInstrumentor, agent);
+        this.delegate = new OracleStatementModifierDelegate(byteCodeInstrumentor);
+    }
+
+    @Override
+    public String getTargetClass() {
+        return OracleClassConstants.ORACLE_STATEMENT;
+    }
+
+    @Override
+    public byte[] modify(ClassLoader classLoader, String javassistClassName, ProtectionDomain protectedDomain, byte[] classFileBuffer) {
+     // Do not modify if wrapper exists
+        if (byteCodeInstrumentor.findClass(classLoader, OracleClassConstants.ORACLE_STATEMENT_WRAPPER)) {
+            return null;
+        }
+        return this.delegate.modify(classLoader, javassistClassName, protectedDomain, classFileBuffer);
+    }
+    
+}

--- a/profiler/src/main/java/com/navercorp/pinpoint/profiler/modifier/db/oracle/OracleStatementModifierDelegate.java
+++ b/profiler/src/main/java/com/navercorp/pinpoint/profiler/modifier/db/oracle/OracleStatementModifierDelegate.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2015 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.profiler.modifier.db.oracle;
+
+import java.security.ProtectionDomain;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.navercorp.pinpoint.bootstrap.instrument.ByteCodeInstrumentor;
+import com.navercorp.pinpoint.bootstrap.instrument.InstrumentClass;
+import com.navercorp.pinpoint.bootstrap.instrument.InstrumentException;
+import com.navercorp.pinpoint.bootstrap.interceptor.Interceptor;
+import com.navercorp.pinpoint.bootstrap.interceptor.tracevalue.DatabaseInfoTraceValue;
+import com.navercorp.pinpoint.profiler.modifier.AbstractModifierDelegate;
+import com.navercorp.pinpoint.profiler.modifier.db.interceptor.StatementExecuteQueryInterceptor;
+import com.navercorp.pinpoint.profiler.modifier.db.interceptor.StatementExecuteUpdateInterceptor;
+
+/**
+ * @author HyunGil Jeong
+ */
+public class OracleStatementModifierDelegate extends AbstractModifierDelegate {
+    
+    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+    
+    public OracleStatementModifierDelegate(ByteCodeInstrumentor byteCodeInstrumentor) {
+        super(byteCodeInstrumentor);
+    }
+
+    @Override
+    public byte[] modify(ClassLoader classLoader, String className, ProtectionDomain protectedDomain, byte[] classFileBuffer) {
+        if (logger.isInfoEnabled()) {
+            logger.info("Modifying. {}", className);
+        }
+        try {
+            InstrumentClass statementClass = byteCodeInstrumentor.getClass(classLoader, className, classFileBuffer);
+            Interceptor executeQuery = new StatementExecuteQueryInterceptor();
+            statementClass.addScopeInterceptor("executeQuery", new String[]{"java.lang.String"}, executeQuery, OracleScope.SCOPE_NAME);
+
+            // FIXME
+            Interceptor executeUpdateInterceptor1 = new StatementExecuteUpdateInterceptor();
+            statementClass.addScopeInterceptor("executeUpdate", new String[]{"java.lang.String"}, executeUpdateInterceptor1, OracleScope.SCOPE_NAME);
+
+
+            Interceptor executeUpdateInterceptor2 = new StatementExecuteUpdateInterceptor();
+            statementClass.addScopeInterceptor("executeUpdate", new String[]{"java.lang.String", "int"}, executeUpdateInterceptor2, OracleScope.SCOPE_NAME);
+
+            Interceptor executeInterceptor1 = new StatementExecuteUpdateInterceptor();
+            statementClass.addScopeInterceptor("execute", new String[]{"java.lang.String"}, executeInterceptor1, OracleScope.SCOPE_NAME);
+
+            Interceptor executeInterceptor2 = new StatementExecuteUpdateInterceptor();
+            statementClass.addScopeInterceptor("execute", new String[]{"java.lang.String", "int"}, executeInterceptor2, OracleScope.SCOPE_NAME);
+
+            statementClass.addTraceValue(DatabaseInfoTraceValue.class);
+            return statementClass.toBytecode();
+        } catch (InstrumentException e) {
+            if (logger.isWarnEnabled()) {
+                logger.warn("{} modify fail. Cause:{}", this.getClass().getSimpleName(), e.getMessage(), e);
+            }
+            return null;
+        }
+    }
+
+}

--- a/profiler/src/main/java/com/navercorp/pinpoint/profiler/modifier/db/oracle/OracleStatementWrapperModifier.java
+++ b/profiler/src/main/java/com/navercorp/pinpoint/profiler/modifier/db/oracle/OracleStatementWrapperModifier.java
@@ -16,70 +16,33 @@
 
 package com.navercorp.pinpoint.profiler.modifier.db.oracle;
 
+import java.security.ProtectionDomain;
+
 import com.navercorp.pinpoint.bootstrap.Agent;
 import com.navercorp.pinpoint.bootstrap.instrument.ByteCodeInstrumentor;
-import com.navercorp.pinpoint.bootstrap.instrument.InstrumentClass;
-import com.navercorp.pinpoint.bootstrap.instrument.InstrumentException;
-import com.navercorp.pinpoint.bootstrap.interceptor.Interceptor;
-import com.navercorp.pinpoint.bootstrap.interceptor.tracevalue.DatabaseInfoTraceValue;
 import com.navercorp.pinpoint.profiler.modifier.AbstractModifier;
-import com.navercorp.pinpoint.profiler.modifier.db.interceptor.StatementExecuteQueryInterceptor;
-import com.navercorp.pinpoint.profiler.modifier.db.interceptor.StatementExecuteUpdateInterceptor;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.security.ProtectionDomain;
+import com.navercorp.pinpoint.profiler.modifier.ModifierDelegate;
 
 /**
  * @author emeroad
  */
 public class OracleStatementWrapperModifier extends AbstractModifier {
 
-    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+    private final ModifierDelegate delegate;
 
     public OracleStatementWrapperModifier(ByteCodeInstrumentor byteCodeInstrumentor, Agent agent) {
         super(byteCodeInstrumentor, agent);
+        this.delegate = new OracleStatementModifierDelegate(byteCodeInstrumentor);
     }
 
+    @Override
     public String getTargetClass() {
-        return "oracle/jdbc/driver/OracleStatementWrapper";
+        return OracleClassConstants.ORACLE_STATEMENT_WRAPPER;
     }
 
+    @Override
     public byte[] modify(ClassLoader classLoader, String javassistClassName, ProtectionDomain protectedDomain, byte[] classFileBuffer) {
-        if (logger.isInfoEnabled()) {
-            logger.info("Modifing. {}", javassistClassName);
-        }
-
-
-        try {
-            InstrumentClass statementClass = byteCodeInstrumentor.getClass(classLoader, javassistClassName, classFileBuffer);
-            Interceptor executeQuery = new StatementExecuteQueryInterceptor();
-            statementClass.addScopeInterceptor("executeQuery", new String[]{"java.lang.String"}, executeQuery, OracleScope.SCOPE_NAME);
-
-            // FIXME
-            Interceptor executeUpdateInterceptor1 = new StatementExecuteUpdateInterceptor();
-            statementClass.addScopeInterceptor("executeUpdate", new String[]{"java.lang.String"}, executeUpdateInterceptor1, OracleScope.SCOPE_NAME);
-
-
-            Interceptor executeUpdateInterceptor2 = new StatementExecuteUpdateInterceptor();
-            statementClass.addScopeInterceptor("executeUpdate", new String[]{"java.lang.String", "int"}, executeUpdateInterceptor2, OracleScope.SCOPE_NAME);
-
-            Interceptor executeInterceptor1 = new StatementExecuteUpdateInterceptor();
-            statementClass.addScopeInterceptor("execute", new String[]{"java.lang.String"}, executeInterceptor1, OracleScope.SCOPE_NAME);
-
-            Interceptor executeInterceptor2 = new StatementExecuteUpdateInterceptor();
-            statementClass.addScopeInterceptor("execute", new String[]{"java.lang.String", "int"}, executeInterceptor2, OracleScope.SCOPE_NAME);
-
-            statementClass.addTraceValue(DatabaseInfoTraceValue.class);
-            return statementClass.toBytecode();
-        } catch (InstrumentException e) {
-            if (logger.isWarnEnabled()) {
-                logger.warn("{} modify fail. Cause:{}", this.getClass().getSimpleName(), e.getMessage(), e);
-            }
-            return null;
-        }
+        return this.delegate.modify(classLoader, javassistClassName, protectedDomain, classFileBuffer);
     }
-
 
 }


### PR DESCRIPTION
Added tracing support for Oracle jdbc drivers 10.x and older.
Modifiers can now also check if a class can exists in a given class loader's path. (Necessary for ojdbc 11+ as `OracleStatementModifier` and `OraclePreparedStatementModifier` should not modify their target classes when their wrapper classes exist)