### PR TITLE
Fix syntax of markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ We welcome any documentation contribution.
 ## Contribution
 We welcome any and all suggestions. Our development guide is currently WIP so check back often for any updates.
 
-For contributions, please make a pull-request against our ```master``` branch.
+For contributions, please make a pull-request against our `master` branch.
 
 We would love to see additional tracing support for libraries such as [Storm](https://storm.apache.org/), [HBase](http://hbase.apache.org/), as well as profiler support for additional languages (.NET, C++).
 

--- a/profiler-optional/README.md
+++ b/profiler-optional/README.md
@@ -6,9 +6,9 @@
 In order to build pinpoint-profiler-optional, the following requirements must be met:
 
 * JDK 7+ installed
-* ```JAVA_7_HOME``` environment variable set to JDK 7 home directory
+* `JAVA_7_HOME` environment variable set to JDK 7 home directory
 
-Once the ```JAVA_7_HOME``` environment is set, the *maven-compiler-plugin* invokes the JDK 7 compiler to compile the optional package:
+Once the `JAVA_7_HOME` environment is set, the *maven-compiler-plugin* invokes the JDK 7 compiler to compile the optional package:
 
 ```xml
 <plugin>

--- a/quickstart/README.Win.ko.md
+++ b/quickstart/README.Win.ko.md
@@ -3,26 +3,26 @@ Pinpoint는 공식적으로는 Linux와 OS X를 지원한다. 하지만 Pinpoint
 
 ## 시작하기
 
-```git clone https://github.com/naver/pinpoint.git```로 Pinpoint를 다운로드 하거나 zip 파일로 프로젝트를 [다운로드](https://github.com/naver/pinpoint/archive/master.zip)하고 압축을 해제한다.
+`git clone https://github.com/naver/pinpoint.git`로 Pinpoint를 다운로드 하거나 zip 파일로 프로젝트를 [다운로드](https://github.com/naver/pinpoint/archive/master.zip)하고 압축을 해제한다.
 
-```cd pinpoint```를 하고  ```mvn install -Dmaven.test.skip=true```를 실행하여 maven으로 Pinpoint를 설치한다.
+`cd pinpoint`를 하고 `mvn install -Dmaven.test.skip=true`를 실행하여 maven으로 Pinpoint를 설치한다.
 
 ### 설치 및 HBase 시작하기
 **[Apache 다운로드 사이트](http://apache.mirror.cdnetworks.com/hbase/)에서 HBase 1.0.x 버전을 다운로드 받는다.
 
-**다운로드 받은 파일을 quickstart\hbase 디렉토리에 압축을 풀고 디렉토리 이름을 hbase로 변경하여 ```quickstart\hbase\hbase``` 로 만든다.
+**다운로드 받은 파일을 quickstart\hbase 디렉토리에 압축을 풀고 디렉토리 이름을 hbase로 변경하여 `quickstart\hbase\hbase`로 만든다.
 
-**HBase 시작 - ```quickstart\bin\start-hbase.cmd``` 실행
+**HBase 시작** - `quickstart\bin\start-hbase.cmd` 실행
 
-**테이블 초기화** - ```quickstart\bin\init-hbase.cmd``` 실행
+**테이블 초기화** - `quickstart\bin\init-hbase.cmd` 실행
 
 ### Pinpoint 데몬 시작하기
 
-**Collector** - ```quickstart\bin\start-collector.cmd``` 실행
+**Collector** - `quickstart\bin\start-collector.cmd` 실행
 
-**Web UI** - ```quickstart\bin\start-web.cmd``` 실행
+**Web UI** - `quickstart\bin\start-web.cmd` 실행
 
-**TestApp** - ```quickstart\bin\start-testapp.cmd``` 실행
+**TestApp** - `quickstart\bin\start-testapp.cmd` 실행
 
 ### 상태 확인
 HBase와 3개 데몬이 실행한 후 Pinpoint 인스턴스를 테스트하려면 아래 주소로 접속한다.
@@ -34,10 +34,10 @@ TestApp UI를 사용하여 Pinpoint로 추적 데이터를 전송하고, Pinpoin
 
 ## 종료하기
 
-**HBase** - ```quickstart\bin\stop-hbase.cmd``` 실행
+**HBase** - `quickstart\bin\stop-hbase.cmd` 실행
 
-**Collector** - ```quickstart\bin\stop-collector.cmd``` 실행
+**Collector** - `quickstart\bin\stop-collector.cmd` 실행
 
-**Web UI** - ```quickstart\bin\stop-web.cmd``` 실행
+**Web UI** - `quickstart\bin\stop-web.cmd` 실행
 
-**TestApp** - ```quickstart\bin\stop-testapp.cmd``` 실행
+**TestApp** - `quickstart\bin\stop-testapp.cmd` 실행

--- a/quickstart/README.md
+++ b/quickstart/README.md
@@ -16,7 +16,7 @@ QuickStart supports Linux, OSX, and Windows.
 
 
 ## Starting 
-Download Pinpoint with `git clone https://github.com/naver/pinpoint.gi`` or [download](https://github.com/naver/pinpoint/archive/master.zip) the project as a zip file and unzip.
+Download Pinpoint with `git clone https://github.com/naver/pinpoint.git` or [download](https://github.com/naver/pinpoint/archive/master.zip) the project as a zip file and unzip.
 
 Install Pinpoint with maven by `cd pinpoint` and running `mvn install -Dmaven.test.skip=true`
 
@@ -38,11 +38,11 @@ The following script downloads HBase standalone from [Apache download site](http
 
 ### Start Pinpoint Daemons
 
-**Collector** - Run ```quickstart/bin/start-collector.sh```
+**Collector** - Run `quickstart/bin/start-collector.sh`
 
-**Web UI** - Run ```quickstart/bin/start-web.sh```
+**Web UI** - Run `quickstart/bin/start-web.sh`
 
-**TestApp** - Run ```quickstart/bin/start-testapp.sh```
+**TestApp** - Run `quickstart/bin/start-testapp.sh`
 
 Once the startup scripts are completed, the last 10 lines of the Tomcat log are tailed to the console:
 
@@ -63,10 +63,10 @@ You can feed trace data to Pinpoint using the TestApp UI, and check them using P
 
 ## Stopping
 
-**HBase** - Run ```quickstart/bin/stop-hbase.sh```
+**HBase** - Run `quickstart/bin/stop-hbase.sh`
 
-**Collector** - Run ```quickstart/bin/stop-collector.sh```
+**Collector** - Run `quickstart/bin/stop-collector.sh`
 
-**Web UI** - Run ```quickstart/bin/stop-web.sh```
+**Web UI** - Run `quickstart/bin/stop-web.sh`
 
-**TestApp** - Run ```quickstart/bin/stop-testapp.sh```
+**TestApp** - Run `quickstart/bin/stop-testapp.sh`


### PR DESCRIPTION
Inline code can be written with one backtick `` `code` ``. Three backticks are used for multiline code:

    ```
    code
    ```