### PR TITLE
Add Gson plugin

### DIFF
--- a/agent/pom.xml
+++ b/agent/pom.xml
@@ -46,6 +46,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.3.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.navercorp.pinpoint</groupId>
             <artifactId>pinpoint-test</artifactId>
             <scope>test</scope>

--- a/agent/src/test/java/com/navercorp/pinpoint/plugin/gson/GsonMethodFilterIT.java
+++ b/agent/src/test/java/com/navercorp/pinpoint/plugin/gson/GsonMethodFilterIT.java
@@ -1,0 +1,138 @@
+/**
+ * Copyright 2014 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.plugin.gson;
+
+import static com.navercorp.pinpoint.bootstrap.plugin.test.PluginTestVerifier.ExpectedAnnotation.*;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+import com.navercorp.pinpoint.bootstrap.plugin.test.PluginTestVerifier;
+import com.navercorp.pinpoint.bootstrap.plugin.test.PluginTestVerifierHolder;
+import com.navercorp.pinpoint.test.plugin.Dependency;
+import com.navercorp.pinpoint.test.plugin.PinpointPluginTestSuite;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.Reader;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.lang.reflect.Member;
+import java.lang.reflect.Method;
+import java.lang.reflect.Type;
+
+/**
+ * @author ChaYoung You
+ */
+@RunWith(PinpointPluginTestSuite.class)
+@Dependency({"com.google.code.gson:gson:2.3.1"})
+public class GsonMethodFilterIT {
+    @Test
+    public void test() throws Exception {
+        final String json = "Pinpoint";
+        final String serviceType = "GSON";
+        final String annotationKeyName = "JSON_LENGTH";
+        // Pinpoint
+        final PluginTestVerifier.ExpectedAnnotation fromJsonAnnotation = annotation(annotationKeyName, json.length());
+        // "Pinpoint"
+        final PluginTestVerifier.ExpectedAnnotation toJsonAnnotation = annotation(annotationKeyName, json.length() + 2);
+        final Gson gson = new Gson();
+        final JsonElement jsonElement = new JsonParser().parse(json);
+
+        /**
+         * @see Gson#fromJson(String, Class)
+         * @see Gson#fromJson(String, Type)
+         * @see Gson#fromJson(Reader, Class)
+         * @see Gson#fromJson(Reader, Type)
+         * @see Gson#fromJson(JsonReader, Type)
+         * @see Gson#fromJson(JsonElement, Class)
+         * @see Gson#fromJson(JsonElement, Type)
+         */
+        gson.fromJson(json, String.class);
+        gson.fromJson(json, (Type) String.class);
+        gson.fromJson(new StringReader(json), (Class) String.class);
+        gson.fromJson(new StringReader(json), (Type) String.class);
+        gson.fromJson(new JsonReader(new StringReader(json)), String.class);
+        gson.fromJson(jsonElement, String.class);
+        gson.fromJson(jsonElement, (Type) String.class);
+
+        Method fromJson1 = Gson.class.getDeclaredMethod("fromJson", String.class, Class.class);
+        Method fromJson2 = Gson.class.getDeclaredMethod("fromJson", String.class, Type.class);
+        Method fromJson3 = Gson.class.getDeclaredMethod("fromJson", Reader.class, Class.class);
+        Method fromJson4 = Gson.class.getDeclaredMethod("fromJson", Reader.class, Type.class);
+        Method fromJson5 = Gson.class.getDeclaredMethod("fromJson", JsonReader.class, Type.class);
+        Method fromJson6 = Gson.class.getDeclaredMethod("fromJson", JsonElement.class, Class.class);
+        Method fromJson7 = Gson.class.getDeclaredMethod("fromJson", JsonElement.class, Type.class);
+
+        /**
+         * @see Gson#toJson(Object)
+         * @see Gson#toJson(Object, Type)
+         * @see Gson#toJson(Object, Appendable)
+         * @see Gson#toJson(Object, Type, Appendable)
+         * @see Gson#toJson(Object, Type, JsonWriter)
+         * @see Gson#toJson(JsonElement)
+         * @see Gson#toJson(JsonElement, Appendable)
+         * @see Gson#toJson(JsonElement, JsonWriter)
+         */
+        gson.toJson(json);
+        gson.toJson(json, String.class);
+        gson.toJson(json, new StringWriter());
+        gson.toJson(json, String.class, new StringWriter());
+        gson.toJson(json, String.class, new JsonWriter(new StringWriter()));
+        gson.toJson(jsonElement);
+        gson.toJson(jsonElement, new StringWriter());
+        gson.toJson(jsonElement, new JsonWriter(new StringWriter()));
+
+        Method toJson1 = Gson.class.getDeclaredMethod("toJson", Object.class);
+        Method toJson2 = Gson.class.getDeclaredMethod("toJson", Object.class, Type.class);
+        Method toJson3 = Gson.class.getDeclaredMethod("toJson", Object.class, Appendable.class);
+        Method toJson4 = Gson.class.getDeclaredMethod("toJson", Object.class, Type.class, Appendable.class);
+        Method toJson5 = Gson.class.getDeclaredMethod("toJson", Object.class, Type.class, JsonWriter.class);
+        Method toJson6 = Gson.class.getDeclaredMethod("toJson", JsonElement.class);
+        Method toJson7 = Gson.class.getDeclaredMethod("toJson", JsonElement.class, Appendable.class);
+        Method toJson8 = Gson.class.getDeclaredMethod("toJson", JsonElement.class, JsonWriter.class);
+
+        PluginTestVerifier verifier = PluginTestVerifierHolder.getInstance();
+        verifier.printCache(System.out);
+        verifier.printBlocks(System.out);
+
+        verifyTraceBlockAnnotation(verifier, serviceType, fromJson1, fromJsonAnnotation);
+        verifyTraceBlockAnnotation(verifier, serviceType, fromJson2, fromJsonAnnotation);
+        verifier.verifyApi(serviceType, fromJson3);
+        verifier.verifyApi(serviceType, fromJson4);
+        verifier.verifyApi(serviceType, fromJson5);
+        verifier.verifyApi(serviceType, fromJson6);
+        verifier.verifyApi(serviceType, fromJson7);
+
+        verifyTraceBlockAnnotation(verifier, serviceType, toJson1, toJsonAnnotation);
+        verifyTraceBlockAnnotation(verifier, serviceType, toJson2, toJsonAnnotation);
+        verifier.verifyApi(serviceType, toJson3);
+        verifier.verifyApi(serviceType, toJson4);
+        verifier.verifyApi(serviceType, toJson5);
+        verifyTraceBlockAnnotation(verifier, serviceType, toJson6, toJsonAnnotation);
+        verifier.verifyApi(serviceType, toJson7);
+        verifier.verifyApi(serviceType, toJson8);
+
+        // No more traces
+        verifier.verifyTraceBlockCount(0);
+    }
+
+    private void verifyTraceBlockAnnotation(PluginTestVerifier verifier, String serviceType, Member api, PluginTestVerifier.ExpectedAnnotation annotation) {
+        verifier.verifyTraceBlock(PluginTestVerifier.BlockType.EVENT, serviceType, api, null, null, null, null, annotation);
+    }
+}

