### PR TITLE
#329 modify ITs to retrieve hostnames from InetSocketAddress

### DIFF
--- a/agent/src/test/java/com/navercorp/pinpoint/plugin/thrift/common/client/AsyncEchoTestClient.java
+++ b/agent/src/test/java/com/navercorp/pinpoint/plugin/thrift/common/client/AsyncEchoTestClient.java
@@ -105,7 +105,7 @@ public class AsyncEchoTestClient implements EchoTestClient {
                 null, // rpc
                 null, // endPoint
                 null, // remoteAddress
-                SERVER_IP + ":" + SERVER_PORT, // destinationId
+                SERVER_ADDRESS.getHostName() + ":" + SERVER_ADDRESS.getPort(), // destinationId
                 thriftUrl // Annotation("thrift.url")
         );
         

--- a/agent/src/test/java/com/navercorp/pinpoint/plugin/thrift/common/client/SyncEchoTestClient.java
+++ b/agent/src/test/java/com/navercorp/pinpoint/plugin/thrift/common/client/SyncEchoTestClient.java
@@ -67,7 +67,7 @@ public abstract class SyncEchoTestClient implements EchoTestClient {
                 null, // rpc
                 null, // endPoint
                 null, // remoteAddress
-                SERVER_IP + ":" + SERVER_PORT, // destinationId
+                SERVER_ADDRESS.getHostName() + ":" + SERVER_ADDRESS.getPort(), // destinationId
                 thriftUrl, // Annotation("thrift.url")
                 thriftArgs // Annotation("thrift.args")
         );

--- a/agent/src/test/java/com/navercorp/pinpoint/plugin/thrift/common/server/AsyncEchoTestServer.java
+++ b/agent/src/test/java/com/navercorp/pinpoint/plugin/thrift/common/server/AsyncEchoTestServer.java
@@ -54,8 +54,8 @@ public abstract class AsyncEchoTestServer<T extends AbstractNonblockingServer> e
                 "THRIFT_SERVER", // ServiceType,
                 "Thrift Server Invocation", // Method
                 "com/navercorp/pinpoint/plugin/thrift/dto/EchoService/echo", // rpc
-                null, // endPoint (could be SERVER_IP:SERVER_PORT, but SERVER_IP is may be resolved as 0.0.0.0 or 127.0.0.1)
-                SERVER_IP, // remoteAddress
+                SERVER_ADDRESS.getHostName() + ":" + SERVER_ADDRESS.getPort(), // endPoint
+                SERVER_ADDRESS.getHostName(), // remoteAddress
                 null // destinationId
         );
     }

--- a/agent/src/test/java/com/navercorp/pinpoint/plugin/thrift/common/server/SyncEchoTestServer.java
+++ b/agent/src/test/java/com/navercorp/pinpoint/plugin/thrift/common/server/SyncEchoTestServer.java
@@ -58,8 +58,8 @@ public abstract class SyncEchoTestServer<T extends TServer> extends EchoTestServ
                 "THRIFT_SERVER", // ServiceType,
                 "Thrift Server Invocation", // Method
                 "com/navercorp/pinpoint/plugin/thrift/dto/EchoService/echo", // rpc
-                null, // endPoint (could be SERVER_IP:SERVER_PORT, but SERVER_IP is may be resolved as 0.0.0.0 or 127.0.0.1)
-                SERVER_IP, // remoteAddress
+                SERVER_ADDRESS.getHostName() + ":" + SERVER_ADDRESS.getPort(), // endPoint
+                SERVER_ADDRESS.getHostName(), // remoteAddress
                 null // destinationId
         );
     }


### PR DESCRIPTION
There may yet be a mismatch between hostname resolved by the Thrift plugin and those used to check in integration tests. Trying fix.