### PR TITLE
Add @suppressWarnings("deprecation") for using DEFAULT_CONTENT_CHARSET i...

### DIFF
--- a/plugins/httpclient4/src/main/java/com/navercorp/pinpoint/plugin/httpclient4/interceptor/AbstractHttpClientExecuteMethodInterceptor.java
+++ b/plugins/httpclient4/src/main/java/com/navercorp/pinpoint/plugin/httpclient4/interceptor/AbstractHttpClientExecuteMethodInterceptor.java
@@ -296,6 +296,7 @@ public abstract class AbstractHttpClientExecuteMethodInterceptor implements Simp
      * @throws IOException
      *             if an error occurs reading the input stream
      */
+    @SuppressWarnings("deprecation")
     public static String entityUtilsToString(final HttpEntity entity, final String defaultCharset, int maxLength) throws IOException, ParseException {
         if (entity == null) {
             throw new IllegalArgumentException("HTTP entity may not be null");

--- a/plugins/httpclient4/src/main/java/com/navercorp/pinpoint/plugin/httpclient4/interceptor/DefaultClientExchangeHandlerImplStartMethodInterceptor.java
+++ b/plugins/httpclient4/src/main/java/com/navercorp/pinpoint/plugin/httpclient4/interceptor/DefaultClientExchangeHandlerImplStartMethodInterceptor.java
@@ -301,6 +301,7 @@ public class DefaultClientExchangeHandlerImplStartMethodInterceptor implements S
      * @throws IOException
      *             if an error occurs reading the input stream
      */
+    @SuppressWarnings("deprecation")
     public static String entityUtilsToString(final HttpEntity entity, final String defaultCharset, int maxLength) throws IOException, ParseException {
         if (entity == null) {
             throw new IllegalArgumentException("HTTP entity may not be null");

--- a/web/src/main/java/com/navercorp/pinpoint/web/cluster/zookeeper/ZookeeperClusterManager.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/cluster/zookeeper/ZookeeperClusterManager.java
@@ -106,7 +106,8 @@ public class ZookeeperClusterManager implements ClusterManager, Watcher {
 
         return true;
     }
-
+    
+    @SuppressWarnings("deprecation")
     @Override
     public void process(WatchedEvent event) {
         synchronized (initilizeLock) {

--- a/web/src/main/java/com/navercorp/pinpoint/web/cluster/zookeeper/ZookeeperUtils.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/cluster/zookeeper/ZookeeperUtils.java
@@ -36,6 +36,7 @@ public final class ZookeeperUtils {
         return isConnectedEvent(state, eventType);
     }
 
+    @SuppressWarnings("deprecation")
     public static boolean isConnectedEvent(KeeperState state, EventType eventType) {
         if ((state == KeeperState.SyncConnected || state == KeeperState.NoSyncConnected) && eventType == EventType.None) {
             return true;

--- a/web/src/main/java/com/navercorp/pinpoint/web/view/JacksonPinpointModule.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/view/JacksonPinpointModule.java
@@ -37,6 +37,7 @@ public class JacksonPinpointModule extends Module {
     /* (non-Javadoc)
      * @see org.codehaus.jackson.map.Module#version()
      */
+    @SuppressWarnings("deprecation")
     @Override
     public Version version() {
         return new Version(1, 0, 4, null);


### PR DESCRIPTION
For "DEFAULT_CONTENT_CHARSET in org.apache.http.protocol.HTTP has been deprecated" compile warning, I added "@SuppressWarnings("deprecation")".

For "NoSyncConnected in org.apache.zookeeper.Watcher.Event.KeeperState has been deprecated" compile warning, I removed the case checking whether keeperstate is NoSyncConnected because NoSyncConnected is deprecated and said that it will never be generated by server
 