### PR TITLE
[#215] Let bootstrap handle agent's lifecycle. 

### DIFF
--- a/bootstrap/src/main/java/com/navercorp/pinpoint/bootstrap/PinpointBootStrap.java
+++ b/bootstrap/src/main/java/com/navercorp/pinpoint/bootstrap/PinpointBootStrap.java
@@ -123,7 +123,9 @@ public class PinpointBootStrap {
             String bootClass = argMap.containsKey("bootClass") ? argMap.get("bootClass") : BOOT_CLASS;
             agentClassLoader.setBootClass(bootClass);
             logger.info("pinpoint agent [" + bootClass + "] starting...");
-            agentClassLoader.boot(agentArgs, instrumentation, profilerConfig, pluginJars, serviceTypeRegistryService);
+            Agent pinpointAgent = agentClassLoader.boot(agentArgs, instrumentation, profilerConfig, pluginJars, serviceTypeRegistryService);
+            pinpointAgent.start();
+            registerShutdownHook(pinpointAgent);
             logger.info("pinpoint agent started normally.");
         } catch (Exception e) {
             // unexpected exception that did not be checked above
@@ -133,6 +135,15 @@ public class PinpointBootStrap {
 
     }
     
+    private static void registerShutdownHook(final Agent pinpointAgent) {
+        Runtime.getRuntime().addShutdownHook(new Thread() {
+            @Override
+            public void run() {
+                pinpointAgent.stop();
+            }
+        });
+    }
+
     private static Map<String, String> parseAgentArgs(String str) {
         Map<String, String> map = new HashMap<String, String>();
         

--- a/bootstrap/src/main/java/com/navercorp/pinpoint/bootstrap/context/ServerMetaDataHolder.java
+++ b/bootstrap/src/main/java/com/navercorp/pinpoint/bootstrap/context/ServerMetaDataHolder.java
@@ -22,11 +22,22 @@ import java.util.List;
  * @author hyungil.jeong
  */
 public interface ServerMetaDataHolder {
+    
     void setServerName(String serverName);
     
     void addConnector(String protocol, int port);
     
     void addServiceInfo(String serviceName, List<String> serviceLibs);
     
-    ServerMetaData getServerMetaData();
+    void addListener(ServerMetaDataListener listener);
+    
+    void removeListener(ServerMetaDataListener listener);
+    
+    void publishServerMetaData();
+    
+    public interface ServerMetaDataListener {
+        
+        public void publishServerMetaData(ServerMetaData serverMetaData);
+        
+    }
 }

--- a/bootstrap/src/main/java/com/navercorp/pinpoint/bootstrap/interceptor/LifeCycleEventListener.java
+++ b/bootstrap/src/main/java/com/navercorp/pinpoint/bootstrap/interceptor/LifeCycleEventListener.java
@@ -24,6 +24,7 @@ import com.navercorp.pinpoint.bootstrap.logging.PLoggerFactory;
  * @author emeroad
  * @author hyungil.jeong
  */
+@Deprecated
 public class LifeCycleEventListener {
 
     private final static PLogger logger = PLoggerFactory.getLogger(LifeCycleEventListener.class.getName());

--- a/plugins/tomcat/src/main/java/com/navercorp/pinpoint/plugin/tomcat/interceptor/StandardServiceStartInterceptor.java
+++ b/plugins/tomcat/src/main/java/com/navercorp/pinpoint/plugin/tomcat/interceptor/StandardServiceStartInterceptor.java
@@ -51,5 +51,7 @@ public class StandardServiceStartInterceptor implements SimpleAroundInterceptor 
 
         String serverInfo = ServerInfo.getServerInfo();
         this.traceContext.getServerMetaDataHolder().setServerName(serverInfo);
+        // Service started. Publish server meta data.
+        this.traceContext.getServerMetaDataHolder().publishServerMetaData();
     }
 }

--- a/profiler/src/main/java/com/navercorp/pinpoint/profiler/DefaultAgent.java
+++ b/profiler/src/main/java/com/navercorp/pinpoint/profiler/DefaultAgent.java
@@ -134,7 +134,6 @@ public class DefaultAgent implements Agent {
             throw new NullPointerException("serviceTypeRegistryService must not be null");
         }
 
-
         this.binder = new Slf4jLoggerBinder();
         bindPLoggerFactory(this.binder);
 
@@ -193,10 +192,7 @@ public class DefaultAgent implements Agent {
         this.classFileTransformer = new ClassFileTransformerDispatcher(this, byteCodeInstrumentor, retransformer, pluginContexts, pluginJars);
         instrumentation.addTransformer(this.classFileTransformer);
 
-
         preLoadClass();
-
-        start();
     }
 
     private CommandDispatcher createCommandDispatcher() {

--- a/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/DefaultServerMetaDataHolder.java
+++ b/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/DefaultServerMetaDataHolder.java
@@ -33,6 +33,8 @@ import com.navercorp.pinpoint.bootstrap.context.ServiceInfo;
  * @author hyungil.jeong
  */
 public class DefaultServerMetaDataHolder implements ServerMetaDataHolder {
+    
+    private final List<ServerMetaDataListener> listeners;
 
     protected String serverName;
     private final List<String> vmArgs;
@@ -40,6 +42,7 @@ public class DefaultServerMetaDataHolder implements ServerMetaDataHolder {
     protected final Queue<ServiceInfo> serviceInfos = new ConcurrentLinkedQueue<ServiceInfo>();
 
     public DefaultServerMetaDataHolder(List<String> vmArgs) {
+        this.listeners = new ArrayList<ServerMetaDataListener>();
         this.vmArgs = vmArgs;
     }
 
@@ -60,7 +63,24 @@ public class DefaultServerMetaDataHolder implements ServerMetaDataHolder {
     }
 
     @Override
-    public ServerMetaData getServerMetaData() {
+    public void addListener(ServerMetaDataListener listener) {
+        this.listeners.add(listener);
+    }
+
+    @Override
+    public void removeListener(ServerMetaDataListener listener) {
+        this.listeners.remove(listener);
+    }
+
+    @Override
+    public void publishServerMetaData() {
+        final ServerMetaData serverMetaData = createServerMetaData();
+        for (ServerMetaDataListener listener : this.listeners) {
+            listener.publishServerMetaData(serverMetaData);
+        }
+    }
+
+    private ServerMetaData createServerMetaData() {
         String serverName = this.serverName == null ? "" : this.serverName;
         List<String> vmArgs = 
                 this.vmArgs == null ? Collections.<String>emptyList() : new ArrayList<String>(this.vmArgs);

--- a/profiler/src/main/java/com/navercorp/pinpoint/profiler/util/ApplicationServerTypeResolver.java
+++ b/profiler/src/main/java/com/navercorp/pinpoint/profiler/util/ApplicationServerTypeResolver.java
@@ -19,12 +19,12 @@ package com.navercorp.pinpoint.profiler.util;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.navercorp.pinpoint.common.service.ServiceTypeRegistryService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.navercorp.pinpoint.bootstrap.plugin.ServerTypeDetector;
 import com.navercorp.pinpoint.common.ServiceType;
+import com.navercorp.pinpoint.common.service.ServiceTypeRegistryService;
 import com.navercorp.pinpoint.profiler.plugin.DefaultProfilerPluginContext;
 
 /**
@@ -40,26 +40,18 @@ public class ApplicationServerTypeResolver {
     private final List<ServerTypeDetector> detectors = new ArrayList<ServerTypeDetector>();
 
     private final ServiceTypeRegistryService serviceTypeRegistryService;
-    /**
-     * If we have to invoke startup() during agent initialization.
-     * Some service types like BLOC or STAND_ALONE don't have an acceptor to do this.
-     */
-    private boolean manuallyStartupRequired = true;
 
     public ApplicationServerTypeResolver(List<DefaultProfilerPluginContext> plugins, ServiceType defaultType, ServiceTypeRegistryService serviceTypeRegistryService) {
         if (serviceTypeRegistryService == null) {
             throw new NullPointerException("serviceTypeRegistryService must not be null");
         }
-
+        this.serviceTypeRegistryService = serviceTypeRegistryService;
         this.defaultType = defaultType;
         
         for (DefaultProfilerPluginContext context : plugins) {
             detectors.addAll(context.getServerTypeDetectors());
         }
-
-        this.serviceTypeRegistryService = serviceTypeRegistryService;
     }
-
 
     public String[] getServerLibPath() {
         return new String[0];
@@ -67,10 +59,6 @@ public class ApplicationServerTypeResolver {
 
     public ServiceType getServerType() {
         return serverType;
-    }
-    
-    public boolean isManuallyStartupRequired() {
-        return manuallyStartupRequired;
     }
     
     public boolean resolve() {

--- a/profiler/src/main/java/com/navercorp/pinpoint/test/TestableServerMetaDataListener.java
+++ b/profiler/src/main/java/com/navercorp/pinpoint/test/TestableServerMetaDataListener.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2015 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.test;
+
+import com.navercorp.pinpoint.bootstrap.context.ServerMetaData;
+import com.navercorp.pinpoint.bootstrap.context.ServerMetaDataHolder.ServerMetaDataListener;
+
+/**
+ * @author HyunGil Jeong
+ */
+public class TestableServerMetaDataListener implements ServerMetaDataListener {
+    
+    private volatile ServerMetaData serverMetaData;
+
+    @Override
+    public void publishServerMetaData(ServerMetaData serverMetaData) {
+        this.serverMetaData = serverMetaData;
+    }
+    
+    public ServerMetaData getServerMetaData() {
+        return this.serverMetaData;
+    }
+    
+}

--- a/profiler/src/main/java/com/navercorp/pinpoint/test/junit4/BasePinpointTest.java
+++ b/profiler/src/main/java/com/navercorp/pinpoint/test/junit4/BasePinpointTest.java
@@ -23,6 +23,8 @@ import com.navercorp.pinpoint.profiler.sender.DataSender;
 import com.navercorp.pinpoint.test.ListenableDataSender;
 import com.navercorp.pinpoint.test.MockAgent;
 import com.navercorp.pinpoint.test.ResettableServerMetaDataHolder;
+import com.navercorp.pinpoint.test.TestableServerMetaDataListener;
+
 import org.apache.thrift.TBase;
 import org.junit.runner.RunWith;
 
@@ -42,6 +44,7 @@ public abstract class BasePinpointTest {
 
     private volatile TBaseRecorder<? extends TBase<?, ?>> tBaseRecorder;
     private volatile ServerMetaDataHolder serverMetaDataHolder;
+    private final TestableServerMetaDataListener listener = new TestableServerMetaDataListener();
 
     protected List<SpanEventBo> getCurrentSpanEvents() {
         List<SpanEventBo> spanEvents = new ArrayList<SpanEventBo>();
@@ -65,7 +68,7 @@ public abstract class BasePinpointTest {
     }
     
     protected ServerMetaData getServerMetaData() {
-        return this.serverMetaDataHolder.getServerMetaData();
+        return this.listener.getServerMetaData();
     }
 
     private void setTBaseRecorder(TBaseRecorder tBaseRecorder) {
@@ -99,5 +102,6 @@ public abstract class BasePinpointTest {
             ResettableServerMetaDataHolder resettableServerMetaDataHolder = (ResettableServerMetaDataHolder) serverMetaDataHolder;
             this.setServerMetaDataHolder(resettableServerMetaDataHolder);
         }
+        this.serverMetaDataHolder.addListener(this.listener);
     }
 }


### PR DESCRIPTION
Agent's lifecycle and the application's lifecycle is now completely separated.

Interceptors can no longer call agent's start method. This was done previously to send `ServerMetaData` along with `AgentInfo`, and the agent had no way of knowing when to send this data.

Now, the `AgentInfo` is sent as soon as Pinpoint agent is booted up, and the interceptors can specify when to send `ServerMetaData` independently.

resolve #215 