--- a/plugins/gson/.gitignore
+++ b/plugins/gson/.gitignore
@@ -1,0 +1,5 @@
+/target/
+/.settings/
+/.classpath
+/.project
+/*.iml

--- a/plugins/gson/pom.xml
+++ b/plugins/gson/pom.xml
@@ -1,0 +1,25 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.navercorp.pinpoint</groupId>
+        <artifactId>pom</artifactId>
+        <relativePath>../..</relativePath>
+        <version>1.5.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>pinpoint-gson-plugin</artifactId>
+    <name>pinpoint-gson-plugin</name>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.navercorp.pinpoint</groupId>
+            <artifactId>pinpoint-bootstrap</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.navercorp.pinpoint</groupId>
+            <artifactId>pinpoint-bootstrap-core</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/plugins/gson/src/main/java/com/navercorp/pinpoint/plugin/gson/GsonMetadataProvider.java
+++ b/plugins/gson/src/main/java/com/navercorp/pinpoint/plugin/gson/GsonMetadataProvider.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2014 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.plugin.gson;
+
+import com.navercorp.pinpoint.common.trace.TraceMetadataProvider;
+import com.navercorp.pinpoint.common.trace.TraceMetadataSetupContext;
+
+/**
+ * @author ChaYoung You
+ */
+public class GsonMetadataProvider implements TraceMetadataProvider {
+    /**
+     * @see TraceMetadataProvider#setup(TraceMetadataSetupContext)
+     */
+    @Override
+    public void setup(TraceMetadataSetupContext context) {
+        context.addServiceType(GsonPlugin.GSON_SERVICE_TYPE);
+        context.addAnnotationKey(GsonPlugin.GSON_ANNOTATION_KEY_JSON_LENGTH);
+    }
+}

