### PR TITLE
Improve AgentInfoSenderTest client server comm timing

### DIFF
--- a/rpc/src/main/java/com/navercorp/pinpoint/rpc/util/ClientFactoryUtils.java
+++ b/rpc/src/main/java/com/navercorp/pinpoint/rpc/util/ClientFactoryUtils.java
@@ -47,7 +47,7 @@ public final class ClientFactoryUtils {
                 LOGGER.info("tcp connect success. remote:{}", connectAddress);
                 return pinpointClient;
             } catch (PinpointSocketException e) {
-                LOGGER.warn("tcp connect fail. retmoe:{} try reconnect, retryCount:{}", connectAddress, i);
+                LOGGER.warn("tcp connect fail. remote:{} try reconnect, retryCount:{}", connectAddress, i);
             }
         }
         LOGGER.warn("change background tcp connect mode remote:{} ", connectAddress);


### PR DESCRIPTION
Test modified to reduce potential timing issues when client connects/reconnects to server while the server starts, restarts, and shutdowns.
Also fixed a small typo.