### PR TITLE
Add configuration for tracing SQL bind values

### DIFF
--- a/agent/src/main/resources/pinpoint.config
+++ b/agent/src/main/resources/pinpoint.config
@@ -114,6 +114,8 @@ profiler.tomcat.excludeurl=/aa/test.html, /bb/exclude.html
 profiler.jdbc=true
 # Size of cache. Fixed maximum.
 profiler.jdbc.sqlcachesize=1024
+# trace bindvalues for PreparedStatements
+profiler.jdbc.tracesqlbindvalue=true
 # Maximum bindvalue size.
 profiler.jdbc.maxsqlbindvaluesize=1024
 
@@ -128,6 +130,8 @@ profiler.jdbc.mysql.setautocommit=true
 profiler.jdbc.mysql.commit=true
 # Allow profiling of rollback.
 profiler.jdbc.mysql.rollback=true
+# Trace bindvalues for MySQL PreparedStatements (overrides profiler.jdbc.tracesqlbindvalue)
+#profiler.jdbc.mysql.tracesqlbindvalue=true
 
 #
 # MSSQL Jtds
@@ -140,6 +144,8 @@ profiler.jdbc.jtds.setautocommit=true
 profiler.jdbc.jtds.commit=true
 # Allow profiling of rollback.
 profiler.jdbc.jtds.rollback=true
+# Trace bindvalues for jTDS PreparedStatements (overrides profiler.jdbc.tracesqlbindvalue)
+#profiler.jdbc.jtds.tracesqlbindvalue=true
 
 #
 # Oracle
@@ -152,6 +158,8 @@ profiler.jdbc.oracle.setautocommit=true
 profiler.jdbc.oracle.commit=true
 # Allow profiling of rollback.
 profiler.jdbc.oracle.rollback=true
+# Trace bindvalues for Oracle PreparedStatements (overrides profiler.jdbc.tracesqlbindvalue)
+#profiler.jdbc.oracle.tracesqlbindvalue=true
 
 #
 # CUBRID
@@ -164,6 +172,8 @@ profiler.jdbc.cubrid.setautocommit=true
 profiler.jdbc.cubrid.commit=true
 # Allow profiling of rollback.
 profiler.jdbc.cubrid.rollback=true
+# Trace bindvalues for CUBRID PreparedStatements (overrides profiler.jdbc.tracesqlbindvalue)
+#profiler.jdbc.cubrid.tracesqlbindvalue=true
 
 #
 # DBCP