--- a/plugins/gson/src/main/java/com/navercorp/pinpoint/plugin/gson/GsonPlugin.java
+++ b/plugins/gson/src/main/java/com/navercorp/pinpoint/plugin/gson/GsonPlugin.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright 2014 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.plugin.gson;
+
+import static com.navercorp.pinpoint.common.trace.HistogramSchema.*;
+
+import com.navercorp.pinpoint.bootstrap.logging.PLogger;
+import com.navercorp.pinpoint.bootstrap.logging.PLoggerFactory;
+import com.navercorp.pinpoint.bootstrap.plugin.ProfilerPlugin;
+import com.navercorp.pinpoint.bootstrap.plugin.ProfilerPluginContext;
+import com.navercorp.pinpoint.bootstrap.plugin.transformer.ClassFileTransformerBuilder;
+import com.navercorp.pinpoint.bootstrap.plugin.transformer.MethodTransformerBuilder;
+import com.navercorp.pinpoint.bootstrap.plugin.transformer.MethodTransformerExceptionHandler;
+import com.navercorp.pinpoint.common.trace.AnnotationKey;
+import com.navercorp.pinpoint.common.trace.ServiceType;
+import com.navercorp.pinpoint.plugin.gson.filter.GsonMethodFilter;
+import com.navercorp.pinpoint.plugin.gson.filter.GsonMethodNames;
+
+/**
+ * @author ChaYoung You
+ */
+public class GsonPlugin implements ProfilerPlugin {
+    public static final ServiceType GSON_SERVICE_TYPE = ServiceType.of(7000, "GSON", NORMAL_SCHEMA);
+    public static final AnnotationKey GSON_ANNOTATION_KEY_JSON_LENGTH = new AnnotationKey(9000, "JSON_LENGTH");
+    private static final String GSON_CLASS = "com.google.gson.Gson";
+    private static final String GSON_METHODS_INTERCEPTOR = "com.navercorp.pinpoint.plugin.gson.interceptor.GsonMethodInterceptor";
+    private static final String GSON_GROUP = "GSON_GROUP";
+
+    private final PLogger logger = PLoggerFactory.getLogger(getClass());
+
+    @Override
+    public void setup(ProfilerPluginContext context) {
+        final ClassFileTransformerBuilder classEditorBuilder = context.getClassFileTransformerBuilder(GSON_CLASS);
+        final MethodTransformerBuilder methodEditorBuilder = classEditorBuilder.editMethods(new GsonMethodFilter(GsonMethodNames.get()));
+        methodEditorBuilder.exceptionHandler(new MethodTransformerExceptionHandler() {
+            @Override
+            public void handle(String targetClassName, String targetMethodName, String[] targetMethodParameterTypes, Throwable exception) throws Throwable {
+                if (logger.isWarnEnabled()) {
+                    logger.warn("Unsupported method " + targetClassName + "." + targetMethodName, exception);
+                }
+            }
+        });
+        methodEditorBuilder.injectInterceptor(GSON_METHODS_INTERCEPTOR).group(GSON_GROUP);
+        context.addClassFileTransformer(classEditorBuilder.build());
+    }
+}

