### PR TITLE
#254 fix exception when user node points to nodes with the same app name

### DIFF
--- a/commons/src/main/java/com/navercorp/pinpoint/common/util/ApplicationMapStatisticsUtils.java
+++ b/commons/src/main/java/com/navercorp/pinpoint/common/util/ApplicationMapStatisticsUtils.java
@@ -105,7 +105,13 @@ public class ApplicationMapStatisticsUtils {
         final short length = BytesUtils.bytesToShort(bytes, 4);
         return BytesUtils.toStringAndRightTrim(bytes, 6, length);
     }
-
+    
+    public static String getDestApplicationNameFromColumnNameForUser(byte[] bytes, ServiceType destServiceType) {
+        String destApplicationName = getDestApplicationNameFromColumnName(bytes);
+        String destServiceTypeName = destServiceType.getName();
+        return destApplicationName + "_" + destServiceTypeName;
+    }
+    
     public static String getHost(byte[] bytes) {
         int offset = 6 + BytesUtils.bytesToShort(bytes, 4);
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/LinkList.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/LinkList.java
@@ -56,7 +56,7 @@ public class LinkList {
         for (Link link : linkMap.values()) {
             Node toNode = link.getTo();
             // find all the callers of toApplication/destination
-            if (toNode.getApplication().equals(toApplication)) {
+            if (toNode.getApplication().equals(toApplication) && toNode.getServiceType().equals(toApplication.getServiceType())) {
                 findList.add(link);
             }
         }
@@ -70,14 +70,14 @@ public class LinkList {
      */
     public List<Link> findFromLink(Application fromApplication) {
         if (fromApplication == null) {
-            throw new NullPointerException("toApplication must not be null");
+            throw new NullPointerException("fromApplication must not be null");
         }
 
         List<Link> findList = new ArrayList<Link>();
         for (Link link : linkMap.values()) {
             Node fromNode = link.getFrom();
 
-            if (fromNode.getApplication().equals(fromApplication)) {
+            if (fromNode.getApplication().equals(fromApplication) && fromNode.getServiceType().equals(fromApplication.getServiceType())) {
                 findList.add(link);
             }
         }


### PR DESCRIPTION
An exception is thrown when drawing the server map in situations where users call multiple nodes with the same application name (but different service types). This was caused because it was not possible to have a single user node pointing to more than 1 destination node.

The user nodes are uniquely identified by their destination node's application name only and this resulted in only a single user node being created when there were multiple nodes with the same application name.

This commit fixes #254 by taking the destination node's service type into account when creating user nodes.