### PR TITLE
[#228] Decouple application type and span service type.

### DIFF
--- a/commons/src/test/java/com/navercorp/pinpoint/common/bo/SpanBoTest.java
+++ b/commons/src/test/java/com/navercorp/pinpoint/common/bo/SpanBoTest.java
@@ -90,6 +90,9 @@ public class SpanBoTest {
 //        Assert.assertEquals(newSpanBo.getTraceAgentStartTime(), spanBo.getTraceAgentStartTime());
 //        Assert.assertEquals(newSpanBo.getTraceTransactionSequence(), spanBo.getTraceTransactionSequence());
         Assert.assertEquals(newSpanBo.getParentSpanId(), spanBo.getParentSpanId());
+        
+        Assert.assertEquals(newSpanBo.getServiceType(), spanBo.getServiceType());
+        Assert.assertEquals(newSpanBo.getApplicationServiceType(), spanBo.getServiceType());
 
         Assert.assertEquals(newSpanBo.getVersion(), spanBo.getVersion());
 
@@ -108,6 +111,7 @@ public class SpanBoTest {
         spanBo.setRpc(rpc);
 
         spanBo.setServiceType(ServiceType.STAND_ALONE.getCode());
+        spanBo.setApplicationServiceType(ServiceType.UNKNOWN.getCode());
 
         byte[] bytes = spanBo.writeValue();
         logger.info("length:{}", bytes.length);
@@ -116,6 +120,9 @@ public class SpanBoTest {
         int i = newSpanBo.readValue(bytes, 0);
         logger.info("length:{}", i);
         Assert.assertEquals(bytes.length, i);
+        
+        Assert.assertEquals(spanBo.getServiceType(), spanBo.getServiceType());
+        Assert.assertEquals(spanBo.getApplicationServiceType(), spanBo.getApplicationServiceType());
     }
 
     private String createString(int size) {

--- a/profiler/src/main/java/com/navercorp/pinpoint/profiler/DefaultAgent.java
+++ b/profiler/src/main/java/com/navercorp/pinpoint/profiler/DefaultAgent.java
@@ -191,7 +191,7 @@ public class DefaultAgent implements Agent {
                 this.profilerConfig.getStatDataSenderWriteQueueSize(), this.profilerConfig.getStatDataSenderSocketTimeout(),
                 this.profilerConfig.getStatDataSenderSocketSendBufferSize());
 
-        this.traceContext = createTraceContext(agentInformation.getServerType());
+        this.traceContext = createTraceContext();
 
         this.agentInfoSender = new AgentInfoSender(tcpDataSender, profilerConfig.getAgentInfoSendRetryInterval(), this.agentInformation);
         this.serverMetaDataHolder.addListener(this.agentInfoSender);
@@ -272,7 +272,7 @@ public class DefaultAgent implements Agent {
         PLoggerFactory.initialize(binder);
     }
 
-    private TraceContext createTraceContext(ServiceType serverType) {
+    private TraceContext createTraceContext() {
         final StorageFactory storageFactory = createStorageFactory();
         logger.info("StorageFactoryType:{}", storageFactory);
 
@@ -280,8 +280,7 @@ public class DefaultAgent implements Agent {
         logger.info("SamplerType:{}", sampler);
         
         final int jdbcSqlCacheSize = profilerConfig.getJdbcSqlCacheSize();
-        final DefaultTraceContext traceContext = new DefaultTraceContext(jdbcSqlCacheSize, serverType, storageFactory, sampler, this.serverMetaDataHolder);
-        traceContext.setAgentInformation(this.agentInformation);
+        final DefaultTraceContext traceContext = new DefaultTraceContext(jdbcSqlCacheSize, this.agentInformation, storageFactory, sampler, this.serverMetaDataHolder);
         traceContext.setPriorityDataSender(this.tcpDataSender);
 
         traceContext.setProfilerConfig(profilerConfig);

--- a/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/DefaultTrace.java
+++ b/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/DefaultTrace.java
@@ -78,6 +78,7 @@ public final class DefaultTrace implements Trace {
         span.setAgentId(traceContext.getAgentId());
         span.setApplicationName(traceContext.getApplicationName());
         span.setAgentStartTime(traceContext.getAgentStartTime());
+        span.setApplicationServiceType(traceContext.getServerTypeCode());
 
         // have to recode traceId latter.
         span.recordTraceId(traceId);

--- a/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/DefaultTraceContext.java
+++ b/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/DefaultTraceContext.java
@@ -46,7 +46,6 @@ import com.navercorp.pinpoint.thrift.dto.TStringMetaData;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.xml.ws.Service;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -63,14 +62,11 @@ public class DefaultTraceContext implements TraceContext {
 
     private final ActiveThreadCounter activeThreadCounter = new ActiveThreadCounter();
 
-
 //    private GlobalCallTrace globalCallTrace = new GlobalCallTrace();
 
     private AgentInformation agentInformation;
 
     private EnhancedDataSender priorityDataSender;
-
-    private final ServiceType contextServiceType;
 
     private final MetricRegistry metricRegistry;
 
@@ -85,22 +81,25 @@ public class DefaultTraceContext implements TraceContext {
     private ProfilerConfig profilerConfig;
     
     private final ServerMetaDataHolder serverMetaDataHolder;
-
+    
     // for test
-    public DefaultTraceContext() {
-        this(LRUCache.DEFAULT_CACHE_SIZE, ServiceType.STAND_ALONE, new LogStorageFactory(), new TrueSampler(), new DefaultServerMetaDataHolder(RuntimeMXBeanUtils.getVmArgs()));
+    public DefaultTraceContext(final AgentInformation agentInformation) {
+        this(LRUCache.DEFAULT_CACHE_SIZE, agentInformation, new LogStorageFactory(), new TrueSampler(), new DefaultServerMetaDataHolder(RuntimeMXBeanUtils.getVmArgs()));
     }
 
-    public DefaultTraceContext(final int sqlCacheSize, final ServiceType contextServiceType, StorageFactory storageFactory, Sampler sampler, ServerMetaDataHolder serverMetaDataHolder) {
+    public DefaultTraceContext(final int sqlCacheSize, final AgentInformation agentInformation, StorageFactory storageFactory, Sampler sampler, ServerMetaDataHolder serverMetaDataHolder) {
+        if (agentInformation == null) {
+            throw new NullPointerException("agentInformation must not be null");
+        }
         if (storageFactory == null) {
             throw new NullPointerException("storageFactory must not be null");
         }
         if (sampler == null) {
             throw new NullPointerException("sampler must not be null");
         }
+        this.agentInformation = agentInformation;
         this.sqlCache = new SimpleCache<String>(sqlCacheSize);
-        this.contextServiceType = contextServiceType;
-        this.metricRegistry = new MetricRegistry(this.contextServiceType);
+        this.metricRegistry = new MetricRegistry(this.agentInformation.getServerType());
 
         this.traceFactory = new ThreadLocalTraceFactory(this, metricRegistry, storageFactory, sampler);
         
@@ -303,14 +302,6 @@ public class DefaultTraceContext implements TraceContext {
 
     public void setPriorityDataSender(final EnhancedDataSender priorityDataSender) {
         this.priorityDataSender = priorityDataSender;
-    }
-
-
-    public void setAgentInformation(final AgentInformation agentInformation) {
-        if (agentInformation == null) {
-            throw new NullPointerException("agentInformation must not be null");
-        }
-        this.agentInformation = agentInformation;
     }
 
     @Override

--- a/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/SpanChunkFactory.java
+++ b/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/SpanChunkFactory.java
@@ -56,6 +56,7 @@ public class SpanChunkFactory {
         spanChunk.setAgentId(agentId);
         spanChunk.setApplicationName(this.agentInformation.getApplicationName());
         spanChunk.setAgentStartTime(this.agentInformation.getStartTime());
+        spanChunk.setApplicationServiceType(this.agentInformation.getServerType().getCode());
 
         spanChunk.setServiceType(parentSpan.getServiceType());
 

--- a/profiler/src/main/java/com/navercorp/pinpoint/test/MockTraceContextFactory.java
+++ b/profiler/src/main/java/com/navercorp/pinpoint/test/MockTraceContextFactory.java
@@ -25,7 +25,7 @@ import com.navercorp.pinpoint.profiler.context.DefaultTraceContext;
  */
 public class MockTraceContextFactory {
     public TraceContext create() {
-        DefaultTraceContext traceContext = new DefaultTraceContext() ;
+        DefaultTraceContext traceContext = new DefaultTraceContext(new TestAgentInformation()) ;
         ProfilerConfig profilerConfig = new ProfilerConfig();
         traceContext.setProfilerConfig(profilerConfig);
         return traceContext;

--- a/profiler/src/main/java/com/navercorp/pinpoint/test/TestAgentInformation.java
+++ b/profiler/src/main/java/com/navercorp/pinpoint/test/TestAgentInformation.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2015 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.test;
+
+import com.navercorp.pinpoint.common.ServiceType;
+import com.navercorp.pinpoint.common.Version;
+import com.navercorp.pinpoint.profiler.AgentInformation;
+
+/**
+ * @author HyunGil Jeong
+ */
+public class TestAgentInformation extends AgentInformation {
+    
+    private static final String AGENT_ID = "test-agent";
+    private static final String APPLICATION_NAME = "TEST_APPLICATION";
+    private static final int PID = 10;
+    private static final String MACHINE_NAME = "test-machine";
+    private static final String HOST_IP = "127.0.0.1";
+    private static final ServiceType SERVICE_TYPE = ServiceType.TEST_STAND_ALONE;
+    private static final String VERSION = Version.VERSION;
+
+    public TestAgentInformation() {
+        super(AGENT_ID, APPLICATION_NAME, System.currentTimeMillis(), PID, MACHINE_NAME, HOST_IP, SERVICE_TYPE, VERSION);
+    }
+}

--- a/profiler/src/test/java/com/navercorp/pinpoint/profiler/context/DefaultTraceContextTest.java
+++ b/profiler/src/test/java/com/navercorp/pinpoint/profiler/context/DefaultTraceContextTest.java
@@ -18,17 +18,14 @@ package com.navercorp.pinpoint.profiler.context;
 
 import com.navercorp.pinpoint.bootstrap.context.Trace;
 import com.navercorp.pinpoint.bootstrap.context.TraceId;
-import com.navercorp.pinpoint.common.ServiceType;
-import com.navercorp.pinpoint.common.Version;
 import com.navercorp.pinpoint.common.util.TransactionId;
 import com.navercorp.pinpoint.common.util.TransactionIdUtils;
 import com.navercorp.pinpoint.profiler.AgentInformation;
 import com.navercorp.pinpoint.profiler.context.DefaultTraceContext;
 import com.navercorp.pinpoint.profiler.context.DefaultTraceId;
-import com.navercorp.pinpoint.profiler.util.RuntimeMXBeanUtils;
+import com.navercorp.pinpoint.test.TestAgentInformation;
 
 import org.junit.Assert;
-
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -59,7 +56,7 @@ public class DefaultTraceContextTest {
 
     @Test
     public void disableTrace() {
-        DefaultTraceContext traceContext = new DefaultTraceContext();
+        DefaultTraceContext traceContext = new DefaultTraceContext(new TestAgentInformation());
         Trace trace = traceContext.disableSampling();
         Assert.assertNotNull(trace);
         Assert.assertFalse(trace.canSampled());
@@ -70,14 +67,11 @@ public class DefaultTraceContextTest {
 
     @Test
     public void threadLocalBindTest() {
-        AgentInformation agentInformation = new AgentInformation("d", "d", System.currentTimeMillis(), 123, "machineName", "127.0.0.1", ServiceType.TEST_STAND_ALONE, Version.VERSION);
-
-        DefaultTraceContext traceContext1 = new DefaultTraceContext();
-        traceContext1.setAgentInformation(agentInformation);
+        final AgentInformation agentInformation = new TestAgentInformation();
+        DefaultTraceContext traceContext1 = new DefaultTraceContext(agentInformation);
         Assert.assertNotNull(traceContext1.newTraceObject());
 
-        DefaultTraceContext traceContext2 = new DefaultTraceContext();
-        traceContext2.setAgentInformation(agentInformation);
+        DefaultTraceContext traceContext2 = new DefaultTraceContext(agentInformation);
         Trace notExist = traceContext2.currentRawTraceObject();
         Assert.assertNull(notExist);
 

--- a/profiler/src/test/java/com/navercorp/pinpoint/profiler/context/DefaultTraceTest.java
+++ b/profiler/src/test/java/com/navercorp/pinpoint/profiler/context/DefaultTraceTest.java
@@ -16,25 +16,19 @@
 
 package com.navercorp.pinpoint.profiler.context;
 
-import com.navercorp.pinpoint.common.ServiceType;
-import com.navercorp.pinpoint.common.Version;
-import com.navercorp.pinpoint.profiler.AgentInformation;
 import com.navercorp.pinpoint.profiler.context.DefaultTrace;
 import com.navercorp.pinpoint.profiler.context.DefaultTraceContext;
 import com.navercorp.pinpoint.profiler.context.storage.SpanStorage;
 import com.navercorp.pinpoint.profiler.logging.Slf4jLoggerBinderInitializer;
 import com.navercorp.pinpoint.profiler.sender.LoggingDataSender;
+import com.navercorp.pinpoint.test.TestAgentInformation;
 
 import org.junit.*;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * @author emeroad
  */
 public class DefaultTraceTest {
-
-    private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
     @BeforeClass
     public static void before() throws Exception {
@@ -49,8 +43,7 @@ public class DefaultTraceTest {
 
     @Test
     public void testPushPop() {
-        DefaultTraceContext defaultTraceContext = new DefaultTraceContext();
-        defaultTraceContext.setAgentInformation(new AgentInformation("agentId", "applicationName", System.currentTimeMillis(), 10, "test", "127.0.0.1", ServiceType.STAND_ALONE, Version.VERSION));
+        DefaultTraceContext defaultTraceContext = new DefaultTraceContext(new TestAgentInformation());
         DefaultTrace trace = new DefaultTrace(defaultTraceContext, 1);
 
         trace.setStorage(new SpanStorage(LoggingDataSender.DEFAULT_LOGGING_DATA_SENDER));

--- a/profiler/src/test/java/com/navercorp/pinpoint/profiler/context/ThreadLocalTraceFactoryTest.java
+++ b/profiler/src/test/java/com/navercorp/pinpoint/profiler/context/ThreadLocalTraceFactoryTest.java
@@ -21,6 +21,8 @@ import java.util.Collections;
 import com.navercorp.pinpoint.bootstrap.context.ServerMetaDataHolder;
 import com.navercorp.pinpoint.bootstrap.context.Trace;
 import com.navercorp.pinpoint.common.ServiceType;
+import com.navercorp.pinpoint.common.Version;
+import com.navercorp.pinpoint.profiler.AgentInformation;
 import com.navercorp.pinpoint.profiler.context.DefaultServerMetaDataHolder;
 import com.navercorp.pinpoint.profiler.context.DefaultTraceContext;
 import com.navercorp.pinpoint.profiler.context.ThreadLocalTraceFactory;
@@ -29,7 +31,6 @@ import com.navercorp.pinpoint.profiler.monitor.metric.MetricRegistry;
 import com.navercorp.pinpoint.profiler.sampler.TrueSampler;
 
 import org.junit.Assert;
-
 import org.junit.Test;
 
 public class ThreadLocalTraceFactoryTest {
@@ -38,7 +39,8 @@ public class ThreadLocalTraceFactoryTest {
         LogStorageFactory logStorageFactory = new LogStorageFactory();
         TrueSampler trueSampler = new TrueSampler();
         ServerMetaDataHolder serverMetaDataHolder = new DefaultServerMetaDataHolder(Collections.<String>emptyList());
-        DefaultTraceContext traceContext = new DefaultTraceContext(100, ServiceType.STAND_ALONE, logStorageFactory, trueSampler, serverMetaDataHolder);
+        AgentInformation agentInformation = new AgentInformation("agentId", "applicationName", System.currentTimeMillis(), 10, "test", "127.0.0.1", ServiceType.STAND_ALONE, Version.VERSION);
+        DefaultTraceContext traceContext = new DefaultTraceContext(100, agentInformation, logStorageFactory, trueSampler, serverMetaDataHolder);
         MetricRegistry metricRegistry = new MetricRegistry(ServiceType.STAND_ALONE);
         return new ThreadLocalTraceFactory(traceContext, metricRegistry, logStorageFactory, trueSampler);
     }

--- a/profiler/src/test/java/com/navercorp/pinpoint/profiler/context/TraceTest.java
+++ b/profiler/src/test/java/com/navercorp/pinpoint/profiler/context/TraceTest.java
@@ -19,8 +19,6 @@ package com.navercorp.pinpoint.profiler.context;
 import com.navercorp.pinpoint.bootstrap.context.Trace;
 import com.navercorp.pinpoint.common.AnnotationKey;
 import com.navercorp.pinpoint.common.ServiceType;
-import com.navercorp.pinpoint.common.Version;
-import com.navercorp.pinpoint.profiler.AgentInformation;
 import com.navercorp.pinpoint.profiler.context.DefaultTrace;
 import com.navercorp.pinpoint.profiler.context.DefaultTraceContext;
 import com.navercorp.pinpoint.profiler.context.DefaultTraceId;
@@ -30,6 +28,7 @@ import com.navercorp.pinpoint.profiler.sender.LoggingDataSender;
 import com.navercorp.pinpoint.rpc.FutureListener;
 import com.navercorp.pinpoint.rpc.ResponseMessage;
 import com.navercorp.pinpoint.rpc.client.PinpointSocketReconnectEventListener;
+import com.navercorp.pinpoint.test.TestAgentInformation;
 
 import org.apache.thrift.TBase;
 import org.junit.Test;
@@ -83,8 +82,7 @@ public class TraceTest {
     }
 
     private DefaultTraceContext getDefaultTraceContext() {
-        DefaultTraceContext defaultTraceContext = new DefaultTraceContext();
-        defaultTraceContext.setAgentInformation(new AgentInformation("agentId", "applicationName", System.currentTimeMillis(), 10, "test", "127.0.0.1", ServiceType.STAND_ALONE, Version.VERSION));
+        DefaultTraceContext defaultTraceContext = new DefaultTraceContext(new TestAgentInformation());
         return defaultTraceContext;
     }
 

--- a/thrift/src/main/java/com/navercorp/pinpoint/thrift/dto/TSpan.java
+++ b/thrift/src/main/java/com/navercorp/pinpoint/thrift/dto/TSpan.java
@@ -56,6 +56,7 @@ public class TSpan implements org.apache.thrift.TBase<TSpan, TSpan._Fields>, jav
   private static final org.apache.thrift.protocol.TField ACCEPTOR_HOST_FIELD_DESC = new org.apache.thrift.protocol.TField("acceptorHost", org.apache.thrift.protocol.TType.STRING, (short)21);
   private static final org.apache.thrift.protocol.TField API_ID_FIELD_DESC = new org.apache.thrift.protocol.TField("apiId", org.apache.thrift.protocol.TType.I32, (short)25);
   private static final org.apache.thrift.protocol.TField EXCEPTION_INFO_FIELD_DESC = new org.apache.thrift.protocol.TField("exceptionInfo", org.apache.thrift.protocol.TType.STRUCT, (short)26);
+  private static final org.apache.thrift.protocol.TField APPLICATION_SERVICE_TYPE_FIELD_DESC = new org.apache.thrift.protocol.TField("applicationServiceType", org.apache.thrift.protocol.TType.I16, (short)30);
 
   private static final Map<Class<? extends IScheme>, SchemeFactory> schemes = new HashMap<Class<? extends IScheme>, SchemeFactory>();
   static {
@@ -84,6 +85,7 @@ public class TSpan implements org.apache.thrift.TBase<TSpan, TSpan._Fields>, jav
   private String acceptorHost; // optional
   private int apiId; // optional
   private TIntStringValue exceptionInfo; // optional
+  private short applicationServiceType; // optional
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -107,7 +109,8 @@ public class TSpan implements org.apache.thrift.TBase<TSpan, TSpan._Fields>, jav
     PARENT_APPLICATION_TYPE((short)20, "parentApplicationType"),
     ACCEPTOR_HOST((short)21, "acceptorHost"),
     API_ID((short)25, "apiId"),
-    EXCEPTION_INFO((short)26, "exceptionInfo");
+    EXCEPTION_INFO((short)26, "exceptionInfo"),
+    APPLICATION_SERVICE_TYPE((short)30, "applicationServiceType");
 
     private static final Map<String, _Fields> byName = new HashMap<String, _Fields>();
 
@@ -164,6 +167,8 @@ public class TSpan implements org.apache.thrift.TBase<TSpan, TSpan._Fields>, jav
           return API_ID;
         case 26: // EXCEPTION_INFO
           return EXCEPTION_INFO;
+        case 30: // APPLICATION_SERVICE_TYPE
+          return APPLICATION_SERVICE_TYPE;
         default:
           return null;
       }
@@ -214,8 +219,9 @@ public class TSpan implements org.apache.thrift.TBase<TSpan, TSpan._Fields>, jav
   private static final int __ERR_ISSET_ID = 7;
   private static final int __PARENTAPPLICATIONTYPE_ISSET_ID = 8;
   private static final int __APIID_ISSET_ID = 9;
+  private static final int __APPLICATIONSERVICETYPE_ISSET_ID = 10;
   private short __isset_bitfield = 0;
-  private _Fields optionals[] = {_Fields.PARENT_SPAN_ID,_Fields.ELAPSED,_Fields.RPC,_Fields.END_POINT,_Fields.REMOTE_ADDR,_Fields.ANNOTATIONS,_Fields.FLAG,_Fields.ERR,_Fields.SPAN_EVENT_LIST,_Fields.PARENT_APPLICATION_NAME,_Fields.PARENT_APPLICATION_TYPE,_Fields.ACCEPTOR_HOST,_Fields.API_ID,_Fields.EXCEPTION_INFO};
+  private _Fields optionals[] = {_Fields.PARENT_SPAN_ID,_Fields.ELAPSED,_Fields.RPC,_Fields.END_POINT,_Fields.REMOTE_ADDR,_Fields.ANNOTATIONS,_Fields.FLAG,_Fields.ERR,_Fields.SPAN_EVENT_LIST,_Fields.PARENT_APPLICATION_NAME,_Fields.PARENT_APPLICATION_TYPE,_Fields.ACCEPTOR_HOST,_Fields.API_ID,_Fields.EXCEPTION_INFO,_Fields.APPLICATION_SERVICE_TYPE};
   public static final Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> metaDataMap;
   static {
     Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
@@ -263,6 +269,8 @@ public class TSpan implements org.apache.thrift.TBase<TSpan, TSpan._Fields>, jav
         new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.I32)));
     tmpMap.put(_Fields.EXCEPTION_INFO, new org.apache.thrift.meta_data.FieldMetaData("exceptionInfo", org.apache.thrift.TFieldRequirementType.OPTIONAL, 
         new org.apache.thrift.meta_data.StructMetaData(org.apache.thrift.protocol.TType.STRUCT, TIntStringValue.class)));
+    tmpMap.put(_Fields.APPLICATION_SERVICE_TYPE, new org.apache.thrift.meta_data.FieldMetaData("applicationServiceType", org.apache.thrift.TFieldRequirementType.OPTIONAL, 
+        new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.I16)));
     metaDataMap = Collections.unmodifiableMap(tmpMap);
     org.apache.thrift.meta_data.FieldMetaData.addStructMetaDataMap(TSpan.class, metaDataMap);
   }
@@ -356,6 +364,7 @@ public class TSpan implements org.apache.thrift.TBase<TSpan, TSpan._Fields>, jav
     if (other.isSetExceptionInfo()) {
       this.exceptionInfo = new TIntStringValue(other.exceptionInfo);
     }
+    this.applicationServiceType = other.applicationServiceType;
   }
 
   public TSpan deepCopy() {
@@ -395,6 +404,8 @@ public class TSpan implements org.apache.thrift.TBase<TSpan, TSpan._Fields>, jav
     setApiIdIsSet(false);
     this.apiId = 0;
     this.exceptionInfo = null;
+    setApplicationServiceTypeIsSet(false);
+    this.applicationServiceType = 0;
   }
 
   public String getAgentId() {
@@ -909,6 +920,28 @@ public class TSpan implements org.apache.thrift.TBase<TSpan, TSpan._Fields>, jav
     }
   }
 
+  public short getApplicationServiceType() {
+    return this.applicationServiceType;
+  }
+
+  public void setApplicationServiceType(short applicationServiceType) {
+    this.applicationServiceType = applicationServiceType;
+    setApplicationServiceTypeIsSet(true);
+  }
+
+  public void unsetApplicationServiceType() {
+    __isset_bitfield = EncodingUtils.clearBit(__isset_bitfield, __APPLICATIONSERVICETYPE_ISSET_ID);
+  }
+
+  /** Returns true if field applicationServiceType is set (has been assigned a value) and false otherwise */
+  public boolean isSetApplicationServiceType() {
+    return EncodingUtils.testBit(__isset_bitfield, __APPLICATIONSERVICETYPE_ISSET_ID);
+  }
+
+  public void setApplicationServiceTypeIsSet(boolean value) {
+    __isset_bitfield = EncodingUtils.setBit(__isset_bitfield, __APPLICATIONSERVICETYPE_ISSET_ID, value);
+  }
+
   public void setFieldValue(_Fields field, Object value) {
     switch (field) {
     case AGENT_ID:
@@ -1079,6 +1112,14 @@ public class TSpan implements org.apache.thrift.TBase<TSpan, TSpan._Fields>, jav
       }
       break;
 
+    case APPLICATION_SERVICE_TYPE:
+      if (value == null) {
+        unsetApplicationServiceType();
+      } else {
+        setApplicationServiceType((Short)value);
+      }
+      break;
+
     }
   }
 
@@ -1147,6 +1188,9 @@ public class TSpan implements org.apache.thrift.TBase<TSpan, TSpan._Fields>, jav
     case EXCEPTION_INFO:
       return getExceptionInfo();
 
+    case APPLICATION_SERVICE_TYPE:
+      return Short.valueOf(getApplicationServiceType());
+
     }
     throw new IllegalStateException();
   }
@@ -1200,6 +1244,8 @@ public class TSpan implements org.apache.thrift.TBase<TSpan, TSpan._Fields>, jav
       return isSetApiId();
     case EXCEPTION_INFO:
       return isSetExceptionInfo();
+    case APPLICATION_SERVICE_TYPE:
+      return isSetApplicationServiceType();
     }
     throw new IllegalStateException();
   }
@@ -1403,6 +1449,15 @@ public class TSpan implements org.apache.thrift.TBase<TSpan, TSpan._Fields>, jav
       if (!(this_present_exceptionInfo && that_present_exceptionInfo))
         return false;
       if (!this.exceptionInfo.equals(that.exceptionInfo))
+        return false;
+    }
+
+    boolean this_present_applicationServiceType = true && this.isSetApplicationServiceType();
+    boolean that_present_applicationServiceType = true && that.isSetApplicationServiceType();
+    if (this_present_applicationServiceType || that_present_applicationServiceType) {
+      if (!(this_present_applicationServiceType && that_present_applicationServiceType))
+        return false;
+      if (this.applicationServiceType != that.applicationServiceType)
         return false;
     }
 
@@ -1632,6 +1687,16 @@ public class TSpan implements org.apache.thrift.TBase<TSpan, TSpan._Fields>, jav
         return lastComparison;
       }
     }
+    lastComparison = Boolean.valueOf(isSetApplicationServiceType()).compareTo(other.isSetApplicationServiceType());
+    if (lastComparison != 0) {
+      return lastComparison;
+    }
+    if (isSetApplicationServiceType()) {
+      lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.applicationServiceType, other.applicationServiceType);
+      if (lastComparison != 0) {
+        return lastComparison;
+      }
+    }
     return 0;
   }
 
@@ -1805,6 +1870,12 @@ public class TSpan implements org.apache.thrift.TBase<TSpan, TSpan._Fields>, jav
       } else {
         sb.append(this.exceptionInfo);
       }
+      first = false;
+    }
+    if (isSetApplicationServiceType()) {
+      if (!first) sb.append(", ");
+      sb.append("applicationServiceType:");
+      sb.append(this.applicationServiceType);
       first = false;
     }
     sb.append(")");
@@ -2046,6 +2117,14 @@ public class TSpan implements org.apache.thrift.TBase<TSpan, TSpan._Fields>, jav
               org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
             }
             break;
+          case 30: // APPLICATION_SERVICE_TYPE
+            if (schemeField.type == org.apache.thrift.protocol.TType.I16) {
+              struct.applicationServiceType = iprot.readI16();
+              struct.setApplicationServiceTypeIsSet(true);
+            } else { 
+              org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
+            }
+            break;
           default:
             org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
         }
@@ -2186,6 +2265,11 @@ public class TSpan implements org.apache.thrift.TBase<TSpan, TSpan._Fields>, jav
           oprot.writeFieldEnd();
         }
       }
+      if (struct.isSetApplicationServiceType()) {
+        oprot.writeFieldBegin(APPLICATION_SERVICE_TYPE_FIELD_DESC);
+        oprot.writeI16(struct.applicationServiceType);
+        oprot.writeFieldEnd();
+      }
       oprot.writeFieldStop();
       oprot.writeStructEnd();
     }
@@ -2267,7 +2351,10 @@ public class TSpan implements org.apache.thrift.TBase<TSpan, TSpan._Fields>, jav
       if (struct.isSetExceptionInfo()) {
         optionals.set(20);
       }
-      oprot.writeBitSet(optionals, 21);
+      if (struct.isSetApplicationServiceType()) {
+        optionals.set(21);
+      }
+      oprot.writeBitSet(optionals, 22);
       if (struct.isSetAgentId()) {
         oprot.writeString(struct.agentId);
       }
@@ -2343,12 +2430,15 @@ public class TSpan implements org.apache.thrift.TBase<TSpan, TSpan._Fields>, jav
       if (struct.isSetExceptionInfo()) {
         struct.exceptionInfo.write(oprot);
       }
+      if (struct.isSetApplicationServiceType()) {
+        oprot.writeI16(struct.applicationServiceType);
+      }
     }
 
     @Override
     public void read(org.apache.thrift.protocol.TProtocol prot, TSpan struct) throws org.apache.thrift.TException {
       TTupleProtocol iprot = (TTupleProtocol) prot;
-      BitSet incoming = iprot.readBitSet(21);
+      BitSet incoming = iprot.readBitSet(22);
       if (incoming.get(0)) {
         struct.agentId = iprot.readString();
         struct.setAgentIdIsSet(true);
@@ -2453,6 +2543,10 @@ public class TSpan implements org.apache.thrift.TBase<TSpan, TSpan._Fields>, jav
         struct.exceptionInfo = new TIntStringValue();
         struct.exceptionInfo.read(iprot);
         struct.setExceptionInfoIsSet(true);
+      }
+      if (incoming.get(21)) {
+        struct.applicationServiceType = iprot.readI16();
+        struct.setApplicationServiceTypeIsSet(true);
       }
     }
   }

--- a/thrift/src/main/java/com/navercorp/pinpoint/thrift/dto/TSpanChunk.java
+++ b/thrift/src/main/java/com/navercorp/pinpoint/thrift/dto/TSpanChunk.java
@@ -43,6 +43,7 @@ public class TSpanChunk implements org.apache.thrift.TBase<TSpanChunk, TSpanChun
   private static final org.apache.thrift.protocol.TField SPAN_ID_FIELD_DESC = new org.apache.thrift.protocol.TField("spanId", org.apache.thrift.protocol.TType.I64, (short)8);
   private static final org.apache.thrift.protocol.TField END_POINT_FIELD_DESC = new org.apache.thrift.protocol.TField("endPoint", org.apache.thrift.protocol.TType.STRING, (short)9);
   private static final org.apache.thrift.protocol.TField SPAN_EVENT_LIST_FIELD_DESC = new org.apache.thrift.protocol.TField("spanEventList", org.apache.thrift.protocol.TType.LIST, (short)10);
+  private static final org.apache.thrift.protocol.TField APPLICATION_SERVICE_TYPE_FIELD_DESC = new org.apache.thrift.protocol.TField("applicationServiceType", org.apache.thrift.protocol.TType.I16, (short)11);
 
   private static final Map<Class<? extends IScheme>, SchemeFactory> schemes = new HashMap<Class<? extends IScheme>, SchemeFactory>();
   static {
@@ -58,6 +59,7 @@ public class TSpanChunk implements org.apache.thrift.TBase<TSpanChunk, TSpanChun
   private long spanId; // required
   private String endPoint; // optional
   private List<TSpanEvent> spanEventList; // required
+  private short applicationServiceType; // optional
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -68,7 +70,8 @@ public class TSpanChunk implements org.apache.thrift.TBase<TSpanChunk, TSpanChun
     TRANSACTION_ID((short)5, "transactionId"),
     SPAN_ID((short)8, "spanId"),
     END_POINT((short)9, "endPoint"),
-    SPAN_EVENT_LIST((short)10, "spanEventList");
+    SPAN_EVENT_LIST((short)10, "spanEventList"),
+    APPLICATION_SERVICE_TYPE((short)11, "applicationServiceType");
 
     private static final Map<String, _Fields> byName = new HashMap<String, _Fields>();
 
@@ -99,6 +102,8 @@ public class TSpanChunk implements org.apache.thrift.TBase<TSpanChunk, TSpanChun
           return END_POINT;
         case 10: // SPAN_EVENT_LIST
           return SPAN_EVENT_LIST;
+        case 11: // APPLICATION_SERVICE_TYPE
+          return APPLICATION_SERVICE_TYPE;
         default:
           return null;
       }
@@ -142,8 +147,9 @@ public class TSpanChunk implements org.apache.thrift.TBase<TSpanChunk, TSpanChun
   private static final int __AGENTSTARTTIME_ISSET_ID = 0;
   private static final int __SERVICETYPE_ISSET_ID = 1;
   private static final int __SPANID_ISSET_ID = 2;
+  private static final int __APPLICATIONSERVICETYPE_ISSET_ID = 3;
   private byte __isset_bitfield = 0;
-  private _Fields optionals[] = {_Fields.END_POINT};
+  private _Fields optionals[] = {_Fields.END_POINT,_Fields.APPLICATION_SERVICE_TYPE};
   public static final Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> metaDataMap;
   static {
     Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
@@ -164,6 +170,8 @@ public class TSpanChunk implements org.apache.thrift.TBase<TSpanChunk, TSpanChun
     tmpMap.put(_Fields.SPAN_EVENT_LIST, new org.apache.thrift.meta_data.FieldMetaData("spanEventList", org.apache.thrift.TFieldRequirementType.DEFAULT, 
         new org.apache.thrift.meta_data.ListMetaData(org.apache.thrift.protocol.TType.LIST, 
             new org.apache.thrift.meta_data.StructMetaData(org.apache.thrift.protocol.TType.STRUCT, TSpanEvent.class))));
+    tmpMap.put(_Fields.APPLICATION_SERVICE_TYPE, new org.apache.thrift.meta_data.FieldMetaData("applicationServiceType", org.apache.thrift.TFieldRequirementType.OPTIONAL, 
+        new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.I16)));
     metaDataMap = Collections.unmodifiableMap(tmpMap);
     org.apache.thrift.meta_data.FieldMetaData.addStructMetaDataMap(TSpanChunk.class, metaDataMap);
   }
