### PR TITLE
Add status information to server map and allow transaction-less nodes to be displayed

### DIFF
--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/ServerBuilder.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/ServerBuilder.java
@@ -16,10 +16,11 @@
 
 package com.navercorp.pinpoint.web.applicationmap;
 
-import com.navercorp.pinpoint.common.bo.AgentInfoBo;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.web.applicationmap.rawdata.AgentHistogram;
 import com.navercorp.pinpoint.web.applicationmap.rawdata.AgentHistogramList;
+import com.navercorp.pinpoint.web.vo.AgentInfo;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -29,17 +30,18 @@ import java.util.Set;
 /**
  * @author emeroad
  * @author minwoo.jung
+ * @author HyunGil Jeong
  */
 public class ServerBuilder {
 
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
     private final AgentHistogramList agentHistogramList;
-    private final Set<AgentInfoBo> agentSet;
+    private final Set<AgentInfo> agentSet;
 
     public ServerBuilder() {
         this.agentHistogramList = new AgentHistogramList();
-        this.agentSet = new HashSet<AgentInfoBo>();
+        this.agentSet = new HashSet<AgentInfo>();
     }
 
     public void addCallHistogramList(AgentHistogramList agentHistogramList) {
@@ -49,11 +51,11 @@ public class ServerBuilder {
         this.agentHistogramList.addAgentHistogram(agentHistogramList);
     }
 
-    public void addAgentInfo(Set<AgentInfoBo> agentInfoBo) {
-        if (agentInfoBo == null) {
+    public void addAgentInfo(Set<AgentInfo> agentInfo) {
+        if (agentInfo == null) {
             return;
         }
-        this.agentSet.addAll(agentInfoBo);
+        this.agentSet.addAll(agentInfo);
     }
 
     public void addServerInstance(ServerBuilder copy) {
@@ -63,8 +65,6 @@ public class ServerBuilder {
         addCallHistogramList(copy.agentHistogramList);
         addAgentInfo(copy.agentSet);
     }
-
-
 
     private String getHostName(String instanceName) {
         final int pos = instanceName.indexOf(':');
@@ -93,17 +93,15 @@ public class ServerBuilder {
         return serverInstanceList;
     }
 
-    public ServerInstanceList buildPhysicalServer(final Set<AgentInfoBo> agentSet) {
+    public ServerInstanceList buildPhysicalServer(final Set<AgentInfo> agentSet) {
         final ServerInstanceList serverInstanceList = new ServerInstanceList();
-        for (AgentInfoBo agent : agentSet) {
+        for (AgentInfo agent : agentSet) {
             final ServerInstance serverInstance = new ServerInstance(agent);
             serverInstanceList.addServerInstance(serverInstance);
 
         }
         return serverInstanceList;
     }
-
-
 
     public ServerInstanceList build() {
         if (!agentSet.isEmpty()) {
@@ -116,6 +114,5 @@ public class ServerBuilder {
             return buildLogicalServer(agentHistogramList);
         }
     }
-
 
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/ServerInstance.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/ServerInstance.java
@@ -18,15 +18,20 @@ package com.navercorp.pinpoint.web.applicationmap;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.navercorp.pinpoint.common.bo.AgentInfoBo;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.navercorp.pinpoint.common.trace.ServiceType;
+import com.navercorp.pinpoint.common.util.AgentLifeCycleState;
 import com.navercorp.pinpoint.web.applicationmap.link.MatcherGroup;
 import com.navercorp.pinpoint.web.applicationmap.link.ServerMatcher;
+import com.navercorp.pinpoint.web.view.AgentLifeCycleStateSerializer;
+import com.navercorp.pinpoint.web.vo.AgentInfo;
+import com.navercorp.pinpoint.web.vo.AgentStatus;
 
 /**
  *
  * @author netspider
  * @author emeroad
+ * @author HyunGil Jeong
  */
 public class ServerInstance {
 
@@ -37,8 +42,7 @@ public class ServerInstance {
 
     private final ServerType serverType;
 
-    private final AgentInfoBo agentInfo;
-
+    private final AgentLifeCycleState status;
 
     // it is better for something else to inject this.
     // it's difficult to do that since it is new'ed within logic
@@ -46,14 +50,19 @@ public class ServerInstance {
 
     private ServerMatcher match;
 
-    public ServerInstance(AgentInfoBo agentInfo) {
+    public ServerInstance(AgentInfo agentInfo) {
         if (agentInfo == null) {
             throw new NullPointerException("agentInfo must not be null");
         }
         this.hostName = agentInfo.getHostName();
         this.name = agentInfo.getAgentId();
         this.serviceType = agentInfo.getServiceType();
-        this.agentInfo = agentInfo;
+        AgentStatus agentStatus = agentInfo.getStatus();
+        if (agentStatus != null) {
+            this.status = agentStatus.getState();
+        } else {
+            this.status = AgentLifeCycleState.UNKNOWN;
+        }
         this.serverType = ServerType.Physical;
         this.match = MATCHER_GROUP.match(hostName);
     }
@@ -71,7 +80,7 @@ public class ServerInstance {
         this.hostName = hostName;
         this.name = physicalName;
         this.serviceType = serviceType;
-        this.agentInfo = null;
+        this.status = AgentLifeCycleState.UNKNOWN;
         this.serverType = ServerType.Logical;
         this.match = MATCHER_GROUP.match(hostName);
     }
@@ -91,14 +100,15 @@ public class ServerInstance {
         return serviceType;
     }
 
+    @JsonProperty("status")
+    @JsonSerialize(using = AgentLifeCycleStateSerializer.class)
+    public AgentLifeCycleState getStatus() {
+        return status;
+    }
+
     @JsonIgnore
     public ServerType getServerType() {
         return serverType;
-    }
-
-    @JsonProperty("agentInfo")
-    public AgentInfoBo getAgentInfo() {
-        return agentInfo;
     }
 
     @JsonProperty("linkName")
@@ -120,17 +130,21 @@ public class ServerInstance {
         }
     }
 
-
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
 
-        ServerInstance that = (ServerInstance) o;
+        ServerInstance that = (ServerInstance)o;
 
-        if (!name.equals(that.name)) return false;
-        if (serverType != that.serverType) return false;
-        if (serviceType != that.serviceType) return false;
+        if (!name.equals(that.name))
+            return false;
+        if (serverType != that.serverType)
+            return false;
+        if (serviceType != that.serviceType)
+            return false;
 
         return true;
     }
@@ -142,6 +156,5 @@ public class ServerInstance {
         result = 31 * result + serviceType.hashCode();
         return result;
     }
-
 
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/ServerInstanceList.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/ServerInstanceList.java
@@ -18,10 +18,6 @@ package com.navercorp.pinpoint.web.applicationmap;
 
 import java.util.*;
 
-import com.navercorp.pinpoint.common.bo.AgentInfoBo;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.navercorp.pinpoint.web.applicationmap.link.MatcherGroup;
 import com.navercorp.pinpoint.web.applicationmap.link.ServerMatcher;
@@ -31,11 +27,10 @@ import com.navercorp.pinpoint.web.view.ServerInstanceListSerializer;
  * @author emeroad
  * @author netspider
  * @author minwoo.jung
+ * @author HyunGil Jeong
  */
 @JsonSerialize(using = ServerInstanceListSerializer.class)
 public class ServerInstanceList {
-
-    private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
     private final Map<String, List<ServerInstance>> serverInstanceList = new TreeMap<String, List<ServerInstance>>();
 
@@ -53,8 +48,7 @@ public class ServerInstanceList {
         final List<String> agentList = new ArrayList<String>();
         for (List<ServerInstance> serverInstanceList : serverInstanceValueList) {
             for (ServerInstance serverInstance : serverInstanceList) {
-                AgentInfoBo agentInfo = serverInstance.getAgentInfo();
-                agentList.add(agentInfo.getAgentId());
+                agentList.add(serverInstance.getName());
             }
         }
         return agentList;

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/AgentInfoService.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/AgentInfoService.java
@@ -18,7 +18,6 @@ package com.navercorp.pinpoint.web.service;
 
 import java.util.Set;
 
-import com.navercorp.pinpoint.common.bo.AgentInfoBo;
 import com.navercorp.pinpoint.web.vo.AgentInfo;
 import com.navercorp.pinpoint.web.vo.AgentStatus;
 import com.navercorp.pinpoint.web.vo.ApplicationAgentList;
@@ -30,7 +29,7 @@ import com.navercorp.pinpoint.web.vo.ApplicationAgentList;
 public interface AgentInfoService {
     ApplicationAgentList getApplicationAgentList(String applicationName, long timestamp);
 
-    Set<AgentInfoBo> getAgentsByApplicationName(String applicationName, long timestamp);
+    Set<AgentInfo> getAgentsByApplicationName(String applicationName, long timestamp);
     
     AgentInfo getAgentInfo(String agentId, long timestamp);
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/AgentInfoServiceImpl.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/AgentInfoServiceImpl.java
@@ -81,7 +81,7 @@ public class AgentInfoServiceImpl implements AgentInfoService {
 
             final AgentInfo agentInfo = new AgentInfo(agentInfoBo);
 
-            final AgentStatus currentStatus = this.getAgentStatus(agentId, Long.MAX_VALUE);
+            final AgentStatus currentStatus = this.getAgentStatus(agentId, timestamp);
             agentInfo.setStatus(currentStatus);
 
             final AgentInfoBo initialAgentInfo = this.agentInfoDao.getInitialAgentInfo(agentId);

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/MapServiceImpl.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/MapServiceImpl.java
@@ -85,6 +85,9 @@ public class MapServiceImpl implements MapService {
         watch.start("ApplicationMap MapBuilding(Response) Time");
         ApplicationMapBuilder builder = new ApplicationMapBuilder(range);
         ApplicationMap map = builder.build(linkDataDuplexMap, agentInfoService, this.mapResponseDao);
+        if (map.getNodes().isEmpty()) {
+            map = builder.build(sourceApplication, agentInfoService);
+        }
         watch.stop();
         if (logger.isInfoEnabled()) {
             logger.info("ApplicationMap BuildTime: {}", watch.prettyPrint());

--- a/web/src/main/java/com/navercorp/pinpoint/web/vo/AgentInfo.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/vo/AgentInfo.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.navercorp.pinpoint.common.bo.AgentInfoBo;
 import com.navercorp.pinpoint.common.bo.ServerMetaDataBo;
+import com.navercorp.pinpoint.common.trace.ServiceType;
 
 /**
  * @author HyunGil Jeong
@@ -43,7 +44,7 @@ public class AgentInfo {
     private String hostName;
     private String ip;
     private String ports;
-    private String serviceType;
+    private ServiceType serviceType;
     private int pid;
     private String vmVersion;
     private String agentVersion;
@@ -65,7 +66,7 @@ public class AgentInfo {
         this.hostName = agentInfoBo.getHostName();
         this.ip = agentInfoBo.getIp();
         this.ports = agentInfoBo.getPorts();
-        this.serviceType = agentInfoBo.getServiceType().getName();
+        this.serviceType = agentInfoBo.getServiceType();
         this.pid = agentInfoBo.getPid();
         this.vmVersion = agentInfoBo.getVmVersion();
         this.agentVersion = agentInfoBo.getAgentVersion();
@@ -120,11 +121,11 @@ public class AgentInfo {
         this.ports = ports;
     }
 
-    public String getServiceType() {
+    public ServiceType getServiceType() {
         return serviceType;
     }
 
-    public void setServiceType(String serviceType) {
+    public void setServiceType(ServiceType serviceType) {
         this.serviceType = serviceType;
     }
 
@@ -181,18 +182,7 @@ public class AgentInfo {
         final int prime = 31;
         int result = 1;
         result = prime * result + ((agentId == null) ? 0 : agentId.hashCode());
-        result = prime * result + ((agentVersion == null) ? 0 : agentVersion.hashCode());
-        result = prime * result + ((applicationName == null) ? 0 : applicationName.hashCode());
-        result = prime * result + ((hostName == null) ? 0 : hostName.hashCode());
-        result = prime * result + (int)(initialStartTimestamp ^ (initialStartTimestamp >>> 32));
-        result = prime * result + ((ip == null) ? 0 : ip.hashCode());
-        result = prime * result + pid;
-        result = prime * result + ((ports == null) ? 0 : ports.hashCode());
-        result = prime * result + ((serverMetaData == null) ? 0 : serverMetaData.hashCode());
         result = prime * result + ((serviceType == null) ? 0 : serviceType.hashCode());
-        result = prime * result + (int)(startTimestamp ^ (startTimestamp >>> 32));
-        result = prime * result + ((status == null) ? 0 : status.hashCode());
-        result = prime * result + ((vmVersion == null) ? 0 : vmVersion.hashCode());
         return result;
     }
 
@@ -210,56 +200,10 @@ public class AgentInfo {
                 return false;
         } else if (!agentId.equals(other.agentId))
             return false;
-        if (agentVersion == null) {
-            if (other.agentVersion != null)
-                return false;
-        } else if (!agentVersion.equals(other.agentVersion))
-            return false;
-        if (applicationName == null) {
-            if (other.applicationName != null)
-                return false;
-        } else if (!applicationName.equals(other.applicationName))
-            return false;
-        if (hostName == null) {
-            if (other.hostName != null)
-                return false;
-        } else if (!hostName.equals(other.hostName))
-            return false;
-        if (initialStartTimestamp != other.initialStartTimestamp)
-            return false;
-        if (ip == null) {
-            if (other.ip != null)
-                return false;
-        } else if (!ip.equals(other.ip))
-            return false;
-        if (pid != other.pid)
-            return false;
-        if (ports == null) {
-            if (other.ports != null)
-                return false;
-        } else if (!ports.equals(other.ports))
-            return false;
-        if (serverMetaData == null) {
-            if (other.serverMetaData != null)
-                return false;
-        } else if (!serverMetaData.equals(other.serverMetaData))
-            return false;
         if (serviceType == null) {
             if (other.serviceType != null)
                 return false;
         } else if (!serviceType.equals(other.serviceType))
-            return false;
-        if (startTimestamp != other.startTimestamp)
-            return false;
-        if (status == null) {
-            if (other.status != null)
-                return false;
-        } else if (!status.equals(other.status))
-            return false;
-        if (vmVersion == null) {
-            if (other.vmVersion != null)
-                return false;
-        } else if (!vmVersion.equals(other.vmVersion))
             return false;
         return true;
     }

--- a/web/src/main/webapp/features/nodeInfoDetails/node-info-details.directive.js
+++ b/web/src/main/webapp/features/nodeInfoDetails/node-info-details.directive.js
@@ -95,7 +95,8 @@
                         	var instanceList = scope.serverList[p].instanceList;
                         	for( var p2 in instanceList ) {
                         		scope.serverCount++;
-                        		if ( scope.agentHistogram[instanceList[p2].name].Error > 0 ) {
+                        		if (( scope.agentHistogram[instanceList[p2].name] ) &&
+                        		    ( scope.agentHistogram[instanceList[p2].name].Error > 0 )) {
                         			scope.errorServerCount++;
                         		}
                         	}

--- a/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/ServerInstanceListTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/ServerInstanceListTest.java
@@ -18,14 +18,14 @@ package com.navercorp.pinpoint.web.applicationmap;
 
 import com.navercorp.pinpoint.common.bo.AgentInfoBo;
 import com.navercorp.pinpoint.common.trace.ServiceType;
+import com.navercorp.pinpoint.web.vo.AgentInfo;
+
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-
-import static org.junit.Assert.*;
 
 /**
  * @author emeroad
@@ -35,15 +35,15 @@ public class ServerInstanceListTest {
     @Test
     public void testGetAgentIdList() throws Exception {
 
-        AgentInfoBo agentInfoBo1 = createAgentInfo("agentId1", "testHost");
-        AgentInfoBo agentInfoBo2 = createAgentInfo("agentId2", "testHost");
+        AgentInfo agentInfo1 = createAgentInfo("agentId1", "testHost");
+        AgentInfo agentInfo2 = createAgentInfo("agentId2", "testHost");
 
-        Set<AgentInfoBo> agentInfoBoSet = new HashSet<AgentInfoBo>();
-        agentInfoBoSet.add(agentInfoBo1);
-        agentInfoBoSet.add(agentInfoBo2);
+        Set<AgentInfo> agentInfoSet = new HashSet<AgentInfo>();
+        agentInfoSet.add(agentInfo1);
+        agentInfoSet.add(agentInfo2);
 
         ServerBuilder builder = new ServerBuilder();
-        builder.addAgentInfo(agentInfoBoSet);
+        builder.addAgentInfo(agentInfoSet);
         ServerInstanceList serverInstanceList = builder.build();
         List<String> agentIdList = serverInstanceList.getAgentIdList();
 
@@ -52,7 +52,7 @@ public class ServerInstanceListTest {
         Assert.assertEquals(agentIdList.get(1), "agentId2");
     }
 
-    public static AgentInfoBo createAgentInfo(String agentId, String hostName) {
+    public static AgentInfo createAgentInfo(String agentId, String hostName) {
         AgentInfoBo.Builder agentInfoBuilder = new AgentInfoBo.Builder();
         agentInfoBuilder.setAgentId(agentId);
 
@@ -63,6 +63,6 @@ public class ServerInstanceListTest {
 
         agentInfoBuilder.setHostName(hostName);
 
-        return agentInfoBuilder.build();
+        return new AgentInfo(agentInfoBuilder.build());
     }
 }

--- a/web/src/test/java/com/navercorp/pinpoint/web/view/ServerInstanceListSerializerTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/view/ServerInstanceListSerializerTest.java
@@ -19,14 +19,15 @@ package com.navercorp.pinpoint.web.view;
 import java.util.HashSet;
 
 import com.navercorp.pinpoint.web.applicationmap.ServerInstanceListTest;
+
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.databind.ObjectWriter;
-import com.navercorp.pinpoint.common.bo.AgentInfoBo;
 import com.navercorp.pinpoint.web.applicationmap.ServerBuilder;
 import com.navercorp.pinpoint.web.applicationmap.ServerInstanceList;
+import com.navercorp.pinpoint.web.vo.AgentInfo;
 
 
 /**
@@ -42,13 +43,13 @@ public class ServerInstanceListSerializerTest {
         mapper.afterPropertiesSet();
 
 
-        AgentInfoBo agentInfoBo = ServerInstanceListTest.createAgentInfo("agentId1", "testHost");
+        AgentInfo agentInfo = ServerInstanceListTest.createAgentInfo("agentId1", "testHost");
 
-        HashSet<AgentInfoBo> agentInfoBoSet = new HashSet<AgentInfoBo>();
-        agentInfoBoSet.add(agentInfoBo);
+        HashSet<AgentInfo> agentInfoSet = new HashSet<AgentInfo>();
+        agentInfoSet.add(agentInfo);
 
         ServerBuilder builder = new ServerBuilder();
-        builder.addAgentInfo(agentInfoBoSet);
+        builder.addAgentInfo(agentInfoSet);
 
         ServerInstanceList serverInstanceList = builder.build();
         ObjectWriter objectWriter = mapper.writerWithDefaultPrettyPrinter();


### PR DESCRIPTION
Allow agents without transactions to be displayed in the server map as long as they were running at the time of querying. Also add agent status data to be utilized in the server map.