### PR TITLE
Allow tests to use different ports for different test runs

### DIFF
--- a/agent/src/test/java/com/navercorp/pinpoint/plugin/thrift/common/TestEnvironment.java
+++ b/agent/src/test/java/com/navercorp/pinpoint/plugin/thrift/common/TestEnvironment.java
@@ -24,12 +24,33 @@ import org.apache.thrift.protocol.TProtocolFactory;
 /**
  * @author HyunGil Jeong
  */
-public interface TestEnvironment {
+public class TestEnvironment {
 
-    public static final String SERVER_IP = "127.0.0.1";
-    public static final int SERVER_PORT = 9090;
-    public static final InetSocketAddress SERVER_ADDRESS = new InetSocketAddress(SERVER_IP, SERVER_PORT);
+    private static final int MIN_SERVER_PORT = 9091;
+    private static final int MAX_SERVER_PORT = 9099;
 
-    public static final TProtocolFactory PROTOCOL_FACTORY = new TBinaryProtocol.Factory();
-    
+    private static final String SERVER_IP = "127.0.0.1";
+    private static final TProtocolFactory PROTOCOL_FACTORY = new TBinaryProtocol.Factory();
+
+    private final String serverIp = SERVER_IP;
+    private final int port = MIN_SERVER_PORT + (int)(Math.random() * (MAX_SERVER_PORT - MIN_SERVER_PORT) + 1);
+    private final InetSocketAddress serverAddress = new InetSocketAddress(SERVER_IP, this.port);
+    private final TProtocolFactory protocolFactory = PROTOCOL_FACTORY;
+
+    public String getServerIp() {
+        return this.serverIp;
+    }
+
+    public int getPort() {
+        return this.port;
+    }
+
+    public InetSocketAddress getServerAddress() {
+        return this.serverAddress;
+    }
+
+    public TProtocolFactory getProtocolFactory() {
+        return this.protocolFactory;
+    }
+
 }

--- a/agent/src/test/java/com/navercorp/pinpoint/plugin/thrift/common/client/EchoTestClient.java
+++ b/agent/src/test/java/com/navercorp/pinpoint/plugin/thrift/common/client/EchoTestClient.java
@@ -19,17 +19,16 @@ package com.navercorp.pinpoint.plugin.thrift.common.client;
 import org.apache.thrift.TException;
 
 import com.navercorp.pinpoint.bootstrap.plugin.test.PluginTestVerifier;
-import com.navercorp.pinpoint.plugin.thrift.common.TestEnvironment;
 
 /**
  * @author HyunGil Jeong
  */
-public interface EchoTestClient extends TestEnvironment {
-    
+public interface EchoTestClient {
+
     public String echo(String message) throws TException;
-    
+
     public void verifyTraces(PluginTestVerifier verifier, String expectedMessage) throws Exception;
-    
+
     public void close();
-    
+
 }

--- a/agent/src/test/java/com/navercorp/pinpoint/plugin/thrift/common/server/EchoTestServer.java
+++ b/agent/src/test/java/com/navercorp/pinpoint/plugin/thrift/common/server/EchoTestServer.java
@@ -33,7 +33,7 @@ import com.navercorp.pinpoint.plugin.thrift.dto.EchoService;
 /**
  * @author HyunGil Jeong
  */
-public abstract class EchoTestServer<T extends TServer> implements TestEnvironment {
+public abstract class EchoTestServer<T extends TServer> {
 
     protected static class EchoServiceHandler implements EchoService.Iface {
         @Override
@@ -41,14 +41,15 @@ public abstract class EchoTestServer<T extends TServer> implements TestEnvironme
             return message;
         }
     }
-    
+
     protected static class EchoServiceAsyncHandler implements EchoService.AsyncIface {
-        
+
         private final EchoServiceHandler syncHandler = new EchoServiceHandler();
-        
+
         @SuppressWarnings("unchecked")
         @Override
-        public void echo(String message, @SuppressWarnings("rawtypes") AsyncMethodCallback resultHandler) throws TException {
+        public void echo(String message, @SuppressWarnings("rawtypes") AsyncMethodCallback resultHandler)
+                throws TException {
             try {
                 final String echo = this.syncHandler.echo(message);
                 resultHandler.onComplete(echo);
@@ -57,16 +58,19 @@ public abstract class EchoTestServer<T extends TServer> implements TestEnvironme
             }
         }
     }
-    
+
     private final T server;
-    
-    protected EchoTestServer(T server) throws TTransportException {
+
+    protected final TestEnvironment environment;
+
+    protected EchoTestServer(T server, TestEnvironment environment) throws TTransportException {
         if (server == null) {
             throw new IllegalArgumentException("server cannot be null");
         }
         this.server = server;
+        this.environment = environment;
     }
-    
+
     public void start(ExecutorService executor) throws TTransportException, InterruptedException {
         if (this.server.isServing()) {
             return;
@@ -80,19 +84,19 @@ public abstract class EchoTestServer<T extends TServer> implements TestEnvironme
         // give a chance for the server to initialize
         Thread.sleep(500L);
     }
-    
+
     public void stop() {
         this.server.stop();
     }
-    
+
     public void verifyTraces(PluginTestVerifier verifier) throws Exception {
         this.verifyServerTraces(verifier);
     }
-    
+
     protected abstract void verifyServerTraces(PluginTestVerifier verifier) throws Exception;
-    
+
     public abstract SyncEchoTestClient getSynchronousClient() throws TTransportException;
-    
+
     public abstract AsyncEchoTestClient getAsynchronousClient() throws IOException;
-    
+
 }

--- a/agent/src/test/java/com/navercorp/pinpoint/plugin/thrift/it/EchoTestRunner.java
+++ b/agent/src/test/java/com/navercorp/pinpoint/plugin/thrift/it/EchoTestRunner.java
@@ -35,14 +35,14 @@ import com.navercorp.pinpoint.plugin.thrift.common.server.EchoTestServer;
 /**
  * @author HyunGil Jeong
  */
-public abstract class EchoTestRunner<T extends TServer> implements TestEnvironment {
+public abstract class EchoTestRunner<T extends TServer> {
 
     private static ExecutorService SERVER_EXECUTOR;
-    
+
     private EchoTestServer<T> echoServer;
-    
+
     PluginTestVerifier verifier;
-    
+
     @BeforeClass
     public static void setUpBeforeClass() throws InterruptedException {
         SERVER_EXECUTOR = Executors.newSingleThreadExecutor();
@@ -50,11 +50,11 @@ public abstract class EchoTestRunner<T extends TServer> implements TestEnvironme
 
     @Before
     public void setUp() throws TTransportException, InterruptedException {
-        this.echoServer = createEchoServer();
+        this.echoServer = createEchoServer(new TestEnvironment());
         this.verifier = PluginTestVerifierHolder.getInstance();
         this.echoServer.start(SERVER_EXECUTOR);
     }
-    
+
     @After
     public void tearDown() {
         if (this.echoServer != null) {
@@ -66,17 +66,17 @@ public abstract class EchoTestRunner<T extends TServer> implements TestEnvironme
     public static void tearDownAfterClass() {
         SERVER_EXECUTOR.shutdown();
     }
-    
+
     protected String invokeEcho(String message) throws Exception {
         final EchoTestClient echoClient = this.echoServer.getSynchronousClient();
         return invokeAndVerify(echoClient, message);
     }
-    
+
     protected String invokeEchoAsync(String message) throws Exception {
         final EchoTestClient echoClient = this.echoServer.getAsynchronousClient();
         return invokeAndVerify(echoClient, message);
     }
-    
+
     private String invokeAndVerify(EchoTestClient echoClient, String message) throws Exception {
         try {
             return echoClient.echo(message);
@@ -87,13 +87,13 @@ public abstract class EchoTestRunner<T extends TServer> implements TestEnvironme
             this.verifyTraces(echoClient, message);
         }
     }
-    
-    protected abstract EchoTestServer<T> createEchoServer() throws TTransportException;
-    
+
+    protected abstract EchoTestServer<T> createEchoServer(TestEnvironment environment) throws TTransportException;
+
     private void verifyTraces(EchoTestClient echoClient, String expectedMessage) throws Exception {
         this.verifier.printCache(System.out);
         echoClient.verifyTraces(this.verifier, expectedMessage);
         this.echoServer.verifyTraces(this.verifier);
     }
-    
+
 }

--- a/agent/src/test/java/com/navercorp/pinpoint/plugin/thrift/it/asynchronous/ThriftHalfSyncHalfAsyncServerAsyncIT.java
+++ b/agent/src/test/java/com/navercorp/pinpoint/plugin/thrift/it/asynchronous/ThriftHalfSyncHalfAsyncServerAsyncIT.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import com.navercorp.pinpoint.common.Version;
+import com.navercorp.pinpoint.plugin.thrift.common.TestEnvironment;
 import com.navercorp.pinpoint.plugin.thrift.common.server.EchoTestServer;
 import com.navercorp.pinpoint.plugin.thrift.common.server.AsyncEchoTestServer.AsyncEchoTestServerFactory;
 import com.navercorp.pinpoint.plugin.thrift.it.EchoTestRunner;
@@ -44,8 +45,8 @@ import com.navercorp.pinpoint.test.plugin.PinpointPluginTestSuite;
 public class ThriftHalfSyncHalfAsyncServerAsyncIT extends EchoTestRunner<THsHaServer> {
 
     @Override
-    protected EchoTestServer<THsHaServer> createEchoServer() throws TTransportException {
-        return AsyncEchoTestServerFactory.halfSyncHalfAsyncServer();
+    protected EchoTestServer<THsHaServer> createEchoServer(TestEnvironment environment) throws TTransportException {
+        return AsyncEchoTestServerFactory.halfSyncHalfAsyncServer(environment);
     }
 
     @Test
@@ -57,7 +58,7 @@ public class ThriftHalfSyncHalfAsyncServerAsyncIT extends EchoTestRunner<THsHaSe
         // Then
         assertEquals(expectedMessage, result);
     }
-    
+
     @Test
     public void testAsynchronousRpcCall() throws Exception {
         // Given

--- a/agent/src/test/java/com/navercorp/pinpoint/plugin/thrift/it/asynchronous/ThriftNonblockingServerAsyncIT.java
+++ b/agent/src/test/java/com/navercorp/pinpoint/plugin/thrift/it/asynchronous/ThriftNonblockingServerAsyncIT.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import com.navercorp.pinpoint.common.Version;
+import com.navercorp.pinpoint.plugin.thrift.common.TestEnvironment;
 import com.navercorp.pinpoint.plugin.thrift.common.server.EchoTestServer;
 import com.navercorp.pinpoint.plugin.thrift.common.server.AsyncEchoTestServer.AsyncEchoTestServerFactory;
 import com.navercorp.pinpoint.plugin.thrift.it.EchoTestRunner;
@@ -44,10 +45,11 @@ import com.navercorp.pinpoint.test.plugin.PinpointPluginTestSuite;
 public class ThriftNonblockingServerAsyncIT extends EchoTestRunner<TNonblockingServer> {
 
     @Override
-    protected EchoTestServer<TNonblockingServer> createEchoServer() throws TTransportException {
-        return AsyncEchoTestServerFactory.nonblockingServer();
+    protected EchoTestServer<TNonblockingServer> createEchoServer(TestEnvironment environment)
+            throws TTransportException {
+        return AsyncEchoTestServerFactory.nonblockingServer(environment);
     }
-    
+
     @Test
     public void testSynchronousRpcCall() throws Exception {
         // Given
@@ -57,7 +59,7 @@ public class ThriftNonblockingServerAsyncIT extends EchoTestRunner<TNonblockingS
         // Then
         assertEquals(expectedMessage, result);
     }
-    
+
     @Test
     public void testAsynchronousRpcCall() throws Exception {
         // Given

--- a/agent/src/test/java/com/navercorp/pinpoint/plugin/thrift/it/asynchronous/ThriftThreadedSelectorServerAsyncIT.java
+++ b/agent/src/test/java/com/navercorp/pinpoint/plugin/thrift/it/asynchronous/ThriftThreadedSelectorServerAsyncIT.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import com.navercorp.pinpoint.common.Version;
+import com.navercorp.pinpoint.plugin.thrift.common.TestEnvironment;
 import com.navercorp.pinpoint.plugin.thrift.common.server.EchoTestServer;
 import com.navercorp.pinpoint.plugin.thrift.common.server.AsyncEchoTestServer.AsyncEchoTestServerFactory;
 import com.navercorp.pinpoint.plugin.thrift.it.EchoTestRunner;
@@ -44,10 +45,11 @@ import com.navercorp.pinpoint.test.plugin.PinpointPluginTestSuite;
 public class ThriftThreadedSelectorServerAsyncIT extends EchoTestRunner<TThreadedSelectorServer> {
 
     @Override
-    protected EchoTestServer<TThreadedSelectorServer> createEchoServer() throws TTransportException {
-        return AsyncEchoTestServerFactory.threadedSelectorServer();
+    protected EchoTestServer<TThreadedSelectorServer> createEchoServer(TestEnvironment environment)
+            throws TTransportException {
+        return AsyncEchoTestServerFactory.threadedSelectorServer(environment);
     }
-    
+
     @Test
     public void testSynchronousRpcCall() throws Exception {
         // Given
@@ -57,7 +59,7 @@ public class ThriftThreadedSelectorServerAsyncIT extends EchoTestRunner<TThreade
         // Then
         assertEquals(expectedMessage, result);
     }
-    
+
     @Test
     public void testAsynchronousRpcCall() throws Exception {
         // Given

--- a/agent/src/test/java/com/navercorp/pinpoint/plugin/thrift/it/synchronous/ThriftHalfSyncHalfAsyncServerIT.java
+++ b/agent/src/test/java/com/navercorp/pinpoint/plugin/thrift/it/synchronous/ThriftHalfSyncHalfAsyncServerIT.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import com.navercorp.pinpoint.common.Version;
+import com.navercorp.pinpoint.plugin.thrift.common.TestEnvironment;
 import com.navercorp.pinpoint.plugin.thrift.common.server.EchoTestServer;
 import com.navercorp.pinpoint.plugin.thrift.common.server.SyncEchoTestServer.SyncEchoTestServerFactory;
 import com.navercorp.pinpoint.plugin.thrift.it.EchoTestRunner;
@@ -44,10 +45,10 @@ import com.navercorp.pinpoint.test.plugin.PinpointPluginTestSuite;
 public class ThriftHalfSyncHalfAsyncServerIT extends EchoTestRunner<THsHaServer> {
 
     @Override
-    protected EchoTestServer<THsHaServer> createEchoServer() throws TTransportException {
-        return SyncEchoTestServerFactory.halfSyncHalfAsyncServer();
+    protected EchoTestServer<THsHaServer> createEchoServer(TestEnvironment environment) throws TTransportException {
+        return SyncEchoTestServerFactory.halfSyncHalfAsyncServer(environment);
     }
-    
+
     @Test
     public void testSynchronousRpcCall() throws Exception {
         // Given
@@ -57,7 +58,7 @@ public class ThriftHalfSyncHalfAsyncServerIT extends EchoTestRunner<THsHaServer>
         // Then
         assertEquals(expectedMessage, result);
     }
-    
+
     @Test
     public void testAsynchronousRpcCall() throws Exception {
         // Given

--- a/agent/src/test/java/com/navercorp/pinpoint/plugin/thrift/it/synchronous/ThriftNonblockingServerIT.java
+++ b/agent/src/test/java/com/navercorp/pinpoint/plugin/thrift/it/synchronous/ThriftNonblockingServerIT.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import com.navercorp.pinpoint.common.Version;
+import com.navercorp.pinpoint.plugin.thrift.common.TestEnvironment;
 import com.navercorp.pinpoint.plugin.thrift.common.server.EchoTestServer;
 import com.navercorp.pinpoint.plugin.thrift.common.server.SyncEchoTestServer.SyncEchoTestServerFactory;
 import com.navercorp.pinpoint.plugin.thrift.it.EchoTestRunner;
@@ -44,10 +45,11 @@ import com.navercorp.pinpoint.test.plugin.PinpointPluginTestSuite;
 public class ThriftNonblockingServerIT extends EchoTestRunner<TNonblockingServer> {
 
     @Override
-    protected EchoTestServer<TNonblockingServer> createEchoServer() throws TTransportException {
-        return SyncEchoTestServerFactory.nonblockingServer();
+    protected EchoTestServer<TNonblockingServer> createEchoServer(TestEnvironment environment)
+            throws TTransportException {
+        return SyncEchoTestServerFactory.nonblockingServer(environment);
     }
-    
+
     @Test
     public void testSynchronousRpcCall() throws Exception {
         // Given
@@ -57,7 +59,7 @@ public class ThriftNonblockingServerIT extends EchoTestRunner<TNonblockingServer
         // Then
         assertEquals(expectedMessage, result);
     }
-    
+
     @Test
     public void testAsynchronousRpcCall() throws Exception {
         // Given

--- a/agent/src/test/java/com/navercorp/pinpoint/plugin/thrift/it/synchronous/ThriftSimpleServerIT.java
+++ b/agent/src/test/java/com/navercorp/pinpoint/plugin/thrift/it/synchronous/ThriftSimpleServerIT.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import com.navercorp.pinpoint.common.Version;
+import com.navercorp.pinpoint.plugin.thrift.common.TestEnvironment;
 import com.navercorp.pinpoint.plugin.thrift.common.server.EchoTestServer;
 import com.navercorp.pinpoint.plugin.thrift.common.server.SyncEchoTestServer.SyncEchoTestServerFactory;
 import com.navercorp.pinpoint.plugin.thrift.it.EchoTestRunner;
@@ -44,10 +45,10 @@ import com.navercorp.pinpoint.test.plugin.PinpointPluginTestSuite;
 public class ThriftSimpleServerIT extends EchoTestRunner<TSimpleServer> {
 
     @Override
-    protected EchoTestServer<TSimpleServer> createEchoServer() throws TTransportException {
-        return SyncEchoTestServerFactory.simpleServer();
+    protected EchoTestServer<TSimpleServer> createEchoServer(TestEnvironment environment) throws TTransportException {
+        return SyncEchoTestServerFactory.simpleServer(environment);
     }
-    
+
     @Test
     public void testSynchronousRpcCall() throws Exception {
         // Given

--- a/agent/src/test/java/com/navercorp/pinpoint/plugin/thrift/it/synchronous/ThriftThreadPoolServerIT.java
+++ b/agent/src/test/java/com/navercorp/pinpoint/plugin/thrift/it/synchronous/ThriftThreadPoolServerIT.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import com.navercorp.pinpoint.common.Version;
+import com.navercorp.pinpoint.plugin.thrift.common.TestEnvironment;
 import com.navercorp.pinpoint.plugin.thrift.common.server.EchoTestServer;
 import com.navercorp.pinpoint.plugin.thrift.common.server.SyncEchoTestServer.SyncEchoTestServerFactory;
 import com.navercorp.pinpoint.plugin.thrift.it.EchoTestRunner;
@@ -44,10 +45,11 @@ import com.navercorp.pinpoint.test.plugin.PinpointPluginTestSuite;
 public class ThriftThreadPoolServerIT extends EchoTestRunner<TThreadPoolServer> {
 
     @Override
-    protected EchoTestServer<TThreadPoolServer> createEchoServer() throws TTransportException {
-        return SyncEchoTestServerFactory.threadedPoolServer();
+    protected EchoTestServer<TThreadPoolServer> createEchoServer(TestEnvironment environment)
+            throws TTransportException {
+        return SyncEchoTestServerFactory.threadedPoolServer(environment);
     }
-    
+
     @Test
     public void testSynchronousRpcCall() throws Exception {
         // Given

--- a/agent/src/test/java/com/navercorp/pinpoint/plugin/thrift/it/synchronous/ThriftThreadedSelectorServerIT.java
+++ b/agent/src/test/java/com/navercorp/pinpoint/plugin/thrift/it/synchronous/ThriftThreadedSelectorServerIT.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import com.navercorp.pinpoint.common.Version;
+import com.navercorp.pinpoint.plugin.thrift.common.TestEnvironment;
 import com.navercorp.pinpoint.plugin.thrift.common.server.EchoTestServer;
 import com.navercorp.pinpoint.plugin.thrift.common.server.SyncEchoTestServer.SyncEchoTestServerFactory;
 import com.navercorp.pinpoint.plugin.thrift.it.EchoTestRunner;
@@ -44,10 +45,11 @@ import com.navercorp.pinpoint.test.plugin.PinpointPluginTestSuite;
 public class ThriftThreadedSelectorServerIT extends EchoTestRunner<TThreadedSelectorServer> {
 
     @Override
-    protected EchoTestServer<TThreadedSelectorServer> createEchoServer() throws TTransportException {
-        return SyncEchoTestServerFactory.threadedSelectorServer();
+    protected EchoTestServer<TThreadedSelectorServer> createEchoServer(TestEnvironment environment)
+            throws TTransportException {
+        return SyncEchoTestServerFactory.threadedSelectorServer(environment);
     }
-    
+
     @Test
     public void testSynchronousRpcCall() throws Exception {
         // Given
@@ -57,7 +59,7 @@ public class ThriftThreadedSelectorServerIT extends EchoTestRunner<TThreadedSele
         // Then
         assertEquals(expectedMessage, result);
     }
-    
+
     @Test
     public void testAsynchronousRpcCall() throws Exception {
         // Given


### PR DESCRIPTION
Thrift integration tests now uses a random port between 9091~9099 to fix occasional port collision.
Fixes #329 