@@ -221,6 +229,7 @@ public class TSpanChunk implements org.apache.thrift.TBase<TSpanChunk, TSpanChun
       }
       this.spanEventList = __this__spanEventList;
     }
+    this.applicationServiceType = other.applicationServiceType;
   }
 
   public TSpanChunk deepCopy() {
@@ -240,6 +249,8 @@ public class TSpanChunk implements org.apache.thrift.TBase<TSpanChunk, TSpanChun
     this.spanId = 0;
     this.endPoint = null;
     this.spanEventList = null;
+    setApplicationServiceTypeIsSet(false);
+    this.applicationServiceType = 0;
   }
 
   public String getAgentId() {
@@ -447,6 +458,28 @@ public class TSpanChunk implements org.apache.thrift.TBase<TSpanChunk, TSpanChun
     }
   }
 
+  public short getApplicationServiceType() {
+    return this.applicationServiceType;
+  }
+
+  public void setApplicationServiceType(short applicationServiceType) {
+    this.applicationServiceType = applicationServiceType;
+    setApplicationServiceTypeIsSet(true);
+  }
+
+  public void unsetApplicationServiceType() {
+    __isset_bitfield = EncodingUtils.clearBit(__isset_bitfield, __APPLICATIONSERVICETYPE_ISSET_ID);
+  }
+
+  /** Returns true if field applicationServiceType is set (has been assigned a value) and false otherwise */
+  public boolean isSetApplicationServiceType() {
+    return EncodingUtils.testBit(__isset_bitfield, __APPLICATIONSERVICETYPE_ISSET_ID);
+  }
+
+  public void setApplicationServiceTypeIsSet(boolean value) {
+    __isset_bitfield = EncodingUtils.setBit(__isset_bitfield, __APPLICATIONSERVICETYPE_ISSET_ID, value);
+  }
+
   public void setFieldValue(_Fields field, Object value) {
     switch (field) {
     case AGENT_ID:
@@ -513,6 +546,14 @@ public class TSpanChunk implements org.apache.thrift.TBase<TSpanChunk, TSpanChun
       }
       break;
 
+    case APPLICATION_SERVICE_TYPE:
+      if (value == null) {
+        unsetApplicationServiceType();
+      } else {
+        setApplicationServiceType((Short)value);
+      }
+      break;
+
     }
   }
 
