### PR TITLE
#329 refactored Thrift trace headers

### DIFF
--- a/plugins/thrift/src/main/java/com/navercorp/pinpoint/plugin/thrift/ThriftClientCallContext.java
+++ b/plugins/thrift/src/main/java/com/navercorp/pinpoint/plugin/thrift/ThriftClientCallContext.java
@@ -16,20 +16,19 @@
 
 package com.navercorp.pinpoint.plugin.thrift;
 
-import com.navercorp.pinpoint.plugin.thrift.ThriftHeader.ThriftHeaderKey;
 
 /**
  * @author HyunGil Jeong
  */
 public class ThriftClientCallContext {
     
-    public static final ThriftHeaderKey NONE = null;
+    public static final ThriftHeader NONE = null;
     
     private final String methodName;
     
-    private ThriftHeaderKey traceHeaderToBeRead;
+    private ThriftHeader traceHeaderToBeRead;
     
-    private ThriftHeader traceHeader;
+    private ThriftRequestProperty traceHeader;
     
     public ThriftClientCallContext(String methodName) {
         this.methodName = methodName;
@@ -39,19 +38,19 @@ public class ThriftClientCallContext {
         return methodName;
     }
     
-    public ThriftHeaderKey getTraceHeaderToBeRead() {
+    public ThriftHeader getTraceHeaderToBeRead() {
         return traceHeaderToBeRead;
     }
 
-    public void setTraceHeaderToBeRead(ThriftHeaderKey traceHeaderToBeRead) {
+    public void setTraceHeaderToBeRead(ThriftHeader traceHeaderToBeRead) {
         this.traceHeaderToBeRead = traceHeaderToBeRead;
     }
 
-    public ThriftHeader getTraceHeader() {
+    public ThriftRequestProperty getTraceHeader() {
         return traceHeader;
     }
 
-    public void setTraceHeader(ThriftHeader traceHeader) {
+    public void setTraceHeader(ThriftRequestProperty traceHeader) {
         this.traceHeader = traceHeader;
     }
 

--- a/plugins/thrift/src/main/java/com/navercorp/pinpoint/plugin/thrift/ThriftHeader.java
+++ b/plugins/thrift/src/main/java/com/navercorp/pinpoint/plugin/thrift/ThriftHeader.java
@@ -1,5 +1,5 @@
 /*
-\ * Copyright 2015 NAVER Corp.
+ * Copyright 2015 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,264 +16,50 @@
 
 package com.navercorp.pinpoint.plugin.thrift;
 
-import java.nio.ByteBuffer;
-import java.nio.CharBuffer;
-import java.nio.charset.Charset;
-import java.util.EnumMap;
-
-import org.apache.thrift.TException;
-import org.apache.thrift.protocol.TField;
-import org.apache.thrift.protocol.TProtocol;
-import org.apache.thrift.protocol.TProtocolException;
 import org.apache.thrift.protocol.TType;
 
-/**
- * @author HyunGil Jeong
- */
-public class ThriftHeader {
+public enum ThriftHeader {
+    THRIFT_TRACE_ID                (TType.STRING,  (short) Short.MIN_VALUE),
+    THRIFT_SPAN_ID                 (TType.I64,     (short)(Short.MIN_VALUE+1)),
+    THRIFT_PARENT_SPAN_ID          (TType.I64,     (short)(Short.MIN_VALUE+2)),
+    THRFIT_SAMPLED                 (TType.BOOL,    (short)(Short.MIN_VALUE+3)),
+    THRIFT_FLAGS                   (TType.I16,     (short)(Short.MIN_VALUE+4)),
+    THRIFT_PARENT_APPLICATION_NAME (TType.STRING,  (short)(Short.MIN_VALUE+5)),
+    THRIFT_PARENT_APPLICATION_TYPE (TType.I16,     (short)(Short.MIN_VALUE+6)),
+    THRIFT_HOST                    (TType.STRING,  (short)(Short.MIN_VALUE+7));
 
-    private EnumMap<ThriftHeaderKey, Object> thriftHeaders = new EnumMap<ThriftHeaderKey, Object>(ThriftHeaderKey.class);
+    private final short id;
     
-    // TRACE_ID
+    private final byte type;
     
-    public String getTraceId() {
-        return this.getTraceId(null);
+    private ThriftHeader(byte type, short id) {
+        this.type = type;
+        this.id = (short)id;
     }
     
-    public String getTraceId(String defaultValue) {
-        if (this.thriftHeaders.containsKey(ThriftHeaderKey.TRACE_ID)) {
-            return (String)this.thriftHeaders.get(ThriftHeaderKey.TRACE_ID);
-        }
-        return defaultValue;
+    public short getId() {
+        return this.id;
     }
     
-    public void setTraceId(String traceId) {
-        this.thriftHeaders.put(ThriftHeaderKey.TRACE_ID, traceId);
+    public byte getType() {
+        return this.type;
     }
     
-    // SPAN_ID
-    
-    public Long getSpanId() {
-        return this.getSpanId(null);
-    }
-    
-    public Long getSpanId(Long defaultValue) {
-        if (this.thriftHeaders.containsKey(ThriftHeaderKey.SPAN_ID)) {
-            return (Long)this.thriftHeaders.get(ThriftHeaderKey.SPAN_ID);
-        }
-        return defaultValue;
-    }
-    
-    public void setSpanId(Long spanId) {
-        this.thriftHeaders.put(ThriftHeaderKey.SPAN_ID, spanId);
-    }
-    
-    // PARENT_SPAN_ID
-    
-    public Long getParentSpanId() {
-        return this.getParentSpanId(null);
-    }
-    
-    public Long getParentSpanId(Long defaultValue) {
-        if (this.thriftHeaders.containsKey(ThriftHeaderKey.PARENT_SPAN_ID)) {
-            return (Long)this.thriftHeaders.get(ThriftHeaderKey.PARENT_SPAN_ID);
-        }
-        return defaultValue;
-    }
-    
-    public void setParentSpanId(Long parentSpanId) {
-        this.thriftHeaders.put(ThriftHeaderKey.PARENT_SPAN_ID, parentSpanId);
-    }
-
-    // SAMPLED
-    
-    public Boolean shouldSample() {
-        return this.shouldSample(null);
-    }
-    
-    public Boolean shouldSample(Boolean defaultValue) {
-        if (this.thriftHeaders.containsKey(ThriftHeaderKey.SAMPLED)) {
-            return (Boolean)this.thriftHeaders.get(ThriftHeaderKey.SAMPLED);
-        }
-        return defaultValue;
-    }
-    
-    public void setShouldSample(Boolean shouldSample) {
-        this.thriftHeaders.put(ThriftHeaderKey.SAMPLED, shouldSample);
-    }
-    
-    // FLAGS
-    
-    public Short getFlags() {
-        return this.getFlags(null);
-    }
-    
-    public Short getFlags(Short defaultValue) {
-        if (this.thriftHeaders.containsKey(ThriftHeaderKey.FLAGS)) {
-            return (Short)this.thriftHeaders.get(ThriftHeaderKey.FLAGS);
-        }
-        return defaultValue;
-    }
-    
-    public void setFlags(Short flags) {
-        this.thriftHeaders.put(ThriftHeaderKey.FLAGS, flags);
-    }
-    
-    // PARENT_APPLICATION_NAME
-    
-    public String getParentApplicationName() {
-        return this.getParentApplicationName(null);
-    }
-    
-    public String getParentApplicationName(String defaultValue) {
-        if (this.thriftHeaders.containsKey(ThriftHeaderKey.PARENT_APPLICATION_NAME)) {
-            return (String)this.thriftHeaders.get(ThriftHeaderKey.PARENT_APPLICATION_NAME);
-        }
-        return defaultValue;
-    }
-    
-    public void setParentApplicationName(String parentApplicationName) {
-        this.thriftHeaders.put(ThriftHeaderKey.PARENT_APPLICATION_NAME, parentApplicationName);
-    }
-    
-    // PARENT_APPLICATION_TYPE
-    
-    public Short getParentApplicationType() {
-        return this.getParentApplicationType(null);
-    }
-    
-    public Short getParentApplicationType(Short defaultValue) {
-        if (this.thriftHeaders.containsKey(ThriftHeaderKey.PARENT_APPLICATION_TYPE)) {
-            return (Short)this.thriftHeaders.get(ThriftHeaderKey.PARENT_APPLICATION_TYPE);
-        }
-        return defaultValue;
-    }
-    
-    public void setParentApplicationType(Short parentApplicationType) {
-        this.thriftHeaders.put(ThriftHeaderKey.PARENT_APPLICATION_TYPE, parentApplicationType);
-    }
-    
-    // ACCEPTOR_HOST
-    
-    public String getAcceptorHost() {
-        return getAcceptorHost(ThriftConstants.UNKNOWN_ADDRESS);
-    }
-    
-    public String getAcceptorHost(String acceptorHost) {
-        if (this.thriftHeaders.containsKey(ThriftHeaderKey.ACCEPTOR_HOST)) {
-            return (String)this.thriftHeaders.get(ThriftHeaderKey.ACCEPTOR_HOST);
-        }
-        return acceptorHost;
-    }
-    
-    public void setAcceptorHost(String acceptorHost) {
-        this.thriftHeaders.put(ThriftHeaderKey.ACCEPTOR_HOST, acceptorHost);
-    }
-    
-    public void setTraceHeader(ThriftHeaderKey headerKey, Object value) throws TException {
-        byte headerType = headerKey.getType();
-        if (headerType == TType.STRING) {
-            // skipped Strings are read as byte buffer.
-            // see org.apache.thrift.protocol.TProtocolUtil.skip(TProtocol, byte, int)
-            this.thriftHeaders.put(headerKey, byteBufferToString((ByteBuffer)value));
-        } else if (headerType == TType.I64) {
-            this.thriftHeaders.put(headerKey, (Long)value);
-        } else if (headerType == TType.I16) {
-            this.thriftHeaders.put(headerKey, (Short)value);
-        } else if (headerType == TType.BOOL) {
-            this.thriftHeaders.put(headerKey, (Boolean)value);
-        } else {
-            throw new TProtocolException("Invalid pinpoint header type - " + headerType);
-        }
-    }
-    
-    public void writeTraceHeader(ThriftHeaderKey headerKey, TProtocol oprot) throws TException {
-        Object headerValue = this.thriftHeaders.get(headerKey);
-        if (headerValue == null) {
-            return;
-        }
-        byte headerType = headerKey.getType();
-        TField traceField = new TField(headerKey.name(), headerKey.getType(), headerKey.getId());
-        oprot.writeFieldBegin(traceField);
-        try {
-            if (headerType == TType.STRING) {
-                // these will be read as byte buffer although it's probably safe to just use writeString here.
-                // see org.apache.thrift.protocol.TProtocolUtil.skip(TProtocol, byte, int)
-                oprot.writeBinary(stringToByteBuffer((String)headerValue));
-            } else if (headerType == TType.I64) {
-                oprot.writeI64((Long)headerValue);
-            } else if (headerType == TType.I16) {
-                oprot.writeI16((Short)headerValue);
-            } else if (headerType == TType.BOOL) {
-                oprot.writeBool((Boolean)headerValue);
-            } else {
-                throw new TProtocolException("Invalid pinpoint header type - " + headerType);
+    /**
+     * Returns the {@link ThriftRequestProperty} with the specified id,
+     * or {@code null} if there is none.
+     *
+     * @param id the id of the associated <tt>ThriftHeaderKey</tt>
+     * @return the <tt>ThriftHeaderKey</tt> associated with the specified id, or
+     *     <tt>null</tt> if there is none
+     */
+    public static ThriftHeader findThriftHeaderKeyById(short id) {
+        for (ThriftHeader headerKey : ThriftHeader.values()) {
+            if (headerKey.id == id) {
+                return headerKey;
             }
-        } finally {
-            oprot.writeFieldEnd();
         }
-    }
-    
-    private static final Charset HEADER_CHARSET_ENCODING = Charset.forName("UTF-8");
-    
-    private static ByteBuffer stringToByteBuffer(String s) {
-        return ByteBuffer.wrap(s.getBytes(HEADER_CHARSET_ENCODING));
-    }
-    
-    private static String byteBufferToString(ByteBuffer buf) {
-        CharBuffer charBuffer = HEADER_CHARSET_ENCODING.decode(buf);
-        return charBuffer.toString();
-    }
-    
-    @Override
-    public String toString() {
-        return this.thriftHeaders.toString();
-    }
-    
-    public static enum ThriftHeaderKey {
-        TRACE_ID                (TType.STRING,  (short) Short.MIN_VALUE),
-        SPAN_ID                 (TType.I64,     (short)(Short.MIN_VALUE+1)),
-        PARENT_SPAN_ID          (TType.I64,     (short)(Short.MIN_VALUE+2)),
-        SAMPLED                 (TType.BOOL,    (short)(Short.MIN_VALUE+3)),
-        FLAGS                   (TType.I16,     (short)(Short.MIN_VALUE+4)),
-        PARENT_APPLICATION_NAME (TType.STRING,  (short)(Short.MIN_VALUE+5)),
-        PARENT_APPLICATION_TYPE (TType.I16,     (short)(Short.MIN_VALUE+6)),
-        ACCEPTOR_HOST           (TType.STRING,  (short)(Short.MIN_VALUE+7));
-    
-        private final short id;
-        
-        private final byte type;
-        
-        private ThriftHeaderKey(byte type, short id) {
-            this.type = type;
-            this.id = (short)id;
-        }
-        
-        public short getId() {
-            return this.id;
-        }
-        
-        public byte getType() {
-            return this.type;
-        }
-        
-        /**
-         * Returns the {@link ThriftHeader} with the specified id,
-         * or {@code null} if there is none.
-         *
-         * @param id the id of the associated <tt>ThriftHeaderKey</tt>
-         * @return the <tt>ThriftHeaderKey</tt> associated with the specified id, or
-         *     <tt>null</tt> if there is none
-         */
-        public static ThriftHeaderKey findThriftHeaderKeyById(short id) {
-            for (ThriftHeaderKey headerKey : ThriftHeaderKey.values()) {
-                if (headerKey.id == id) {
-                    return headerKey;
-                }
-            }
-            return null;
-        }
-        
+        return null;
     }
     
 }

--- a/plugins/thrift/src/main/java/com/navercorp/pinpoint/plugin/thrift/ThriftRequestProperty.java
+++ b/plugins/thrift/src/main/java/com/navercorp/pinpoint/plugin/thrift/ThriftRequestProperty.java
@@ -1,0 +1,233 @@
+/*
+\ * Copyright 2015 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.plugin.thrift;
+
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.Charset;
+import java.util.EnumMap;
+
+import org.apache.thrift.TException;
+import org.apache.thrift.protocol.TField;
+import org.apache.thrift.protocol.TProtocol;
+import org.apache.thrift.protocol.TProtocolException;
+import org.apache.thrift.protocol.TType;
+
+/**
+ * @author HyunGil Jeong
+ */
+public class ThriftRequestProperty {
+
+    private EnumMap<ThriftHeader, Object> thriftHeaders = new EnumMap<ThriftHeader, Object>(ThriftHeader.class);
+    
+    // TRACE_ID
+    
+    public String getTraceId() {
+        return this.getTraceId(null);
+    }
+    
+    public String getTraceId(String defaultValue) {
+        if (this.thriftHeaders.containsKey(ThriftHeader.THRIFT_TRACE_ID)) {
+            return (String)this.thriftHeaders.get(ThriftHeader.THRIFT_TRACE_ID);
+        }
+        return defaultValue;
+    }
+    
+    public void setTraceId(String traceId) {
+        this.thriftHeaders.put(ThriftHeader.THRIFT_TRACE_ID, traceId);
+    }
+    
+    // SPAN_ID
+    
+    public Long getSpanId() {
+        return this.getSpanId(null);
+    }
+    
+    public Long getSpanId(Long defaultValue) {
+        if (this.thriftHeaders.containsKey(ThriftHeader.THRIFT_SPAN_ID)) {
+            return (Long)this.thriftHeaders.get(ThriftHeader.THRIFT_SPAN_ID);
+        }
+        return defaultValue;
+    }
+    
+    public void setSpanId(Long spanId) {
+        this.thriftHeaders.put(ThriftHeader.THRIFT_SPAN_ID, spanId);
+    }
+    
+    // PARENT_SPAN_ID
+    
+    public Long getParentSpanId() {
+        return this.getParentSpanId(null);
+    }
+    
+    public Long getParentSpanId(Long defaultValue) {
+        if (this.thriftHeaders.containsKey(ThriftHeader.THRIFT_PARENT_SPAN_ID)) {
+            return (Long)this.thriftHeaders.get(ThriftHeader.THRIFT_PARENT_SPAN_ID);
+        }
+        return defaultValue;
+    }
+    
+    public void setParentSpanId(Long parentSpanId) {
+        this.thriftHeaders.put(ThriftHeader.THRIFT_PARENT_SPAN_ID, parentSpanId);
+    }
+
+    // SAMPLED
+    
+    public Boolean shouldSample() {
+        return this.shouldSample(null);
+    }
+    
+    public Boolean shouldSample(Boolean defaultValue) {
+        if (this.thriftHeaders.containsKey(ThriftHeader.THRFIT_SAMPLED)) {
+            return (Boolean)this.thriftHeaders.get(ThriftHeader.THRFIT_SAMPLED);
+        }
+        return defaultValue;
+    }
+    
+    public void setShouldSample(Boolean shouldSample) {
+        this.thriftHeaders.put(ThriftHeader.THRFIT_SAMPLED, shouldSample);
+    }
+    
+    // FLAGS
+    
+    public Short getFlags() {
+        return this.getFlags(null);
+    }
+    
+    public Short getFlags(Short defaultValue) {
+        if (this.thriftHeaders.containsKey(ThriftHeader.THRIFT_FLAGS)) {
+            return (Short)this.thriftHeaders.get(ThriftHeader.THRIFT_FLAGS);
+        }
+        return defaultValue;
+    }
+    
+    public void setFlags(Short flags) {
+        this.thriftHeaders.put(ThriftHeader.THRIFT_FLAGS, flags);
+    }
+    
+    // PARENT_APPLICATION_NAME
+    
+    public String getParentApplicationName() {
+        return this.getParentApplicationName(null);
+    }
+    
+    public String getParentApplicationName(String defaultValue) {
+        if (this.thriftHeaders.containsKey(ThriftHeader.THRIFT_PARENT_APPLICATION_NAME)) {
+            return (String)this.thriftHeaders.get(ThriftHeader.THRIFT_PARENT_APPLICATION_NAME);
+        }
+        return defaultValue;
+    }
+    
+    public void setParentApplicationName(String parentApplicationName) {
+        this.thriftHeaders.put(ThriftHeader.THRIFT_PARENT_APPLICATION_NAME, parentApplicationName);
+    }
+    
+    // PARENT_APPLICATION_TYPE
+    
+    public Short getParentApplicationType() {
+        return this.getParentApplicationType(null);
+    }
+    
+    public Short getParentApplicationType(Short defaultValue) {
+        if (this.thriftHeaders.containsKey(ThriftHeader.THRIFT_PARENT_APPLICATION_TYPE)) {
+            return (Short)this.thriftHeaders.get(ThriftHeader.THRIFT_PARENT_APPLICATION_TYPE);
+        }
+        return defaultValue;
+    }
+    
+    public void setParentApplicationType(Short parentApplicationType) {
+        this.thriftHeaders.put(ThriftHeader.THRIFT_PARENT_APPLICATION_TYPE, parentApplicationType);
+    }
+    
+    // ACCEPTOR_HOST
+    
+    public String getAcceptorHost() {
+        return getAcceptorHost(ThriftConstants.UNKNOWN_ADDRESS);
+    }
+    
+    public String getAcceptorHost(String acceptorHost) {
+        if (this.thriftHeaders.containsKey(ThriftHeader.THRIFT_HOST)) {
+            return (String)this.thriftHeaders.get(ThriftHeader.THRIFT_HOST);
+        }
+        return acceptorHost;
+    }
+    
+    public void setAcceptorHost(String acceptorHost) {
+        this.thriftHeaders.put(ThriftHeader.THRIFT_HOST, acceptorHost);
+    }
+    
+    public void setTraceHeader(ThriftHeader headerKey, Object value) throws TException {
+        byte headerType = headerKey.getType();
+        if (headerType == TType.STRING) {
+            // skipped Strings are read as byte buffer.
+            // see org.apache.thrift.protocol.TProtocolUtil.skip(TProtocol, byte, int)
+            this.thriftHeaders.put(headerKey, byteBufferToString((ByteBuffer)value));
+        } else if (headerType == TType.I64) {
+            this.thriftHeaders.put(headerKey, (Long)value);
+        } else if (headerType == TType.I16) {
+            this.thriftHeaders.put(headerKey, (Short)value);
+        } else if (headerType == TType.BOOL) {
+            this.thriftHeaders.put(headerKey, (Boolean)value);
+        } else {
+            throw new TProtocolException("Invalid pinpoint header type - " + headerType);
+        }
+    }
+    
+    public void writeTraceHeader(ThriftHeader headerKey, TProtocol oprot) throws TException {
+        Object headerValue = this.thriftHeaders.get(headerKey);
+        if (headerValue == null) {
+            return;
+        }
+        byte headerType = headerKey.getType();
+        TField traceField = new TField(headerKey.name(), headerKey.getType(), headerKey.getId());
+        oprot.writeFieldBegin(traceField);
+        try {
+            if (headerType == TType.STRING) {
+                // these will be read as byte buffer although it's probably safe to just use writeString here.
+                // see org.apache.thrift.protocol.TProtocolUtil.skip(TProtocol, byte, int)
+                oprot.writeBinary(stringToByteBuffer((String)headerValue));
+            } else if (headerType == TType.I64) {
+                oprot.writeI64((Long)headerValue);
+            } else if (headerType == TType.I16) {
+                oprot.writeI16((Short)headerValue);
+            } else if (headerType == TType.BOOL) {
+                oprot.writeBool((Boolean)headerValue);
+            } else {
+                throw new TProtocolException("Invalid pinpoint header type - " + headerType);
+            }
+        } finally {
+            oprot.writeFieldEnd();
+        }
+    }
+    
+    private static final Charset HEADER_CHARSET_ENCODING = Charset.forName("UTF-8");
+    
+    private static ByteBuffer stringToByteBuffer(String s) {
+        return ByteBuffer.wrap(s.getBytes(HEADER_CHARSET_ENCODING));
+    }
+    
+    private static String byteBufferToString(ByteBuffer buf) {
+        CharBuffer charBuffer = HEADER_CHARSET_ENCODING.decode(buf);
+        return charBuffer.toString();
+    }
+    
+    @Override
+    public String toString() {
+        return this.thriftHeaders.toString();
+    }
+    
+}

--- a/plugins/thrift/src/main/java/com/navercorp/pinpoint/plugin/thrift/interceptor/client/TServiceClientSendBaseInterceptor.java
+++ b/plugins/thrift/src/main/java/com/navercorp/pinpoint/plugin/thrift/interceptor/client/TServiceClientSendBaseInterceptor.java
@@ -39,7 +39,7 @@ import com.navercorp.pinpoint.bootstrap.plugin.annotation.Group;
 import com.navercorp.pinpoint.bootstrap.plugin.annotation.Name;
 import com.navercorp.pinpoint.bootstrap.util.StringUtils;
 import com.navercorp.pinpoint.plugin.thrift.ThriftConstants;
-import com.navercorp.pinpoint.plugin.thrift.ThriftHeader;
+import com.navercorp.pinpoint.plugin.thrift.ThriftRequestProperty;
 import com.navercorp.pinpoint.plugin.thrift.ThriftUtils;
 
 /**
@@ -94,7 +94,7 @@ public class TServiceClientSendBaseInterceptor implements SimpleAroundIntercepto
             if (trace == null) {
                 return;
             }
-            ThriftHeader parentTraceInfo = new ThriftHeader();
+            ThriftRequestProperty parentTraceInfo = new ThriftRequestProperty();
             final boolean shouldSample = trace.canSampled();
             if (!shouldSample) {
                 if (isDebug) {

--- a/plugins/thrift/src/main/java/com/navercorp/pinpoint/plugin/thrift/interceptor/client/async/TAsyncClientManagerCallInterceptor.java
+++ b/plugins/thrift/src/main/java/com/navercorp/pinpoint/plugin/thrift/interceptor/client/async/TAsyncClientManagerCallInterceptor.java
@@ -35,7 +35,7 @@ import com.navercorp.pinpoint.bootstrap.logging.PLoggerFactory;
 import com.navercorp.pinpoint.bootstrap.plugin.annotation.Group;
 import com.navercorp.pinpoint.bootstrap.plugin.annotation.Name;
 import com.navercorp.pinpoint.plugin.thrift.ThriftConstants;
-import com.navercorp.pinpoint.plugin.thrift.ThriftHeader;
+import com.navercorp.pinpoint.plugin.thrift.ThriftRequestProperty;
 import com.navercorp.pinpoint.plugin.thrift.ThriftUtils;
 
 /**
@@ -88,7 +88,7 @@ public class TAsyncClientManagerCallInterceptor implements SimpleAroundIntercept
         }
 
         try {
-            ThriftHeader parentTraceInfo = new ThriftHeader();
+            ThriftRequestProperty parentTraceInfo = new ThriftRequestProperty();
             final boolean shouldSample = trace.canSampled();
             if (!shouldSample) {
                 if (isDebug) {

--- a/plugins/thrift/src/main/java/com/navercorp/pinpoint/plugin/thrift/interceptor/tprotocol/client/TProtocolWriteFieldStopInterceptor.java
+++ b/plugins/thrift/src/main/java/com/navercorp/pinpoint/plugin/thrift/interceptor/tprotocol/client/TProtocolWriteFieldStopInterceptor.java
@@ -30,8 +30,8 @@ import com.navercorp.pinpoint.bootstrap.logging.PLoggerFactory;
 import com.navercorp.pinpoint.bootstrap.plugin.annotation.Group;
 import com.navercorp.pinpoint.bootstrap.plugin.annotation.Name;
 import com.navercorp.pinpoint.plugin.thrift.ThriftConstants;
+import com.navercorp.pinpoint.plugin.thrift.ThriftRequestProperty;
 import com.navercorp.pinpoint.plugin.thrift.ThriftHeader;
-import com.navercorp.pinpoint.plugin.thrift.ThriftHeader.ThriftHeaderKey;
 
 /**
  * This interceptor writes the trace data directly on the wire to allow remote tracing.
@@ -80,22 +80,22 @@ public class TProtocolWriteFieldStopInterceptor implements SimpleAroundIntercept
     
     private void appendParentTraceInfo(TProtocol oprot) throws TException {
         InterceptorGroupInvocation currentTransaction = this.group.getCurrentInvocation();
-        ThriftHeader parentTraceInfo = (ThriftHeader)currentTransaction.getAttachment();
+        ThriftRequestProperty parentTraceInfo = (ThriftRequestProperty)currentTransaction.getAttachment();
         if (parentTraceInfo == null) {
             return;
         }
         boolean shouldSample = parentTraceInfo.shouldSample(true);
         if (!shouldSample) {
-            parentTraceInfo.writeTraceHeader(ThriftHeaderKey.SAMPLED, oprot);
+            parentTraceInfo.writeTraceHeader(ThriftHeader.THRFIT_SAMPLED, oprot);
             return;
         }
-        parentTraceInfo.writeTraceHeader(ThriftHeaderKey.TRACE_ID, oprot);
-        parentTraceInfo.writeTraceHeader(ThriftHeaderKey.SPAN_ID, oprot);
-        parentTraceInfo.writeTraceHeader(ThriftHeaderKey.PARENT_SPAN_ID, oprot);
-        parentTraceInfo.writeTraceHeader(ThriftHeaderKey.FLAGS, oprot);
-        parentTraceInfo.writeTraceHeader(ThriftHeaderKey.PARENT_APPLICATION_NAME, oprot);
-        parentTraceInfo.writeTraceHeader(ThriftHeaderKey.PARENT_APPLICATION_TYPE, oprot);
-        parentTraceInfo.writeTraceHeader(ThriftHeaderKey.ACCEPTOR_HOST, oprot);
+        parentTraceInfo.writeTraceHeader(ThriftHeader.THRIFT_TRACE_ID, oprot);
+        parentTraceInfo.writeTraceHeader(ThriftHeader.THRIFT_SPAN_ID, oprot);
+        parentTraceInfo.writeTraceHeader(ThriftHeader.THRIFT_PARENT_SPAN_ID, oprot);
+        parentTraceInfo.writeTraceHeader(ThriftHeader.THRIFT_FLAGS, oprot);
+        parentTraceInfo.writeTraceHeader(ThriftHeader.THRIFT_PARENT_APPLICATION_NAME, oprot);
+        parentTraceInfo.writeTraceHeader(ThriftHeader.THRIFT_PARENT_APPLICATION_TYPE, oprot);
+        parentTraceInfo.writeTraceHeader(ThriftHeader.THRIFT_HOST, oprot);
     }
 
 }

--- a/plugins/thrift/src/main/java/com/navercorp/pinpoint/plugin/thrift/interceptor/tprotocol/server/TProtocolReadFieldBeginInterceptor.java
+++ b/plugins/thrift/src/main/java/com/navercorp/pinpoint/plugin/thrift/interceptor/tprotocol/server/TProtocolReadFieldBeginInterceptor.java
@@ -33,7 +33,7 @@ import com.navercorp.pinpoint.bootstrap.plugin.annotation.Group;
 import com.navercorp.pinpoint.bootstrap.plugin.annotation.Name;
 import com.navercorp.pinpoint.plugin.thrift.ThriftClientCallContext;
 import com.navercorp.pinpoint.plugin.thrift.ThriftConstants;
-import com.navercorp.pinpoint.plugin.thrift.ThriftHeader.ThriftHeaderKey;
+import com.navercorp.pinpoint.plugin.thrift.ThriftHeader;
 
 /**
  * This interceptor checks each {@link org.apache.thrift.protocol.TField TField} received if it is a Pinpoint trace data.
@@ -111,7 +111,7 @@ public class TProtocolReadFieldBeginInterceptor implements SimpleAroundIntercept
     }
 
     private void handleClientRequest(TField field, ThriftClientCallContext clientCallContext) {
-        ThriftHeaderKey traceHeaderKey = ThriftHeaderKey.findThriftHeaderKeyById(field.id);
+        ThriftHeader traceHeaderKey = ThriftHeader.findThriftHeaderKeyById(field.id);
         // check if field is pinpoint header field
         if (traceHeaderKey == null || field.type != traceHeaderKey.getType()) {
             clientCallContext.setTraceHeaderToBeRead(NONE);

--- a/plugins/thrift/src/main/java/com/navercorp/pinpoint/plugin/thrift/interceptor/tprotocol/server/TProtocolReadMessageEndInterceptor.java
+++ b/plugins/thrift/src/main/java/com/navercorp/pinpoint/plugin/thrift/interceptor/tprotocol/server/TProtocolReadMessageEndInterceptor.java
@@ -37,7 +37,7 @@ import com.navercorp.pinpoint.bootstrap.plugin.annotation.Name;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.plugin.thrift.ThriftClientCallContext;
 import com.navercorp.pinpoint.plugin.thrift.ThriftConstants;
-import com.navercorp.pinpoint.plugin.thrift.ThriftHeader;
+import com.navercorp.pinpoint.plugin.thrift.ThriftRequestProperty;
 import com.navercorp.pinpoint.plugin.thrift.descriptor.ThriftServerEntryMethodDescriptor;
 
 /**
@@ -105,7 +105,7 @@ public class TProtocolReadMessageEndInterceptor implements SimpleAroundIntercept
         if (attachment instanceof ThriftClientCallContext) {
             ThriftClientCallContext clientCallContext = (ThriftClientCallContext)attachment;
             String methodName = clientCallContext.getMethodName();
-            ThriftHeader parentTraceInfo = clientCallContext.getTraceHeader();
+            ThriftRequestProperty parentTraceInfo = clientCallContext.getTraceHeader();
             try {
                 this.logger.debug("parentTraceInfo : {}", parentTraceInfo);
                 recordTrace(parentTraceInfo, methodName);
@@ -126,7 +126,7 @@ public class TProtocolReadMessageEndInterceptor implements SimpleAroundIntercept
         return false;
     }
 
-    private void recordTrace(ThriftHeader parentTraceInfo, String methodName) {
+    private void recordTrace(ThriftRequestProperty parentTraceInfo, String methodName) {
         final Trace trace = createTrace(parentTraceInfo, methodName);
         if (trace == null) {
             return;
@@ -138,7 +138,7 @@ public class TProtocolReadMessageEndInterceptor implements SimpleAroundIntercept
         trace.recordServiceType(THRIFT_SERVER_INTERNAL);
     }
 
-    private Trace createTrace(ThriftHeader parentTraceInfo, String methodName) {
+    private Trace createTrace(ThriftRequestProperty parentTraceInfo, String methodName) {
         // Check if parent trace info is set.
         // If it is, then make a continued trace object (from parent application)
         // If not, make a new trace object (from user cloud)
@@ -187,7 +187,7 @@ public class TProtocolReadMessageEndInterceptor implements SimpleAroundIntercept
         }
     }
     
-    private void recordRootSpan(final Trace trace, final ThriftHeader parentTraceInfo) {
+    private void recordRootSpan(final Trace trace, final ThriftRequestProperty parentTraceInfo) {
         // begin root span
         trace.markBeforeTime();
         trace.recordServiceType(THRIFT_SERVER);
@@ -199,7 +199,7 @@ public class TProtocolReadMessageEndInterceptor implements SimpleAroundIntercept
         trace.traceBlockBegin();
     }
 
-    private boolean checkSamplingFlag(ThriftHeader parentTraceInfo) {
+    private boolean checkSamplingFlag(ThriftRequestProperty parentTraceInfo) {
         // parent trace info not given, should start a new trace and thus be sampled
         if (parentTraceInfo == null) {
             return true;
@@ -215,7 +215,7 @@ public class TProtocolReadMessageEndInterceptor implements SimpleAroundIntercept
         return samplingFlag;
     }
 
-    private TraceId populateTraceIdThriftHeader(ThriftHeader parentTraceInfo) {
+    private TraceId populateTraceIdThriftHeader(ThriftRequestProperty parentTraceInfo) {
         if (parentTraceInfo == null) {
             return null;
         }
@@ -227,7 +227,7 @@ public class TProtocolReadMessageEndInterceptor implements SimpleAroundIntercept
         return this.traceContext.createTraceId(transactionId, parentSpanId, spanId, flags);
     }
     
-    private void recordParentInfo(RecordableTrace trace, ThriftHeader parentTraceInfo) {
+    private void recordParentInfo(RecordableTrace trace, ThriftRequestProperty parentTraceInfo) {
         if (parentTraceInfo == null) {
             return;
         }

--- a/plugins/thrift/src/main/java/com/navercorp/pinpoint/plugin/thrift/interceptor/tprotocol/server/TProtocolReadTTypeInterceptor.java
+++ b/plugins/thrift/src/main/java/com/navercorp/pinpoint/plugin/thrift/interceptor/tprotocol/server/TProtocolReadTTypeInterceptor.java
@@ -32,8 +32,8 @@ import com.navercorp.pinpoint.bootstrap.plugin.annotation.Group;
 import com.navercorp.pinpoint.bootstrap.plugin.annotation.Name;
 import com.navercorp.pinpoint.plugin.thrift.ThriftClientCallContext;
 import com.navercorp.pinpoint.plugin.thrift.ThriftConstants;
+import com.navercorp.pinpoint.plugin.thrift.ThriftRequestProperty;
 import com.navercorp.pinpoint.plugin.thrift.ThriftHeader;
-import com.navercorp.pinpoint.plugin.thrift.ThriftHeader.ThriftHeaderKey;
 
 /**
  * This interceptor reads a data field and if applicable, populates the corresponding parent trace data as marked by the previous interceptor.
@@ -92,13 +92,13 @@ public class TProtocolReadTTypeInterceptor implements SimpleAroundInterceptor, T
         Object attachment = currentTransaction.getAttachment();
         if (attachment instanceof ThriftClientCallContext) {
             ThriftClientCallContext clientCallContext = (ThriftClientCallContext)attachment;
-            ThriftHeaderKey headerKeyToBeRead = clientCallContext.getTraceHeaderToBeRead();
+            ThriftHeader headerKeyToBeRead = clientCallContext.getTraceHeaderToBeRead();
             if (headerKeyToBeRead == NONE) {
                 return;
             }
-            ThriftHeader parentTraceInfo = clientCallContext.getTraceHeader();
+            ThriftRequestProperty parentTraceInfo = clientCallContext.getTraceHeader();
             if (parentTraceInfo == null) {
-                parentTraceInfo = new ThriftHeader();
+                parentTraceInfo = new ThriftRequestProperty();
                 clientCallContext.setTraceHeader(parentTraceInfo);
             }
             try {


### PR DESCRIPTION
This was done to ease up future refactoring that would pull up trace
headers used for tracing various RPC calls into a single common class.