### PR TITLE
change maven plugin repository #417

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,9 +20,9 @@
 
     <pluginRepositories>
         <pluginRepository>
-            <id>codehaus repository</id>
-            <name>Codehaus Maven2 Repository</name>
-            <url>http://repository.codehaus.org</url>
+            <id>central</id>
+            <name>Maven central plugin repository</name>
+            <url>http://repo1.maven.org/maven2</url>
         </pluginRepository>
     </pluginRepositories>
 


### PR DESCRIPTION
Change maven plugin repository becuase Codehaus services will be
terminated.

http://repository.codehaus.org -> http://repo1.maven.org/maven2