@@ -542,6 +583,9 @@ public class TSpanChunk implements org.apache.thrift.TBase<TSpanChunk, TSpanChun
     case SPAN_EVENT_LIST:
       return getSpanEventList();
 
+    case APPLICATION_SERVICE_TYPE:
+      return Short.valueOf(getApplicationServiceType());
+
     }
     throw new IllegalStateException();
   }
@@ -569,6 +613,8 @@ public class TSpanChunk implements org.apache.thrift.TBase<TSpanChunk, TSpanChun
       return isSetEndPoint();
     case SPAN_EVENT_LIST:
       return isSetSpanEventList();
+    case APPLICATION_SERVICE_TYPE:
+      return isSetApplicationServiceType();
     }
     throw new IllegalStateException();
   }
@@ -655,6 +701,15 @@ public class TSpanChunk implements org.apache.thrift.TBase<TSpanChunk, TSpanChun
       if (!(this_present_spanEventList && that_present_spanEventList))
         return false;
       if (!this.spanEventList.equals(that.spanEventList))
+        return false;
+    }
+
+    boolean this_present_applicationServiceType = true && this.isSetApplicationServiceType();
+    boolean that_present_applicationServiceType = true && that.isSetApplicationServiceType();
+    if (this_present_applicationServiceType || that_present_applicationServiceType) {
+      if (!(this_present_applicationServiceType && that_present_applicationServiceType))
+        return false;
+      if (this.applicationServiceType != that.applicationServiceType)
         return false;
     }
 
