### PR TITLE
#382 added missing plugins dependency to collector's pom

### DIFF
--- a/collector/pom.xml
+++ b/collector/pom.xml
@@ -30,6 +30,11 @@
             <artifactId>pinpoint-thrift</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.navercorp.pinpoint</groupId>
+            <artifactId>pinpoint-plugins</artifactId>
+            <type>pom</type>
+        </dependency>
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>12.0.1</version>

--- a/quickstart/collector/pom.xml
+++ b/quickstart/collector/pom.xml
@@ -22,12 +22,6 @@
             <version>${project.version}</version>
             <type>war</type>
         </dependency>
-		<dependency>
-			<groupId>com.navercorp.pinpoint</groupId>
-			<artifactId>pinpoint-plugins</artifactId>
-            <version>${project.version}</version>
-			<type>pom</type>
-		</dependency>
     </dependencies>
 
     <build>

--- a/quickstart/web/pom.xml
+++ b/quickstart/web/pom.xml
@@ -22,12 +22,6 @@
 			<version>${project.version}</version>
 			<type>war</type>
 		</dependency>
-		<dependency>
-			<groupId>com.navercorp.pinpoint</groupId>
-			<artifactId>pinpoint-plugins</artifactId>
-            <version>${project.version}</version>
-			<type>pom</type>
-		</dependency>
 	</dependencies>
 
 	<build>


### PR DESCRIPTION
Collector's pom file in the cherry-picked commit did not have Plugins dependency, which resulted in plugins not being deployed.
This commit restores the dependency.