### PR TITLE
Adding comments to configs.

### DIFF
--- a/agent/src/main/resources/pinpoint-real-env-lowoverhead-sample.config
+++ b/agent/src/main/resources/pinpoint-real-env-lowoverhead-sample.config
@@ -74,11 +74,15 @@ profiler.type.detect.order=
 ###########################################################
 # user defined classes                                    # 
 ###########################################################
-# Specify classes you want to profile here.
-#profiler.include=
+# Specify classes and methods you want to profile here.
 
-# Example: potential jetty entry points.
-#profiler.user.include=org.eclipse.jetty.servlet.ServletHandler.doHandle, org.eclipse.jetty.server.Server.handle
+# Needs to be a comma separated list of fully qualified class names, or fully qualified package names with wild card class.
+profiler.include=
+# Ex: foo.bar.MyClass, foo.baz.*
+
+# Needs to be a comma separated list of fully qualified method names. Wild card not supported.
+profiler.user.include=
+# Ex: foo.bar.MyClass.myMethod, foo.bar.MyClass.anotherMethod
 
 ###########################################################
 # TOMCAT                                                  #

--- a/agent/src/main/resources/pinpoint-real-env-lowoverhead-sample.config
+++ b/agent/src/main/resources/pinpoint-real-env-lowoverhead-sample.config
@@ -26,6 +26,7 @@ profiler.enable=true
 
 profiler.jvm.collect.interval=1000
 
+# Allow sampling.
 profiler.sampling.enable=true
 
 # 1 out of n transactions will be sampled where n is the rate. (20: 5%)
@@ -37,16 +38,19 @@ profiler.io.buffering.enable=true
 # How many spans to store if buffering enabled.
 profiler.io.buffering.buffersize=20
 
+# Capacity of the SpanDataSender write queue.
 profiler.spandatasender.write.queue.size=5120
 #profiler.spandatasender.socket.sendbuffersize=1048576
 #profiler.spandatasender.socket.timeout=3000
 profiler.spandatasender.chunk.size=16384
 
+# Capacity of the StatDataSender write queue.
 profiler.statdatasender.write.queue.size=5120
 #profiler.statdatasender.socket.sendbuffersize=1048576
 #profiler.statdatasender.socket.timeout=3000
 profiler.statdatasender.chunk.size=16384
 
+# Interval to retry sending agent info. Unit is milliseconds.
 profiler.agentInfo.send.retry.interval=300000
 
 #  Allow TCP data command
@@ -79,58 +83,81 @@ profiler.type.detect.order=
 ###########################################################
 # TOMCAT                                                  #
 ###########################################################
+# Hide pinpoint headers.
 profiler.tomcat.hidepinpointheader=true
 profiler.tomcat.excludeurl=/aa/test.html, /bb/exclude.html
 
 ###########################################################
 # JDBC                                                    # 
 ###########################################################
+# Profile JDBC drivers.
 profiler.jdbc=true
+# Size of cache. Fixed maximum.
 profiler.jdbc.sqlcachesize=1024
+# Maximum bindvalue size.
 profiler.jdbc.maxsqlbindvaluesize=1024
 
 #
 # MYSQL
 #
+# Profile MySQL.
 profiler.jdbc.mysql=true
+# Allow profiling of setautocommit.
 profiler.jdbc.mysql.setautocommit=false
+# Allow profiling of commit.
 profiler.jdbc.mysql.commit=false
+# Allow profiling of rollback.
 profiler.jdbc.mysql.rollback=false
 
 #
 # MSSQL Jtds
 #
+# Profile jTDS.
 profiler.jdbc.jtds=true
+# Allow profiling of setautocommit.
 profiler.jdbc.jtds.setautocommit=false
+# Allow profiling of commit.
 profiler.jdbc.jtds.commit=false
+# Allow profiling of rollback.
 profiler.jdbc.jtds.rollback=false
 
 #
 # Oracle
 #