@@ -754,6 +809,16 @@ public class TSpanChunk implements org.apache.thrift.TBase<TSpanChunk, TSpanChun
         return lastComparison;
       }
     }
+    lastComparison = Boolean.valueOf(isSetApplicationServiceType()).compareTo(other.isSetApplicationServiceType());
+    if (lastComparison != 0) {
+      return lastComparison;
+    }
+    if (isSetApplicationServiceType()) {
+      lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.applicationServiceType, other.applicationServiceType);
+      if (lastComparison != 0) {
+        return lastComparison;
+      }
+    }
     return 0;
   }
 
@@ -827,6 +892,12 @@ public class TSpanChunk implements org.apache.thrift.TBase<TSpanChunk, TSpanChun
       sb.append(this.spanEventList);
     }
     first = false;
+    if (isSetApplicationServiceType()) {
+      if (!first) sb.append(", ");
+      sb.append("applicationServiceType:");
+      sb.append(this.applicationServiceType);
+      first = false;
+    }
     sb.append(")");
     return sb.toString();
   }
@@ -947,6 +1018,14 @@ public class TSpanChunk implements org.apache.thrift.TBase<TSpanChunk, TSpanChun
               org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
             }
             break;
+          case 11: // APPLICATION_SERVICE_TYPE
+            if (schemeField.type == org.apache.thrift.protocol.TType.I16) {
+              struct.applicationServiceType = iprot.readI16();
+              struct.setApplicationServiceTypeIsSet(true);
+            } else { 
+              org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
+            }
+            break;
           default:
             org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
         }
