### PR TITLE
fix PinpointJUnit4ClassRunner to work with the updated junit

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -563,7 +563,7 @@
             <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
-                <version>4.8</version>
+                <version>4.12</version>
             </dependency>
             <dependency>
                 <groupId>org.hamcrest</groupId>

--- a/profiler/src/main/java/com/navercorp/pinpoint/test/junit4/PinpointJUnit4ClassRunner.java
+++ b/profiler/src/main/java/com/navercorp/pinpoint/test/junit4/PinpointJUnit4ClassRunner.java
@@ -74,8 +74,8 @@ public final class PinpointJUnit4ClassRunner extends BlockJUnit4ClassRunner {
         // Replace test target with a class loaded by TestClassLoader
         // Cannot override getTestClass() which is used to get test class by JUnit because it's final.
         try {
-            // PinpointJunit4ClassRunner -> BlockJUnit4ClassRunner -> ParentRunner.fTestClass
-            Field testClassField = this.getClass().getSuperclass().getSuperclass().getDeclaredField("fTestClass");
+            // PinpointJunit4ClassRunner -> BlockJUnit4ClassRunner -> ParentRunner.testClass
+            Field testClassField = this.getClass().getSuperclass().getSuperclass().getDeclaredField("testClass");
             testClassField.setAccessible(true);
             testClassField.set(this, this.testContext.getTestClass());
         } catch (Exception e) {


### PR DESCRIPTION
fix PinpointJUnit4ClassRunner to work with junit-4.12 required by Spring 4 mentioned in #765 .