+# Profile Oracle DB.
 profiler.jdbc.oracle=true
+# Allow profiling of setautocommit.
 profiler.jdbc.oracle.setautocommit=false
+# Allow profiling of commit.
 profiler.jdbc.oracle.commit=false
+# Allow profiling of rollback.
 profiler.jdbc.oracle.rollback=false
 
 #
 # CUBRID
 #
+# Profile CUBRID.
 profiler.jdbc.cubrid=true
+# Allow profiling of setautocommit.
 profiler.jdbc.cubrid.setautocommit=false
+# Allow profiling of commit.
 profiler.jdbc.cubrid.commit=false
+# Allow profiling of rollback.
 profiler.jdbc.cubrid.rollback=false
 
 #
 # DBCP
 #
+# Profile DBCP.
 profiler.jdbc.dbcp=true
 profiler.jdbc.dbcp.connectionclose=false
 
 ###########################################################
 # Apache HTTP Client  3.x                                 #
 ###########################################################
+# Profile HTTP Client 3.x
 profiler.apache.httpclient3=true
+# Record Cookies.
 profiler.apache.httpclient3.cookie=true
 
 # When to dump cookies. Either ALWAYS or EXCEPTION.
@@ -142,13 +169,17 @@ profiler.apache.httpclient3.cookie.sampling.rate=10
 # Dump entities of POST or PUT requests. Limited to entities where HttpEtity.isRepeatable() == true.
 profiler.apache.httpclient3.entity=true
 
+# When to dump entities. Either ALWAYS or EXCEPTION.
 profiler.apache.httpclient3.entity.dumptype=EXCEPTION
+# 1 out of n entities will be sampled where n is the rate. (10: 10%)
 profiler.apache.httpclient3.entity.sampling.rate=10
 
 ###########################################################
 # Apache HTTP Client  4.x                                 #
 ###########################################################
+# Profile HTTP Client 4.x
 profiler.apache.httpclient4=true
+# Record cookies.
 profiler.apache.httpclient4.cookie=true
 
 # When to dump cookies. Either ALWAYS or EXCEPTION.
@@ -160,7 +191,10 @@ profiler.apache.httpclient4.cookie.sampling.rate=10
 # Dump entities of POST or PUT requests. Limited to entities where HttpEtity.isRepeatable() == true.
 profiler.apache.httpclient4.entity=false
 
+# When to dump entities. Either ALWAYS or EXCEPTION.
 profiler.apache.httpclient4.entity.dumptype=EXCEPTION
+
+# 1 out of n entities will be sampled where n is the rate. (10: 10%)
 profiler.apache.httpclient4.entity.sampling.rate=10
 
 # Not supported yet
@@ -169,38 +203,55 @@ profiler.apache.httpclient4.entity.sampling.rate=10
 ###########################################################
 # Ning Async HTTP Client                                  # 
 ###########################################################
+# Profile Ning Async HTTP Client.
 profiler.ning.asynchttpclient=true
+# Record cookies.
 profiler.ning.asynchttpclient.cookie=true
 # When to dump cookies. Either ALWAYS or EXCEPTION.
 profiler.ning.asynchttpclient.cookie.dumptype=EXCEPTION
+# Cookie dump size.
 profiler.ning.asynchttpclient.cookie.dumpsize=1024
 # 1 out of n cookies will be sampled where n is the rate. (10: 10%)
 profiler.ning.asynchttpclient.cookie.sampling.rate=10
+# Record Entities.
 profiler.ning.asynchttpclient.entity=false
+# When to dump entities. Either ALWAYS or EXCEPTION.
 profiler.ning.asynchttpclient.entity.dumptype=EXCEPTION
+# Entity dump size.
 profiler.ning.asynchttpclient.entity.dumpsize=1024
+# 1 out of n cookies will be sampled where n is the rate. (10: 10%)
 profiler.ning.asynchttpclient.entity.sampling.rate=10
+# Record parameters.
 profiler.ning.asynchttpclient.param=false