@@ -1003,6 +1082,11 @@ public class TSpanChunk implements org.apache.thrift.TBase<TSpanChunk, TSpanChun
         }
         oprot.writeFieldEnd();
       }
+      if (struct.isSetApplicationServiceType()) {
+        oprot.writeFieldBegin(APPLICATION_SERVICE_TYPE_FIELD_DESC);
+        oprot.writeI16(struct.applicationServiceType);
+        oprot.writeFieldEnd();
+      }
       oprot.writeFieldStop();
       oprot.writeStructEnd();
     }
@@ -1045,7 +1129,10 @@ public class TSpanChunk implements org.apache.thrift.TBase<TSpanChunk, TSpanChun
       if (struct.isSetSpanEventList()) {
         optionals.set(7);
       }
-      oprot.writeBitSet(optionals, 8);
+      if (struct.isSetApplicationServiceType()) {
+        optionals.set(8);
+      }
+      oprot.writeBitSet(optionals, 9);
       if (struct.isSetAgentId()) {
         oprot.writeString(struct.agentId);
       }
@@ -1076,12 +1163,15 @@ public class TSpanChunk implements org.apache.thrift.TBase<TSpanChunk, TSpanChun
           }
         }
       }
+      if (struct.isSetApplicationServiceType()) {
+        oprot.writeI16(struct.applicationServiceType);
+      }
     }
 
     @Override
     public void read(org.apache.thrift.protocol.TProtocol prot, TSpanChunk struct) throws org.apache.thrift.TException {
       TTupleProtocol iprot = (TTupleProtocol) prot;
-      BitSet incoming = iprot.readBitSet(8);
+      BitSet incoming = iprot.readBitSet(9);
       if (incoming.get(0)) {
         struct.agentId = iprot.readString();
         struct.setAgentIdIsSet(true);
@@ -1123,6 +1213,10 @@ public class TSpanChunk implements org.apache.thrift.TBase<TSpanChunk, TSpanChun
           }
         }
         struct.setSpanEventListIsSet(true);