--- a/plugins/gson/src/main/java/com/navercorp/pinpoint/plugin/gson/filter/GsonMethodFilter.java
+++ b/plugins/gson/src/main/java/com/navercorp/pinpoint/plugin/gson/filter/GsonMethodFilter.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2014 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.plugin.gson.filter;
+
+import com.navercorp.pinpoint.bootstrap.instrument.MethodFilter;
+import com.navercorp.pinpoint.bootstrap.instrument.MethodInfo;
+import com.navercorp.pinpoint.bootstrap.logging.PLogger;
+import com.navercorp.pinpoint.bootstrap.logging.PLoggerFactory;
+
+import java.lang.reflect.Modifier;
+import java.util.Set;
+
+/**
+ * @author ChaYoung You
+ */
+public class GsonMethodFilter implements MethodFilter {
+    private static final boolean TRACK = false;
+    private static final boolean DO_NOT_TRACK = true;
+    private final Set<String> methodNames;
+
+    public GsonMethodFilter(final Set<String> methodNames) {
+        this.methodNames = methodNames;
+    }
+
+    @Override
+    public boolean filter(MethodInfo method) {
+        final int modifiers = method.getModifiers();
+
+        if (!Modifier.isPublic(modifiers) || Modifier.isStatic(modifiers) || Modifier.isAbstract(modifiers) || Modifier.isNative(modifiers)) {
+            return DO_NOT_TRACK;
+        }
+
+        if (methodNames.contains(method.getName())) {
+            return TRACK;
+        }
+
+        return DO_NOT_TRACK;
+    }
+}

--- a/plugins/gson/src/main/java/com/navercorp/pinpoint/plugin/gson/filter/GsonMethodNames.java
+++ b/plugins/gson/src/main/java/com/navercorp/pinpoint/plugin/gson/filter/GsonMethodNames.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2014 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.plugin.gson.filter;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * @author ChaYoung You
+ */
+public class GsonMethodNames {
+    public static final String FROM_JSON = "fromJson";
+    public static final String TO_JSON = "toJson";
+
+    private static Set<String> names = null;
+
+    public static Set<String> get() {
+        if (names != null) {
+            return names;
+        }
+
+        final String[] methodNames = {
+                FROM_JSON,
+                TO_JSON
+        };
+
+        names = new HashSet<String>(Arrays.asList(methodNames));
+        return names;
+    }
+}