+# When to dump parameters. Either ALWAYS or EXCEPTION.
 profiler.ning.asynchttpclient.param.dumptype=EXCEPTION
+# Parameter dump size.
 profiler.ning.asynchttpclient.param.dumpsize=1024
+# 1 out of n parameters will be sampled where n is the rate. (10: 10%)
 profiler.ning.asynchttpclient.param.sampling.rate=10
 
 ###########################################################
 # Arcus                                                   # 
 ###########################################################
+# Profile Arcus.
 profiler.arcus=true
+# Record keytrace.
 profiler.arcus.keytrace=false
 
 ###########################################################
 # Memcached                                               # 
 ###########################################################
+# Profile Memecached.
 profiler.memcached=true
+# Record keytrace
 profiler.memcached.keytrace=false
 
 ###########################################################
 # Thrift                                                  # 
 ###########################################################
+# Profile Thrift
 profiler.thrift.client=true
+# Profile processor.
 profiler.thrift.processor=true
 # Allow recording arguments.
 profiler.thrift.service.args=false
@@ -210,16 +261,19 @@ profiler.thrift.service.result=false
 ###########################################################
 # ibatis                                                  # 
 ###########################################################
+# Profile ibatis.
 profiler.orm.ibatis=true
 
 ###########################################################
 # mybatis                                                 # 
 ###########################################################
+# Profile mybatis
 profiler.orm.mybatis=true
 
 ###########################################################
 # spring-beans 
 ###########################################################
+# Profile spring-beans
 profiler.spring.beans=true
 profiler.spring.beans.name.pattern=
 profiler.spring.beans.class.pattern=
@@ -238,6 +292,9 @@ profiler.logback.logging.transactioninfo=false
 ###########################################################
 # google httpclient 
 ###########################################################
+# Profile google httpclient.
 profiler.google.httpclient.enable=true
+# Profile async.
 profiler.google.httpclient.async=true
+# Maximum anonymous innerclass number.
 profiler.google.httpclient.async.innerclassname.max=3

--- a/agent/src/main/resources/pinpoint.config
+++ b/agent/src/main/resources/pinpoint.config
@@ -27,30 +27,37 @@ profiler.enable=true
 
 profiler.jvm.collect.interval=1000
 
+# Allow sampling.
 profiler.sampling.enable=true
 
-# Set sampling rate. If you set it to 10, 1 out of 10 transaction will be sampled.
+# 1 out of n transactions will be sampled where n is the rate. (1: 100%)
 profiler.sampling.rate=1
 
+# Allow buffering when flushing span to IO.
 profiler.io.buffering.enable=true
+
+# How many spans to store if buffering enabled.
 profiler.io.buffering.buffersize=20
 
+# Capacity of the SpanDataSender write queue.
 profiler.spandatasender.write.queue.size=5120
 #profiler.spandatasender.socket.sendbuffersize=1048576
 #profiler.spandatasender.socket.timeout=3000
 profiler.spandatasender.chunk.size=16384
 
+# Capacity of the StatDataSender write queue.
 profiler.statdatasender.write.queue.size=5120
 #profiler.statdatasender.socket.sendbuffersize=1048576
 #profiler.statdatasender.socket.timeout=3000
 profiler.statdatasender.chunk.size=16384
 
+# Interval to retry sending agent info. Unit is milliseconds.
 profiler.agentInfo.send.retry.interval=300000
 
-#  Allows TCP data command
+# Allow TCP data command.
 profiler.tcpdatasender.command.accept.enable=true
 
-# Trace Agent active thread info
+# Trace Agent active thread info.
 profiler.pinpoint.activethread=true
 
 ## Call Stack
@@ -70,6 +77,7 @@ profiler.type.detect.order=
 ###########################################################
 # user defined classes                                    # 
 ###########################################################
+# Specify classes you want to profile here.
 profiler.include=
 profiler.user.include=
 
