### PR TITLE
#271 CDH minor version up

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -283,18 +283,18 @@
             <dependency>
                 <groupId>org.apache.hadoop</groupId>
                 <artifactId>hadoop-common</artifactId>
-                <version>2.0.0-cdh4.5.0</version>
+                <version>2.0.0-cdh4.7.1</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.hadoop</groupId>
                 <artifactId>hadoop-core</artifactId>
-                <version>2.0.0-mr1-cdh4.5.0</version>
+                <version>2.0.0-mr1-cdh4.7.1</version>
             </dependency>
 
             <dependency>
                 <groupId>org.apache.hbase</groupId>
                 <artifactId>hbase</artifactId>
-                <version>0.94.6-cdh4.5.0</version>
+                <version>0.94.15-cdh4.7.1</version>
                 <exclusions>
                     <exclusion>
                         <groupId>commons-beanutils</groupId>
@@ -597,7 +597,7 @@
             <dependency>
                 <groupId>org.apache.zookeeper</groupId>
                 <artifactId>zookeeper</artifactId>
-                <version>3.4.5-cdh4.5.0</version>
+                <version>3.4.5-cdh4.7.1</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
CDH 4.5.0 -> CDH 4.7.1

hadoop 2.0.0-cdh4.5.0 -> 2.0.0-cdh4.7.1
hbase 0.94.6-cdh4.5.0 -> 0.94.15-cdh4.7.1
zookeeper 3.4.5-cdh4.5.0 -> 3.4.5-cdh4.7.1
hadoop-core  2.0.0-mr1-cdh4.5.0 -> 2.0.0-mr1-cdh4.7.1