--- a/plugins/gson/src/main/java/com/navercorp/pinpoint/plugin/gson/interceptor/GsonMethodInterceptor.java
+++ b/plugins/gson/src/main/java/com/navercorp/pinpoint/plugin/gson/interceptor/GsonMethodInterceptor.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright 2014 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.plugin.gson.interceptor;
+
+import com.navercorp.pinpoint.bootstrap.context.Trace;
+import com.navercorp.pinpoint.bootstrap.context.TraceContext;
+import com.navercorp.pinpoint.bootstrap.interceptor.MethodDescriptor;
+import com.navercorp.pinpoint.bootstrap.interceptor.SimpleAroundInterceptor;
+import com.navercorp.pinpoint.bootstrap.logging.PLogger;
+import com.navercorp.pinpoint.bootstrap.logging.PLoggerFactory;
+import com.navercorp.pinpoint.plugin.gson.GsonPlugin;
+import com.navercorp.pinpoint.plugin.gson.filter.GsonMethodNames;
+
+import java.lang.reflect.Type;
+
+/**
+ * Gson method interceptor
+ *
+ * @author ChaYoung You
+ */
+public class GsonMethodInterceptor implements SimpleAroundInterceptor {
+    private final TraceContext traceContext;
+    private final MethodDescriptor descriptor;
+    private final PLogger logger = PLoggerFactory.getLogger(getClass());
+
+    public GsonMethodInterceptor(TraceContext traceContext, MethodDescriptor descriptor) {
+        this.traceContext = traceContext;
+        this.descriptor = descriptor;
+    }
+
+    @Override
+    public void before(Object target, Object[] args) {
+        if (logger.isDebugEnabled()) {
+            logger.beforeInterceptor(target, args);
+        }
+
+        final Trace trace = traceContext.currentTraceObject();
+        if (trace == null) {
+            return;
+        }
+
+        trace.traceBlockBegin();
+        trace.markBeforeTime();
+    }
+
+    @Override
+    public void after(Object target, Object[] args, Object result, Throwable throwable) {
+        if (logger.isDebugEnabled()) {
+            logger.afterInterceptor(target, args, result, throwable);
+        }
+
+        final Trace trace = traceContext.currentTraceObject();
+        if (trace == null) {
+            return;
+        }
+
+        try {
+            trace.recordServiceType(GsonPlugin.GSON_SERVICE_TYPE);
+            trace.recordApi(descriptor);
+            trace.recordException(throwable);
+            if (descriptor.getMethodName().equals(GsonMethodNames.FROM_JSON)) {
+                if (args.length >= 1 && args[0] instanceof String) {
+                    trace.recordAttribute(GsonPlugin.GSON_ANNOTATION_KEY_JSON_LENGTH, ((String) args[0]).length());
+                }
+            } else if (descriptor.getMethodName().equals(GsonMethodNames.TO_JSON)) {
+                if (args.length == 1 || args.length == 2 && args[1] instanceof Type) {
+                    trace.recordAttribute(GsonPlugin.GSON_ANNOTATION_KEY_JSON_LENGTH, ((String) result).length());
+                }
+            }
+            trace.markAfterTime();
+        } finally {
+            trace.traceBlockEnd();
+        }
+    }
+}

--- a/plugins/gson/src/main/resources/META-INF/services/com.navercorp.pinpoint.bootstrap.plugin.ProfilerPlugin
+++ b/plugins/gson/src/main/resources/META-INF/services/com.navercorp.pinpoint.bootstrap.plugin.ProfilerPlugin
@@ -1,0 +1,1 @@
+com.navercorp.pinpoint.plugin.gson.GsonPlugin

--- a/plugins/gson/src/main/resources/META-INF/services/com.navercorp.pinpoint.common.trace.TraceMetadataProvider
+++ b/plugins/gson/src/main/resources/META-INF/services/com.navercorp.pinpoint.common.trace.TraceMetadataProvider
@@ -1,0 +1,1 @@
+com.navercorp.pinpoint.plugin.gson.GsonMetadataProvider

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -13,6 +13,7 @@
     
     <modules>
         <module>httpclient4</module>
+        <module>gson</module>
         <module>jdbc-driver</module>
         <module>jdk-http</module>
         <module>redis</module>
@@ -24,6 +25,11 @@
         <dependency>
             <groupId>com.navercorp.pinpoint</groupId>
             <artifactId>pinpoint-httpclient4-plugin</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.navercorp.pinpoint</groupId>
+            <artifactId>pinpoint-gson-plugin</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>


### PR DESCRIPTION
See https://code.google.com/p/google-gson/.

It records start time and end time of the calls of `fromJson` and `toJson`. If an user passes a `String` to `fromJson`, or doesn't pass a `Appendable` or `JsonWriter` to `toJson`, then this plugin records the length of JSON as an attribute. See `plugins/gson/src/main/java/com/navercorp/pinpoint/plugin/gson/interceptor/GsonMethodInterceptor.java`.

It currently uses 7000 as the code of `ServiceType`, 9000 as the code of `AnnotationKey`. If you want to use other codes, please let me know. Also if you think some additional Javadoc comments are needed, please mention the methods or classes.