@@ -82,45 +90,65 @@ profiler.tomcat.excludeurl=/aa/test.html, /bb/exclude.html
 ###########################################################
 # JDBC                                                    # 
 ###########################################################
+# Profile JDBC drivers.
 profiler.jdbc=true
+# Size of cache. Fixed maximum.
 profiler.jdbc.sqlcachesize=1024
+# Maximum bindvalue size.
 profiler.jdbc.maxsqlbindvaluesize=1024
 
 #
 # MYSQL
 #
+# Profile MySQL.
 profiler.jdbc.mysql=true
+# Allow profiling of setautocommit.
 profiler.jdbc.mysql.setautocommit=true
+# Allow profiling of commit.
 profiler.jdbc.mysql.commit=true
+# Allow profiling of rollback.
 profiler.jdbc.mysql.rollback=true
 
 #
 # MSSQL Jtds
 #
+# Profile jTDS.
 profiler.jdbc.jtds=true
+# Allow profiling of setautocommit.
 profiler.jdbc.jtds.setautocommit=true
+# Allow profiling of commit.
 profiler.jdbc.jtds.commit=true
+# Allow profiling of rollback.
 profiler.jdbc.jtds.rollback=true
 
 #
 # Oracle
 #
+# Profile Oracle DB.
 profiler.jdbc.oracle=true
+# Allow profiling of setautocommit.
 profiler.jdbc.oracle.setautocommit=true
+# Allow profiling of commit.
 profiler.jdbc.oracle.commit=true
+# Allow profiling of rollback.
 profiler.jdbc.oracle.rollback=true
 
 #
 # CUBRID
 #
+# Profile CUBRID.
 profiler.jdbc.cubrid=true
+# Allow profiling of setautocommit.
 profiler.jdbc.cubrid.setautocommit=true
+# Allow profiling of commit.
 profiler.jdbc.cubrid.commit=true
+# Allow profiling of rollback.
 profiler.jdbc.cubrid.rollback=true
 
 #
 # DBCP
 #
+# Profile DBCP.
 profiler.jdbc.dbcp=true
 profiler.jdbc.dbcp.connectionclose=true
 
@@ -128,107 +156,138 @@ profiler.jdbc.dbcp.connectionclose=true
 ###########################################################
 # Apache HTTP Client  3.x                                 #
 ###########################################################
+# Profile HTTP Client 3.x
 profiler.apache.httpclient3=true
+# Record Cookies.
 profiler.apache.httpclient3.cookie=true
 
-# When cookies should be dumped. It could be ALWAYS or EXCEPTION.
+# When to dump cookies. Either ALWAYS or EXCEPTION.
 profiler.apache.httpclient3.cookie.dumptype=ALWAYS
+# 1 out of n cookies will be sampled where n is the rate. (1: 100%)
 profiler.apache.httpclient3.cookie.sampling.rate=1
 
-# Dump entities of POST or PUT request. limited to entities which is HttpEntity.isRepeatable() == true.
+# Dump entities of POST and PUT requests. Limited to entities where HttpEntity.isRepeatable() == true.
 profiler.apache.httpclient3.entity=true
 
-# When entities should be dumped. ALWAYS or EXCEPTION.
+# When to dump entities. Either ALWAYS or EXCEPTION.
 profiler.apache.httpclient3.entity.dumptype=ALWAYS
+# 1 out of n entities will be sampled where n is the rate. (10: 10%)
 profiler.apache.httpclient3.entity.sampling.rate=1
 
 
 ###########################################################
 # Apache HTTP Client  4.x                                 #
 ###########################################################
+# Profile HTTP Client 4.x
 profiler.apache.httpclient4=true
+# Record cookies.
 profiler.apache.httpclient4.cookie=true
 
 # When cookies should be dumped. It could be ALWAYS or EXCEPTION.
 profiler.apache.httpclient4.cookie.dumptype=ALWAYS