+      }
+      if (incoming.get(8)) {
+        struct.applicationServiceType = iprot.readI16();
+        struct.setApplicationServiceTypeIsSet(true);
       }
     }
   }

--- a/thrift/src/main/thrift/Trace.thrift
+++ b/thrift/src/main/thrift/Trace.thrift
@@ -95,6 +95,8 @@ struct TSpan {
 
   25: optional i32 apiId;
   26: optional TIntStringValue exceptionInfo;
+  
+  30: optional i16 applicationServiceType;
 }
 
 struct TSpanChunk {
@@ -115,6 +117,8 @@ struct TSpanChunk {
   9: optional string endPoint
 
   10: list<TSpanEvent> spanEventList
+  
+  11: optional i16 applicationServiceType
 }
 
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/calltree/span/SpanAligner2.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/calltree/span/SpanAligner2.java
@@ -150,7 +150,7 @@ public class SpanAligner2 {
         logger.debug("populate start");
         int currentDepth = spanDepth;
         if (logger.isDebugEnabled()) {
-            logger.debug("span type:{} depth:{} spanDepth:{} ", currentDepth, span.getServiceType(), spanDepth);
+            logger.debug("span type:{} depth:{} spanDepth:{} ", currentDepth, span.getApplicationServiceType(), spanDepth);
         }
 
         SpanAlign spanAlign = new SpanAlign(currentDepth, span);

--- a/web/src/main/java/com/navercorp/pinpoint/web/filter/FromToFilter.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/filter/FromToFilter.java
@@ -61,13 +61,13 @@ public class FromToFilter implements Filter {
     public boolean include(List<SpanBo> transaction) {
         if (includeServiceType(fromServiceCode, ServiceType.USER.getCode())) {
             for (SpanBo span : transaction) {
-                if (span.isRoot() && includeServiceType(toServiceCode, span.getServiceType()) && toApplicationName.equals(span.getApplicationId())) {
+                if (span.isRoot() && includeServiceType(toServiceCode, span.getApplicationServiceType()) && toApplicationName.equals(span.getApplicationId())) {
                     return true;
                 }
             }
         } else if (includeUnknown(toServiceCode)) {
             for (SpanBo span : transaction) {
-                if (includeServiceType(fromServiceCode, span.getServiceType()) && fromApplicationName.equals(span.getApplicationId())) {
+                if (includeServiceType(fromServiceCode, span.getApplicationServiceType()) && fromApplicationName.equals(span.getApplicationId())) {
                     List<SpanEventBo> eventBoList = span.getSpanEventBoList();
                     if (eventBoList == null) {
                         continue;
@@ -86,14 +86,14 @@ public class FromToFilter implements Filter {
              * find src first. span (from, to) may exist more than one. so (spanId == parentSpanID) should be checked.
              */
             for (SpanBo srcSpan : transaction) {
-                if (includeServiceType(fromServiceCode, srcSpan.getServiceType()) && fromApplicationName.equals(srcSpan.getApplicationId())) {
+                if (includeServiceType(fromServiceCode, srcSpan.getApplicationServiceType()) && fromApplicationName.equals(srcSpan.getApplicationId())) {
                     // find dest of src.
                     for (SpanBo destSpan : transaction) {
                         if (destSpan.getParentSpanId() != srcSpan.getSpanId()) {
                             continue;
                         }
 
-                        if (includeServiceType(toServiceCode, destSpan.getServiceType()) && toApplicationName.equals(destSpan.getApplicationId())) {
+                        if (includeServiceType(toServiceCode, destSpan.getApplicationServiceType()) && toApplicationName.equals(destSpan.getApplicationId())) {
                             return true;
                         }
                     }
@@ -102,7 +102,7 @@ public class FromToFilter implements Filter {
             }
         } else {
             for (SpanBo span : transaction) {
-                if (includeServiceType(fromServiceCode, span.getServiceType()) && fromApplicationName.equals(span.getApplicationId())) {
+                if (includeServiceType(fromServiceCode, span.getApplicationServiceType()) && fromApplicationName.equals(span.getApplicationId())) {
                     List<SpanEventBo> eventBoList = span.getSpanEventBoList();
                     if (eventBoList == null) {
                         continue;

--- a/web/src/main/java/com/navercorp/pinpoint/web/filter/FromToResponseFilter.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/filter/FromToResponseFilter.java
@@ -118,7 +118,7 @@ public class FromToResponseFilter implements Filter {
              * USER -> WAS
              */
             for (SpanBo span : transaction) {
-                if (span.isRoot() && includeServiceType(toServiceCode, span.getServiceType()) && toApplicationName.equals(span.getApplicationId())) {
+                if (span.isRoot() && includeServiceType(toServiceCode, span.getApplicationServiceType()) && toApplicationName.equals(span.getApplicationId())) {
                     return checkResponseCondition(span.getElapsed(), span.getErrCode() > 0)
                             && checkPinPointAgentName(null, span.getAgentId());
                 }
@@ -128,7 +128,7 @@ public class FromToResponseFilter implements Filter {
              * WAS -> UNKNOWN
              */
             for (SpanBo span : transaction) {
-                if (includeServiceType(fromServiceCode, span.getServiceType()) && fromApplicationName.equals(span.getApplicationId())) {
+                if (includeServiceType(fromServiceCode, span.getApplicationServiceType()) && fromApplicationName.equals(span.getApplicationId())) {
                     List<SpanEventBo> eventBoList = span.getSpanEventBoList();
                     if (eventBoList == null) {
                         continue;
@@ -175,14 +175,14 @@ public class FromToResponseFilter implements Filter {
                  * if problems happen because of hint, don't use hint at front end (UI) or use below code in order to work properly.
                  */
                 for (SpanBo srcSpan : transaction) {
-                    if (includeServiceType(fromServiceCode, srcSpan.getServiceType()) && fromApplicationName.equals(srcSpan.getApplicationId())) {
+                    if (includeServiceType(fromServiceCode, srcSpan.getApplicationServiceType()) && fromApplicationName.equals(srcSpan.getApplicationId())) {
                         // find dest of src.
                         for (SpanBo destSpan : transaction) {
                             if (destSpan.getParentSpanId() != srcSpan.getSpanId()) {
                                 continue;
                             }
 
-                            if (includeServiceType(toServiceCode, destSpan.getServiceType()) && toApplicationName.equals(destSpan.getApplicationId())) {
+                            if (includeServiceType(toServiceCode, destSpan.getApplicationServiceType()) && toApplicationName.equals(destSpan.getApplicationId())) {
                                 return checkResponseCondition(destSpan.getElapsed(), destSpan.getErrCode() > 0) && checkPinPointAgentName(srcSpan.getAgentId(), destSpan.getAgentId());
                             }
                         }
@@ -194,7 +194,7 @@ public class FromToResponseFilter implements Filter {
              * WAS -> BACKEND (non-WAS)
              */
             for (SpanBo span : transaction) {
-                if (includeServiceType(fromServiceCode, span.getServiceType()) && fromApplicationName.equals(span.getApplicationId())) {
+                if (includeServiceType(fromServiceCode, span.getApplicationServiceType()) && fromApplicationName.equals(span.getApplicationId())) {
                     List<SpanEventBo> eventBoList = span.getSpanEventBoList();
                     if (eventBoList == null) {
                         continue;

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/DotExtractor.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/DotExtractor.java
@@ -59,7 +59,7 @@ public class DotExtractor {
             throw new NullPointerException("span must not be null");
         }
 
-        Application spanApplication = new Application(span.getApplicationId(), registry.findServiceType(span.getServiceType()));
+        Application spanApplication = new Application(span.getApplicationId(), registry.findServiceType(span.getApplicationServiceType()));
         final List<Dot> dotList = getDotList(spanApplication);
 
         final TransactionId transactionId = new TransactionId(span.getTraceAgentId(), span.getTraceAgentStartTime(), span.getTraceTransactionSequence());

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/FilteredMapServiceImpl.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/FilteredMapServiceImpl.java
@@ -132,7 +132,7 @@ public class FilteredMapServiceImpl implements FilteredMapService {
 
         // scan transaction list
         for (SpanBo span : filteredTransactionList) {
-            if (sourceApplication.equals(span.getApplicationId(), registry.findServiceType(span.getServiceType()))) {
+            if (sourceApplication.equals(span.getApplicationId(), registry.findServiceType(span.getApplicationServiceType()))) {
                 List<SpanEventBo> spanEventBoList = span.getSpanEventBoList();
                 if (spanEventBoList == null) {
                     continue;
@@ -244,7 +244,7 @@ public class FilteredMapServiceImpl implements FilteredMapService {
 
             for (SpanBo span : transaction) {
                 final Application parentApplication = createParentApplication(span, transactionSpanMap);
-                final Application spanApplication = new Application(span.getApplicationId(), registry.findServiceType(span.getServiceType()));
+                final Application spanApplication = new Application(span.getApplicationId(), registry.findServiceType(span.getApplicationServiceType()));
 
                 // records the Span's response time statistics
                 recordSpanResponseTime(spanApplication, span, mapHistogramSummary, span.getCollectorAcceptTime());
@@ -323,7 +323,7 @@ public class FilteredMapServiceImpl implements FilteredMapService {
         if (CollectionUtils.isEmpty(spanEventBoList)) {
             return;
         }
-        final Application srcApplication = new Application(span.getApplicationId(), registry.findServiceType(span.getServiceType()));
+        final Application srcApplication = new Application(span.getApplicationId(), registry.findServiceType(span.getApplicationServiceType()));
 
         LinkDataMap sourceLinkDataMap = linkDataDuplexMap.getSourceLinkDataMap();
         for (SpanEventBo spanEvent : spanEventBoList) {
@@ -367,7 +367,7 @@ public class FilteredMapServiceImpl implements FilteredMapService {
         } else {
             String parentApplicationName = parentSpan.getApplicationId();
 
-            ServiceType serviceType = registry.findServiceType(parentSpan.getServiceType());
+            ServiceType serviceType = registry.findServiceType(parentSpan.getApplicationServiceType());
             return new Application(parentApplicationName, serviceType);
         }
     }


### PR DESCRIPTION
This should resolve #228, allowing for an application to have its own service type, and not be bound to a single service type which generates its root spans.
For example, a stand alone application running embedded tomcat will now show up as a STAND_ALONE node in the server map, while having its call stack generated from a TOMCAT span.