--- a/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/config/DefaultProfilerConfig.java
+++ b/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/config/DefaultProfilerConfig.java
@@ -106,8 +106,10 @@ public class DefaultProfilerConfig implements ProfilerConfig {
     private boolean traceAgentActiveThread = true;
 
     private int callStackMaxDepth = 512;
-    
+
     private int jdbcSqlCacheSize = 1024;
+    private boolean traceSqlBindValue = false;
+    private int maxSqlBindValueSize = 1024;
 
     private boolean tomcatHidePinpointHeader = true;
     private Filter<String> tomcatExcludeUrlFilter = new SkipFilter<String>();
@@ -275,6 +277,16 @@ public class DefaultProfilerConfig implements ProfilerConfig {
     @Override
     public int getJdbcSqlCacheSize() {
         return jdbcSqlCacheSize;
+    }
+
+    @Override
+    public boolean isTraceSqlBindValue() {
+        return traceSqlBindValue;
+    }
+
+    @Override
+    public int getMaxSqlBindValueSize() {
+        return maxSqlBindValueSize;
     }
 
     @Override
@@ -545,6 +557,7 @@ public class DefaultProfilerConfig implements ProfilerConfig {
         
         // JDBC
         this.jdbcSqlCacheSize = readInt("profiler.jdbc.sqlcachesize", 1024);
+        this.traceSqlBindValue = readBoolean("profiler.jdbc.tracesqlbindvalue", false);
 
         this.tomcatHidePinpointHeader = readBoolean("profiler.tomcat.hidepinpointheader", true);
         final String tomcatExcludeURL = readString("profiler.tomcat.excludeurl", "");
@@ -556,8 +569,8 @@ public class DefaultProfilerConfig implements ProfilerConfig {
 
         final String tomcatExcludeProfileMethod = readString("profiler.tomcat.excludemethod", "");
         if (!tomcatExcludeProfileMethod.isEmpty()) {
-            this.tomcatExcludeProfileMethodFilter = new ExcludeMethodFilter(tomcatExcludeProfileMethod);
         }
+        this.tomcatExcludeProfileMethodFilter = new ExcludeMethodFilter(tomcatExcludeProfileMethod);
 
         /**
          * apache http client 3
@@ -766,6 +779,10 @@ public class DefaultProfilerConfig implements ProfilerConfig {
         builder.append(callStackMaxDepth);
         builder.append(", jdbcSqlCacheSize=");
         builder.append(jdbcSqlCacheSize);
+        builder.append(", traceSqlBindValue=");
+        builder.append(traceSqlBindValue);
+        builder.append(", maxSqlBindValueSize=");
+        builder.append(maxSqlBindValueSize);
         builder.append(", tomcatHidePinpointHeader=");
         builder.append(tomcatHidePinpointHeader);
         builder.append(", tomcatExcludeUrlFilter=");

--- a/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/config/ProfilerConfig.java
+++ b/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/config/ProfilerConfig.java
@@ -59,6 +59,10 @@ public interface ProfilerConfig {
 
     int getJdbcSqlCacheSize();
 
+    boolean isTraceSqlBindValue();
+
+    int getMaxSqlBindValueSize();
+
     boolean isSamplingEnable();
 
     int getSamplingRate();

--- a/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/jdbc/JdbcConfig.java
+++ b/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/jdbc/JdbcConfig.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2015 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.bootstrap.plugin.jdbc;
+
+/**
+ * @author HyunGil Jeong
+ */
+public class JdbcConfig {
+    private final boolean traceSqlBindValue;
+    private final int maxSqlBindValueSize;
+
+    protected JdbcConfig(boolean traceSqlBindValue, int maxSqlBindValue) {
+        this.traceSqlBindValue = traceSqlBindValue;
+        this.maxSqlBindValueSize = maxSqlBindValue;
+    }
+
+    public boolean isTraceSqlBindValue() {
+        return traceSqlBindValue;
+    }
+
+    public int getMaxSqlBindValueSize() {
+        return maxSqlBindValueSize;
+    }
+
+    @Override
+    public String toString() {
+        return "traceSqlBindValue=" + this.traceSqlBindValue + ", maxSqlBindValueSize=" + this.maxSqlBindValueSize;
+    }
+}

--- a/plugins/cubrid-jdbc/src/main/java/com/navercorp/pinpoint/plugin/jdbc/cubrid/CubridConfig.java
+++ b/plugins/cubrid-jdbc/src/main/java/com/navercorp/pinpoint/plugin/jdbc/cubrid/CubridConfig.java
@@ -1,11 +1,11 @@
-/**
+/*
  * Copyright 2014 NAVER Corp.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,22 +15,21 @@
 package com.navercorp.pinpoint.plugin.jdbc.cubrid;
 
 import com.navercorp.pinpoint.bootstrap.config.ProfilerConfig;
+import com.navercorp.pinpoint.bootstrap.plugin.jdbc.JdbcConfig;
 
 /**
  * @author Jongho Moon
- *
  */
-public class CubridConfig {
+public class CubridConfig extends JdbcConfig {
     private final boolean profileSetAutoCommit;
     private final boolean profileCommit;
     private final boolean profileRollback;
-    private final int maxSqlBindValueSize; 
 
     public CubridConfig(ProfilerConfig config) {
+        super(config.readBoolean("profiler.jdbc.cubrid.tracesqlbindvalue", config.isTraceSqlBindValue()), config.getMaxSqlBindValueSize());
         this.profileSetAutoCommit = config.readBoolean("profiler.jdbc.cubrid.setautocommit", false);
         this.profileCommit = config.readBoolean("profiler.jdbc.cubrid.commit", false);
         this.profileRollback = config.readBoolean("profiler.jdbc.cubrid.rollback", false);
-        this.maxSqlBindValueSize = config.readInt("profiler.jdbc.maxsqlbindvaluesize", 1024);
     }
 
     public boolean isProfileSetAutoCommit() {
@@ -44,14 +43,10 @@ public class CubridConfig {
     public boolean isProfileRollback() {
         return profileRollback;
     }
-    
-    public int getMaxSqlBindValueSize() {
-        return maxSqlBindValueSize;
-    }
 
     @Override
     public String toString() {
-        return "CubridConfig [profileSetAutoCommit=" + profileSetAutoCommit + ", profileCommit=" + profileCommit + ", profileRollback=" + profileRollback + ", maxSqlBindValueSize=" + maxSqlBindValueSize + "]";
+        return "CubridConfig [" + super.toString() + ", profileSetAutoCommit=" + profileSetAutoCommit + ", profileCommit=" + profileCommit + ", profileRollback=" + profileRollback + "]";
     }
 
 }

--- a/plugins/cubrid-jdbc/src/main/java/com/navercorp/pinpoint/plugin/jdbc/cubrid/CubridPlugin.java
+++ b/plugins/cubrid-jdbc/src/main/java/com/navercorp/pinpoint/plugin/jdbc/cubrid/CubridPlugin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 NAVER Corp.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -104,7 +104,10 @@ public class CubridPlugin implements ProfilerPlugin, TransformTemplateAware {
                 int maxBindValueSize = config.getMaxSqlBindValueSize();
 
                 target.addScopedInterceptor("com.navercorp.pinpoint.bootstrap.plugin.jdbc.interceptor.PreparedStatementExecuteQueryInterceptor", va(maxBindValueSize), CubridConstants.CUBRID_SCOPE);
-                target.addScopedInterceptor("com.navercorp.pinpoint.bootstrap.plugin.jdbc.interceptor.PreparedStatementBindVariableInterceptor", CubridConstants.CUBRID_SCOPE);
+
+                if (config.isTraceSqlBindValue()) {
+                    target.addScopedInterceptor("com.navercorp.pinpoint.bootstrap.plugin.jdbc.interceptor.PreparedStatementBindVariableInterceptor", CubridConstants.CUBRID_SCOPE);
+                }
 
                 return target.toBytecode();
             }

--- a/plugins/jtds/src/main/java/com/navercorp/pinpoint/plugin/jdbc/jtds/JtdsConfig.java
+++ b/plugins/jtds/src/main/java/com/navercorp/pinpoint/plugin/jdbc/jtds/JtdsConfig.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 NAVER Corp.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,22 +15,21 @@
 package com.navercorp.pinpoint.plugin.jdbc.jtds;
 
 import com.navercorp.pinpoint.bootstrap.config.ProfilerConfig;
+import com.navercorp.pinpoint.bootstrap.plugin.jdbc.JdbcConfig;
 
 /**
  * @author Jongho Moon
- *
  */
-public class JtdsConfig {
+public class JtdsConfig extends JdbcConfig {
     private final boolean profileSetAutoCommit;
     private final boolean profileCommit;
     private final boolean profileRollback;
-    private final int maxSqlBindValueSize; 
 
     public JtdsConfig(ProfilerConfig config) {
+        super(config.readBoolean("profiler.jdbc.jtds.tracesqlbindvalue", config.isTraceSqlBindValue()), config.getMaxSqlBindValueSize());
         this.profileSetAutoCommit = config.readBoolean("profiler.jdbc.jtds.setautocommit", false);
         this.profileCommit = config.readBoolean("profiler.jdbc.jtds.commit", false);
         this.profileRollback = config.readBoolean("profiler.jdbc.jtds.rollback", false);
-        this.maxSqlBindValueSize = config.readInt("profiler.jdbc.maxsqlbindvaluesize", 1024);
     }
 
     public boolean isProfileSetAutoCommit() {
@@ -44,13 +43,9 @@ public class JtdsConfig {
     public boolean isProfileRollback() {
         return profileRollback;
     }
-    
-    public int getMaxSqlBindValueSize() {
-        return maxSqlBindValueSize;
-    }
-    
+
     @Override
     public String toString() {
-        return "JtdsConfig [profileSetAutoCommit=" + profileSetAutoCommit + ", profileCommit=" + profileCommit + ", profileRollback=" + profileRollback + ", maxSqlBindValueSize=" + maxSqlBindValueSize + "]";
+        return "JtdsConfig [" + super.toString() + ", profileSetAutoCommit=" + profileSetAutoCommit + ", profileCommit=" + profileCommit + ", profileRollback=" + profileRollback + "]";
     }
 }

--- a/plugins/jtds/src/main/java/com/navercorp/pinpoint/plugin/jdbc/jtds/JtdsPlugin.java
+++ b/plugins/jtds/src/main/java/com/navercorp/pinpoint/plugin/jdbc/jtds/JtdsPlugin.java
@@ -1,11 +1,11 @@
-/**
+/*
  * Copyright 2014 NAVER Corp.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -30,7 +30,6 @@ import static com.navercorp.pinpoint.common.util.VarArgs.va;
 
 /**
  * @author Jongho Moon
- *
  */
 public class JtdsPlugin implements ProfilerPlugin, TransformTemplateAware {
 
@@ -39,17 +38,16 @@ public class JtdsPlugin implements ProfilerPlugin, TransformTemplateAware {
     @Override
     public void setup(ProfilerPluginSetupContext context) {
         JtdsConfig config = new JtdsConfig(context.getConfig());
-        
+
         addConnectionTransformer(config);
         addDriverTransformer();
         addPreparedStatementTransformer(config);
         addStatementTransformer();
     }
 
-    
     private void addConnectionTransformer(final JtdsConfig config) {
         TransformCallback transformer = new TransformCallback() {
-            
+
             @Override
             public byte[] doInTransform(Instrumentor instrumentor, ClassLoader loader, String className, Class<?> classBeingRedefined, ProtectionDomain protectionDomain, byte[] classfileBuffer) throws InstrumentException {
                 InstrumentClass target = instrumentor.getInstrumentClass(loader, className, classfileBuffer);
@@ -58,74 +56,77 @@ public class JtdsPlugin implements ProfilerPlugin, TransformTemplateAware {
                 target.addScopedInterceptor("com.navercorp.pinpoint.bootstrap.plugin.jdbc.interceptor.ConnectionCloseInterceptor", JtdsConstants.JTDS_SCOPE);
                 target.addScopedInterceptor("com.navercorp.pinpoint.bootstrap.plugin.jdbc.interceptor.StatementCreateInterceptor", JtdsConstants.JTDS_SCOPE);
                 target.addScopedInterceptor("com.navercorp.pinpoint.bootstrap.plugin.jdbc.interceptor.PreparedStatementCreateInterceptor", JtdsConstants.JTDS_SCOPE);
-                
+
                 if (config.isProfileSetAutoCommit()) {
                     target.addScopedInterceptor("com.navercorp.pinpoint.bootstrap.plugin.jdbc.interceptor.TransactionSetAutoCommitInterceptor", JtdsConstants.JTDS_SCOPE);
                 }
-                
+
                 if (config.isProfileCommit()) {
                     target.addScopedInterceptor("com.navercorp.pinpoint.bootstrap.plugin.jdbc.interceptor.TransactionCommitInterceptor", JtdsConstants.JTDS_SCOPE);
                 }
-                
+
                 if (config.isProfileRollback()) {
                     target.addScopedInterceptor("com.navercorp.pinpoint.bootstrap.plugin.jdbc.interceptor.TransactionRollbackInterceptor", JtdsConstants.JTDS_SCOPE);
                 }
-                
+
                 return target.toBytecode();
             }
         };
-        
+
         transformTemplate.transform("net.sourceforge.jtds.jdbc.ConnectionJDBC2", transformer);
         transformTemplate.transform("net.sourceforge.jtds.jdbc.JtdsConnection", transformer);
     }
-    
+
     private void addDriverTransformer() {
         transformTemplate.transform("net.sourceforge.jtds.jdbc.Driver", new TransformCallback() {
-            
+
             @Override
             public byte[] doInTransform(Instrumentor instrumentor, ClassLoader loader, String className, Class<?> classBeingRedefined, ProtectionDomain protectionDomain, byte[] classfileBuffer) throws InstrumentException {
                 InstrumentClass target = instrumentor.getInstrumentClass(loader, className, classfileBuffer);
 
                 target.addScopedInterceptor("com.navercorp.pinpoint.bootstrap.plugin.jdbc.interceptor.DriverConnectInterceptor", va(new JtdsJdbcUrlParser()), JtdsConstants.JTDS_SCOPE, ExecutionPolicy.ALWAYS);
-                
+
                 return target.toBytecode();
             }
         });
     }
-    
+
     private void addPreparedStatementTransformer(final JtdsConfig config) {
         transformTemplate.transform("net.sourceforge.jtds.jdbc.JtdsPreparedStatement", new TransformCallback() {
-            
+
             @Override
             public byte[] doInTransform(Instrumentor instrumentor, ClassLoader loader, String className, Class<?> classBeingRedefined, ProtectionDomain protectionDomain, byte[] classfileBuffer) throws InstrumentException {
                 InstrumentClass target = instrumentor.getInstrumentClass(loader, className, classfileBuffer);
-                
+
                 target.addField("com.navercorp.pinpoint.bootstrap.plugin.jdbc.DatabaseInfoAccessor");
                 target.addField("com.navercorp.pinpoint.bootstrap.plugin.jdbc.ParsingResultAccessor");
                 target.addField("com.navercorp.pinpoint.bootstrap.plugin.jdbc.BindValueAccessor");
-                
+
                 int maxBindValueSize = config.getMaxSqlBindValueSize();
 
                 target.addScopedInterceptor("com.navercorp.pinpoint.bootstrap.plugin.jdbc.interceptor.PreparedStatementExecuteQueryInterceptor", va(maxBindValueSize), JtdsConstants.JTDS_SCOPE);
-                target.addScopedInterceptor("com.navercorp.pinpoint.bootstrap.plugin.jdbc.interceptor.PreparedStatementBindVariableInterceptor", JtdsConstants.JTDS_SCOPE);
-                
+
+                if (config.isTraceSqlBindValue()) {
+                    target.addScopedInterceptor("com.navercorp.pinpoint.bootstrap.plugin.jdbc.interceptor.PreparedStatementBindVariableInterceptor", JtdsConstants.JTDS_SCOPE);
+                }
+
                 return target.toBytecode();
             }
         });
     }
-    
+
     private void addStatementTransformer() {
         transformTemplate.transform("net.sourceforge.jtds.jdbc.JtdsStatement", new TransformCallback() {
-            
+
             @Override
             public byte[] doInTransform(Instrumentor instrumentor, ClassLoader loader, String className, Class<?> classBeingRedefined, ProtectionDomain protectionDomain, byte[] classfileBuffer) throws InstrumentException {
                 InstrumentClass target = instrumentor.getInstrumentClass(loader, className, classfileBuffer);
-                
+
                 target.addField("com.navercorp.pinpoint.bootstrap.plugin.jdbc.DatabaseInfoAccessor");
 
                 target.addScopedInterceptor("com.navercorp.pinpoint.bootstrap.plugin.jdbc.interceptor.StatementExecuteQueryInterceptor", JtdsConstants.JTDS_SCOPE);
                 target.addScopedInterceptor("com.navercorp.pinpoint.bootstrap.plugin.jdbc.interceptor.StatementExecuteUpdateInterceptor", JtdsConstants.JTDS_SCOPE);
-                
+
                 return target.toBytecode();
             }
         });

--- a/plugins/mysql-jdbc/src/main/java/com/navercorp/pinpoint/plugin/jdbc/mysql/MySqlConfig.java
+++ b/plugins/mysql-jdbc/src/main/java/com/navercorp/pinpoint/plugin/jdbc/mysql/MySqlConfig.java
@@ -1,11 +1,11 @@
-/**
+/*
  * Copyright 2014 NAVER Corp.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,22 +15,21 @@
 package com.navercorp.pinpoint.plugin.jdbc.mysql;
 
 import com.navercorp.pinpoint.bootstrap.config.ProfilerConfig;
+import com.navercorp.pinpoint.bootstrap.plugin.jdbc.JdbcConfig;
 
 /**
  * @author Jongho Moon
- *
  */
-public class MySqlConfig {
+public class MySqlConfig extends JdbcConfig {
     private final boolean profileSetAutoCommit;
     private final boolean profileCommit;
     private final boolean profileRollback;
-    private final int maxSqlBindValueSize; 
 
     public MySqlConfig(ProfilerConfig config) {
+        super(config.readBoolean("profiler.jdbc.mysql.tracesqlbindvalue", config.isTraceSqlBindValue()), config.getMaxSqlBindValueSize());
         this.profileSetAutoCommit = config.readBoolean("profiler.jdbc.mysql.setautocommit", false);
         this.profileCommit = config.readBoolean("profiler.jdbc.mysql.commit", false);
         this.profileRollback = config.readBoolean("profiler.jdbc.mysql.rollback", false);
-        this.maxSqlBindValueSize = config.readInt("profiler.jdbc.maxsqlbindvaluesize", 1024);
     }
 
     public boolean isProfileSetAutoCommit() {
@@ -44,13 +43,9 @@ public class MySqlConfig {
     public boolean isProfileRollback() {
         return profileRollback;
     }
-    
-    public int getMaxSqlBindValueSize() {
-        return maxSqlBindValueSize;
-    }
-    
+
     @Override
     public String toString() {
-        return "MySqlConfig [profileSetAutoCommit=" + profileSetAutoCommit + ", profileCommit=" + profileCommit + ", profileRollback=" + profileRollback + ", maxSqlBindValueSize=" + maxSqlBindValueSize + "]";
+        return "MySqlConfig [" + super.toString() + ", profileSetAutoCommit=" + profileSetAutoCommit + ", profileCommit=" + profileCommit + ", profileRollback=" + profileRollback + "]";
     }
 }

--- a/plugins/oracle-jdbc/src/main/java/com/navercorp/pinpoint/plugin/jdbc/oracle/OracleConfig.java
+++ b/plugins/oracle-jdbc/src/main/java/com/navercorp/pinpoint/plugin/jdbc/oracle/OracleConfig.java
@@ -1,11 +1,11 @@
-/**
+/*
  * Copyright 2014 NAVER Corp.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,22 +15,21 @@
 package com.navercorp.pinpoint.plugin.jdbc.oracle;
 
 import com.navercorp.pinpoint.bootstrap.config.ProfilerConfig;
+import com.navercorp.pinpoint.bootstrap.plugin.jdbc.JdbcConfig;
 
 /**
  * @author Jongho Moon
- *
  */
-public class OracleConfig {
+public class OracleConfig extends JdbcConfig {
     private final boolean profileSetAutoCommit;
     private final boolean profileCommit;
     private final boolean profileRollback;
-    private final int maxSqlBindValueSize; 
 
     public OracleConfig(ProfilerConfig config) {
+        super(config.readBoolean("profiler.jdbc.oracle.tracesqlbindvalue", config.isTraceSqlBindValue()), config.getMaxSqlBindValueSize());
         this.profileSetAutoCommit = config.readBoolean("profiler.jdbc.oracle.setautocommit", false);
         this.profileCommit = config.readBoolean("profiler.jdbc.oracle.commit", false);
         this.profileRollback = config.readBoolean("profiler.jdbc.oracle.rollback", false);
-        this.maxSqlBindValueSize = config.readInt("profiler.jdbc.maxsqlbindvaluesize", 1024);
     }
 
     public boolean isProfileSetAutoCommit() {
@@ -44,13 +43,9 @@ public class OracleConfig {
     public boolean isProfileRollback() {
         return profileRollback;
     }
-    
-    public int getMaxSqlBindValueSize() {
-        return maxSqlBindValueSize;
-    }
 
     @Override
     public String toString() {
-        return "OracleConfig [profileSetAutoCommit=" + profileSetAutoCommit + ", profileCommit=" + profileCommit + ", profileRollback=" + profileRollback + ", maxSqlBindValueSize=" + maxSqlBindValueSize + "]";
+        return "OracleConfig [" + super.toString() + ", profileSetAutoCommit=" + profileSetAutoCommit + ", profileCommit=" + profileCommit + ", profileRollback=" + profileRollback + "]";
     }
 }


### PR DESCRIPTION
Adds configuration to enable/disable tracing SQL bind values with a single global option that may be overridden on a per-plugin basis.