+
+# 1 out of n cookies will be sampled where n is the rate. (1: 100%)
 profiler.apache.httpclient4.cookie.sampling.rate=1
 
-# Dump entities of POST or PUT request. limited to entities which is HttpEtity.isRepeatable() == true.
+# Dump entities of POST and PUT requests. Limited to entities where HttpEntity.isRepeatable() == true.
 profiler.apache.httpclient4.entity=true
 
-# When entities should be dumped. ALWAYS or EXCEPTION.
+# When to dump entities. Either ALWAYS or EXCEPTION.
 profiler.apache.httpclient4.entity.dumptype=ALWAYS
+
+# 1 out of n entities will be sampled where n is the rate. (10: 10%)
 profiler.apache.httpclient4.entity.sampling.rate=1
 
-# Can profile status code value
+# Allow profiling status code value.
 profiler.apache.httpclient4.entity.statuscode=true
 
-# Not supported yet  
+# Not supported yet.
 #profiler.apache.nio.httpclient4=true
 
 
 ###########################################################
 # JDK HTTPURLConnection                                   #
 ###########################################################
+# Profile JDK HTTPURPConnection.
 profiler.jdk.httpurlconnection=true
 
 
 ###########################################################
 # Ning Async HTTP Client                                  # 
 ###########################################################
+# Profile Ning Async HTTP Client.
 profiler.ning.asynchttpclient=true
+# Record cookies.
 profiler.ning.asynchttpclient.cookie=true
+# When to dump cookies. Either ALWAYS or EXCEPTION.
 profiler.ning.asynchttpclient.cookie.dumptype=ALWAYS
+# Cookie dump size.
 profiler.ning.asynchttpclient.cookie.dumpsize=1024
+# 1 out of n cookies will be sampled where n is the rate. (1: 100%)
 profiler.ning.asynchttpclient.cookie.sampling.rate=1
+# Record Entities.
 profiler.ning.asynchttpclient.entity=true
+# When to dump entities. Either ALWAYS or EXCEPTION.
 profiler.ning.asynchttpclient.entity.dumptype=ALWAYS
+# Entity dump size.
 profiler.ning.asynchttpclient.entity.dumpsize=1024
+# 1 out of n cookies will be sampled where n is the rate. (1: 100%)
 profiler.ning.asynchttpclient.entity.sampling.rate=1
+# Record parameters.
 profiler.ning.asynchttpclient.param=true
+# When to dump parameters. Either ALWAYS or EXCEPTION.
 profiler.ning.asynchttpclient.param.dumptype=ALWAYS
+# Parameter dump size.
 profiler.ning.asynchttpclient.param.dumpsize=1024
+# 1 out of n parameters will be sampled where n is the rate. (1: 100%)
 profiler.ning.asynchttpclient.param.sampling.rate=1
 
 
 ###########################################################
 # Arcus                                                   # 
 ###########################################################
+# Profile Arcus.
 profiler.arcus=true
+# Record keytrace.
 profiler.arcus.keytrace=true
-
 
 ###########################################################
 # Memcached                                               # 
 ###########################################################
+# Profile Memecached.
 profiler.memcached=true
+# Record keytrace
 profiler.memcached.keytrace=true
-
 
 ###########################################################
 # Thrift                                                  # 
 ###########################################################
+# Profile Thrift
 profiler.thrift.client=true
+# Profile processor.
 profiler.thrift.processor=true
+# Allow recording arguments.
 profiler.thrift.service.args=true
+# Allow recording result.
 profiler.thrift.service.result=true
 
 
 ###########################################################
 # ibatis                                                  # 
 ###########################################################
+# Profile ibatis.
 profiler.orm.ibatis=true
-
 
 ###########################################################
 # mybatis                                                 # 
 ###########################################################
+# Profile mybatis
 profiler.orm.mybatis=true
-
 
 ###########################################################
 # spring-beans 
 ###########################################################
+# Profile spring-beans
 profiler.spring.beans=true
 profiler.spring.beans.name.pattern=
 profiler.spring.beans.class.pattern=
