### PR TITLE
Exclude agents that have been down for over a week when getting real time active thread information

### DIFF
--- a/web/src/main/java/com/navercorp/pinpoint/web/service/AgentInfoService.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/AgentInfoService.java
@@ -38,6 +38,8 @@ public interface AgentInfoService {
 
     Set<AgentInfo> getAgentsByApplicationName(String applicationName, long timestamp);
 
+    Set<AgentInfo> getAgentsByApplicationName(String applicationName, long timestamp, long timeDiff);
+
     AgentInfo getAgentInfo(String agentId, long timestamp);
 
     AgentStatus getAgentStatus(String agentId, long timestamp);

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/AgentService.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/AgentService.java
@@ -42,7 +42,8 @@ public interface AgentService {
     AgentInfo getAgentInfo(String applicationName, String agentId, long startTimeStamp);
     AgentInfo getAgentInfo(String applicationName, String agentId, long startTimeStamp, boolean checkDB);
 
-    List<AgentInfo> getAgentInfoList(String applicationName);
+    List<AgentInfo> getRecentAgentInfoList(String applicationName);
+    List<AgentInfo> getRecentAgentInfoList(String applicationName, long timeDiff);
 
     boolean isConnected(AgentInfo agentInfo);
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/AgentServiceImpl.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/AgentServiceImpl.java
@@ -51,6 +51,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.*;
+import java.util.concurrent.TimeUnit;
 
 /**
  * @author HyunGil Jeong
@@ -60,6 +61,9 @@ import java.util.*;
 public class AgentServiceImpl implements AgentService {
 
     private static final long DEFAULT_FUTURE_TIMEOUT = 3000;
+
+    private static final long DEFAULT_TIME_DIFF_DAYS = 7;
+    private static final long DEFAULT_TIME_DIFF_MS = TimeUnit.MILLISECONDS.convert(DEFAULT_TIME_DIFF_DAYS, TimeUnit.DAYS);
 
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
@@ -135,12 +139,17 @@ public class AgentServiceImpl implements AgentService {
     }
 
     @Override
-    public List<AgentInfo> getAgentInfoList(String applicationName) {
+    public List<AgentInfo> getRecentAgentInfoList(String applicationName) {
+        return this.getRecentAgentInfoList(applicationName, DEFAULT_TIME_DIFF_MS);
+    }
+
+    @Override
+    public List<AgentInfo> getRecentAgentInfoList(String applicationName, long timeDiff) {
         List<AgentInfo> agentInfoList = new ArrayList<>();
 
         long currentTime = System.currentTimeMillis();
 
-        Set<AgentInfo> agentInfos = agentInfoService.getAgentsByApplicationName(applicationName, currentTime);
+        Set<AgentInfo> agentInfos = agentInfoService.getAgentsByApplicationName(applicationName, currentTime, timeDiff);
         for (AgentInfo agentInfo : agentInfos) {
             ListUtils.addIfValueNotNull(agentInfoList, agentInfo);
         }

--- a/web/src/main/java/com/navercorp/pinpoint/web/websocket/ActiveThreadCountResponseAggregator.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/websocket/ActiveThreadCountResponseAggregator.java
@@ -110,7 +110,7 @@ public class ActiveThreadCountResponseAggregator implements PinpointWebSocketRes
 
         logger.info("addWebSocketSession. applicationName:{}, webSocketSession:{}", applicationName, webSocketSession);
 
-        List<AgentInfo> agentInfoList = agentService.getAgentInfoList(applicationName);
+        List<AgentInfo> agentInfoList = agentService.getRecentAgentInfoList(applicationName);
         synchronized (workerManagingLock) {
             if (isStopped) {
                 return;

--- a/web/src/main/java/com/navercorp/pinpoint/web/websocket/WorkerActiveManager.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/websocket/WorkerActiveManager.java
@@ -148,7 +148,7 @@ public class WorkerActiveManager {
             logger.info("AgentCheckTimerTask started.");
 
             try {
-                List<AgentInfo> agentInfoList = agentService.getAgentInfoList(applicationName);
+                List<AgentInfo> agentInfoList = agentService.getRecentAgentInfoList(applicationName);
                 for (AgentInfo agentInfo : agentInfoList) {
                     String agentId = agentInfo.getAgentId();
                     if (defaultAgentIdList.contains(agentId)) {


### PR DESCRIPTION
This adds a time buffer (currently a week) when querying agents for the real time active thread chart to filter out agents that have been dead for too long.

Closes #1318 