### PR TITLE
Remove hadoop dependency from Pinpoint commons test.

### DIFF
--- a/commons/src/test/java/com/navercorp/pinpoint/common/buffer/AutomaticBufferTest.java
+++ b/commons/src/test/java/com/navercorp/pinpoint/common/buffer/AutomaticBufferTest.java
@@ -19,14 +19,13 @@ package com.navercorp.pinpoint.common.buffer;
 import com.navercorp.pinpoint.common.util.BytesUtils;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.hadoop.hbase.util.Bytes;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.nio.charset.Charset;
+import java.util.Arrays;
 import java.util.Random;
 
 /**
@@ -52,7 +51,6 @@ public class AutomaticBufferTest {
     public void testPadBytes() throws Exception {
         int TOTAL_LENGTH = 20;
         int TEST_SIZE = 10;
-        int PAD_SIZE = TOTAL_LENGTH - TEST_SIZE;
         Buffer buffer = new AutomaticBuffer(10);
         byte[] test = new byte[10];
 
@@ -62,9 +60,9 @@ public class AutomaticBufferTest {
 
         byte[] result = buffer.getBuffer();
         org.junit.Assert.assertEquals(result.length, TOTAL_LENGTH);
-        org.junit.Assert.assertTrue("check data", Bytes.equals(test, 0, TEST_SIZE, result, 0, TEST_SIZE));
+        org.junit.Assert.assertTrue("check data", Arrays.equals(Arrays.copyOfRange(test, 0, TEST_SIZE), Arrays.copyOfRange(result, 0, TEST_SIZE)));
         byte[] padBytes = new byte[TOTAL_LENGTH - TEST_SIZE];
-        org.junit.Assert.assertTrue("check pad", Bytes.equals(padBytes, 0, TEST_SIZE, result, TEST_SIZE, PAD_SIZE));
+        org.junit.Assert.assertTrue("check pad", Arrays.equals(Arrays.copyOfRange(padBytes, 0, TEST_SIZE), Arrays.copyOfRange(result, TEST_SIZE, TOTAL_LENGTH)));
 
     }
 

--- a/commons/src/test/java/com/navercorp/pinpoint/common/buffer/FixedBufferTest.java
+++ b/commons/src/test/java/com/navercorp/pinpoint/common/buffer/FixedBufferTest.java
@@ -16,12 +16,12 @@
 
 package com.navercorp.pinpoint.common.buffer;
 
+import com.google.common.primitives.Ints;
 import com.navercorp.pinpoint.common.buffer.Buffer;
 import com.navercorp.pinpoint.common.buffer.FixedBuffer;
 import com.navercorp.pinpoint.common.util.BytesUtils;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.hadoop.hbase.util.Bytes;
 import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -72,7 +72,6 @@ public class FixedBufferTest {
     public void testPadBytes() throws Exception {
         int TOTAL_LENGTH = 20;
         int TEST_SIZE = 10;
-        int PAD_SIZE = TOTAL_LENGTH - TEST_SIZE;
         Buffer buffer = new FixedBuffer(32);
         byte[] test = new byte[10];
 
@@ -82,9 +81,9 @@ public class FixedBufferTest {
 
         byte[] result = buffer.getBuffer();
         Assert.assertEquals(result.length, TOTAL_LENGTH);
-        Assert.assertTrue("check data", Bytes.equals(test, 0, TEST_SIZE, result, 0, TEST_SIZE));
+        Assert.assertTrue("check data", Arrays.equals(Arrays.copyOfRange(test, 0, TEST_SIZE), Arrays.copyOfRange(result, 0, TEST_SIZE)));
         byte[] padBytes = new byte[TOTAL_LENGTH - TEST_SIZE];
-        Assert.assertTrue("check pad", Bytes.equals(padBytes, 0, TEST_SIZE, result, TEST_SIZE, PAD_SIZE));
+        Assert.assertTrue("check pad", Arrays.equals(Arrays.copyOfRange(padBytes, 0, TEST_SIZE), Arrays.copyOfRange(result, TEST_SIZE, TOTAL_LENGTH)));
 
     }
 
@@ -302,9 +301,9 @@ public class FixedBufferTest {
     @Test
     public void testRead4PrefixedString() throws Exception {
         String value = "test";
-        byte[] length = Bytes.toBytes(value.length());
-        byte[] string = Bytes.toBytes(value);
-        byte[] result = Bytes.add(length, string);
+        byte[] length = Ints.toByteArray(value.length());
+        byte[] string = value.getBytes();
+        byte[] result = BytesUtils.merge(length, string);
 
 
         Buffer buffer = new FixedBuffer(result);
@@ -315,7 +314,7 @@ public class FixedBufferTest {
 
     @Test
     public void testRead4PrefixedString_Null() throws Exception {
-        byte[] length = Bytes.toBytes(-1);
+        byte[] length = Ints.toByteArray(-1);
 
 
         Buffer buffer = new FixedBuffer(length);
@@ -400,7 +399,7 @@ public class FixedBufferTest {
                 int i = buffer.readVarInt();
             } catch (IllegalArgumentException e) {
                 logger.info(e.getMessage(), e);
-                String binaryString = Bytes.toStringBinary(bytes);
+                String binaryString = BytesUtils.toString(bytes);
                 logger.info(binaryString);;
                 for (byte aByte : bytes) {
                     String code = String.valueOf((int) aByte);
@@ -423,7 +422,7 @@ public class FixedBufferTest {
                 long i = buffer.readVarLong();
             } catch (IllegalArgumentException e) {
                 logger.info(e.getMessage(), e);
-                String binaryString = Bytes.toStringBinary(bytes);
+                String binaryString = BytesUtils.toString(bytes);
                 logger.info(binaryString);;
                 for (byte aByte : bytes) {
                     String code = String.valueOf((int) aByte);

--- a/commons/src/test/java/com/navercorp/pinpoint/common/util/ApplicationMapStatisticsUtilsTest.java
+++ b/commons/src/test/java/com/navercorp/pinpoint/common/util/ApplicationMapStatisticsUtilsTest.java
@@ -16,7 +16,6 @@
 
 package com.navercorp.pinpoint.common.util;
 
-import org.apache.hadoop.hbase.util.Bytes;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -41,10 +40,10 @@ public class ApplicationMapStatisticsUtilsTest {
     @Test
     public void testMakeColumnName() throws Exception {
         final byte[] columnNameBytes = ApplicationMapStatisticsUtils.makeColumnName("test", (short) 10);
-        short slotNumber = Bytes.toShort(columnNameBytes);
+        short slotNumber = BytesUtils.bytesToShort(columnNameBytes,0);
         Assert.assertEquals(slotNumber, 10);
 
-        String columnName = Bytes.toString(columnNameBytes, Bytes.SIZEOF_SHORT, columnNameBytes.length - Bytes.SIZEOF_SHORT);
+        String columnName = BytesUtils.toString(columnNameBytes, BytesUtils.SHORT_BYTE_LENGTH, columnNameBytes.length - BytesUtils.SHORT_BYTE_LENGTH);
         Assert.assertEquals(columnName, "test");
 
     }

--- a/commons/src/test/java/com/navercorp/pinpoint/common/util/BytesUtilsTest.java
+++ b/commons/src/test/java/com/navercorp/pinpoint/common/util/BytesUtilsTest.java
@@ -16,7 +16,6 @@
 
 package com.navercorp.pinpoint.common.util;
 
-import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.thrift.TException;
 import org.apache.thrift.protocol.TCompactProtocol;
 import org.apache.thrift.transport.TMemoryBuffer;
@@ -25,6 +24,9 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.primitives.Ints;
+
+import java.nio.ByteBuffer;
 import java.util.Arrays;
 
 
@@ -75,10 +77,10 @@ public class BytesUtilsTest {
     }
 
     private void checkInt(int i) {
-        byte[] bytes = Bytes.toBytes(i);
+        byte[] bytes = Ints.toByteArray(i);
         int i2 = BytesUtils.bytesToInt(bytes, 0);
         Assert.assertEquals(i, i2);
-        int i3 = Bytes.toInt(bytes);
+        int i3 = Ints.fromByteArray(bytes);
         Assert.assertEquals(i, i3);
     }
 
@@ -86,7 +88,7 @@ public class BytesUtilsTest {
     @Test
     public void testAddStringLong() {
         byte[] testAgents = BytesUtils.add("testAgent", 11L);
-        byte[] buf = Bytes.add(Bytes.toBytes("testAgent"), Bytes.toBytes(11L));
+        byte[] buf = ByteBuffer.allocate(17).put("testAgent".getBytes()).putLong(11L).array();
         Assert.assertArrayEquals(testAgents, buf);
     }
 

--- a/commons/src/test/java/com/navercorp/pinpoint/common/util/SpanUtilsTest.java
+++ b/commons/src/test/java/com/navercorp/pinpoint/common/util/SpanUtilsTest.java
@@ -16,12 +16,13 @@
 
 package com.navercorp.pinpoint.common.util;
 
+import java.util.Arrays;
+
+import com.google.common.primitives.Longs;
 import com.navercorp.pinpoint.common.PinpointConstants;
 import com.navercorp.pinpoint.thrift.dto.TSpan;
 
 import org.junit.Assert;
-
-import org.apache.hadoop.hbase.util.Bytes;
 import org.junit.Test;
 
 /**
@@ -75,10 +76,11 @@ public class SpanUtilsTest {
 
         byte[] traceIndexRowKey = SpanUtils.getAgentIdTraceIndexRowKey(span.getAgentId(), span.getStartTime());
 
-        String agentId = Bytes.toString(traceIndexRowKey, 0, PinpointConstants.AGENT_NAME_MAX_LEN).trim();
+        String agentId = BytesUtils.toString(traceIndexRowKey, 0, PinpointConstants.AGENT_NAME_MAX_LEN).trim();
         Assert.assertEquals(agentId0, agentId);
 
-        long time = TimeUtils.recoveryTimeMillis(Bytes.toLong(traceIndexRowKey, PinpointConstants.AGENT_NAME_MAX_LEN));
+        long time = Longs.fromByteArray(Arrays.copyOfRange(traceIndexRowKey, PinpointConstants.AGENT_NAME_MAX_LEN, PinpointConstants.AGENT_NAME_MAX_LEN + 8));
+        time = TimeUtils.recoveryTimeMillis(time);
         Assert.assertEquals(time, l1);
     }
 }


### PR DESCRIPTION
Pinpoint now uses HBase 1.0.x, which is compiled against jdk 1.7.
Pinpoint commons however is compiled with jdk 1.6 and would throw
UnsupportedClassVersionError when tests that use classes in Hadoop/HBase
library.
This commit removes these so such tests won't fail - fixes #432 