@@ -247,6 +306,9 @@ profiler.logback.logging.transactioninfo=false
 ###########################################################
 # google httpclient 
 ###########################################################
+# Profile google httpclient.
 profiler.google.httpclient.enable=true
+# Profile async.
 profiler.google.httpclient.async=true
+# Maximum anonymous innerclass number.
 profiler.google.httpclient.async.innerclassname.max=3

--- a/agent/src/main/resources/pinpoint.config
+++ b/agent/src/main/resources/pinpoint.config
@@ -77,9 +77,15 @@ profiler.type.detect.order=
 ###########################################################
 # user defined classes                                    # 
 ###########################################################
-# Specify classes you want to profile here.
+# Specify classes and methods you want to profile here.
+
+# Needs to be a comma separated list of fully qualified class names, or fully qualified package names with wild card class.
 profiler.include=
+# Ex: foo.bar.MyClass, foo.baz.*
+
+# Needs to be a comma separated list of fully qualified method names. Wild card not supported.
 profiler.user.include=
+# Ex: foo.bar.MyClass.myMethod, foo.bar.MyClass.anotherMethod
 
 ###########################################################
 # TOMCAT                                                  #

--- a/collector/src/main/resources/pinpoint-collector.properties
+++ b/collector/src/main/resources/pinpoint-collector.properties
@@ -15,7 +15,7 @@ collector.l4.ip=
 
 # number of udp statworker threads
 collector.udpStatWorkerThread=16
-# capacity of udp stat worker queue
+# capacity of udp statworker queue
 collector.udpStatWorkerQueueSize=512
 
 collector.udpStatSocketReceiveBufferSize=4194304
@@ -28,7 +28,7 @@ collector.udpSpanListenPort=9996
 
 # number of udp spanworker threads
 collector.udpSpanWorkerThread=32
-# capacity of udp stat worker queue
+# capacity of udp spanworker queue
 collector.udpSpanWorkerQueueSize=1024
 
 collector.udpSpanSocketReceiveBufferSize=4194304

--- a/collector/src/main/resources/pinpoint-collector.properties
+++ b/collector/src/main/resources/pinpoint-collector.properties
@@ -1,17 +1,21 @@
-# tcp listen ip
+# tcp listen ip and port
 collector.tcpListenIp=0.0.0.0
 collector.tcpListenPort=9994
 
+# number of tcp worker threads
 collector.tcpWorkerThread=8
+# capacity of tcp worker queue
 collector.tcpWorkerQueueSize=1024
 
-# udp listen ip
+# udp listen ip and port
 collector.udpStatListenIp=0.0.0.0
 collector.udpStatListenPort=9995
 
 collector.l4.ip=
 
+# number of udp statworker threads
 collector.udpStatWorkerThread=16
+# capacity of udp stat worker queue
 collector.udpStatWorkerQueueSize=512
 
 collector.udpStatSocketReceiveBufferSize=4194304
@@ -21,17 +25,22 @@ collector.udpStatSocketReceiveBufferSize=4194304
 collector.udpSpanListenIp=0.0.0.0
 collector.udpSpanListenPort=9996
 
+
+# number of udp spanworker threads
 collector.udpSpanWorkerThread=32
+# capacity of udp stat worker queue
 collector.udpSpanWorkerQueueSize=1024
 
 collector.udpSpanSocketReceiveBufferSize=4194304
 
-# agent event worker
+# number of agent event worker threads
 collector.agentEventWorker.threadSize=8
+# capacity of agent event worker queue
 collector.agentEventWorker.queueSize=1024
 
 statistics.flushPeriod=1000
 
+# enable cluster in socket manager.
 cluster.enable=false
 cluster.zookeeper.address=
 cluster.zookeeper.sessiontimeout=


### PR DESCRIPTION
For Agent.
Some items like ```profiler.enable=true``` weren't being used, so I didn't add comments to those.