### PR TITLE
Add default hbase parallel scanning options

### DIFF
--- a/web/src/main/resources/applicationContext-hbase.xml
+++ b/web/src/main/resources/applicationContext-hbase.xml
@@ -35,9 +35,9 @@
     <bean id="hbaseTemplate" class="com.navercorp.pinpoint.common.hbase.HbaseTemplate2">
         <property name="configuration" ref="hbaseConfiguration"/>
         <property name="tableFactory" ref="connectionFactory"/>
-        <property name="enableParallelScan" value="${hbase.client.parallel.scan.enable}"/>
-        <property name="maxThreads" value="${hbase.client.parallel.scan.maxthreads}"/>
-        <property name="maxThreadsPerParallelScan" value="${hbase.client.parallel.scan.maxthreadsperscan}"/>
+        <property name="enableParallelScan" value="${hbase.client.parallel.scan.enable:false}"/>
+        <property name="maxThreads" value="${hbase.client.parallel.scan.maxthreads:16}"/>
+        <property name="maxThreadsPerParallelScan" value="${hbase.client.parallel.scan.maxthreadsperscan:4}"/>
     </bean>
     
     <bean id="hBaseAdminTemplate" class="com.navercorp.pinpoint.common.hbase.HBaseAdminTemplate" destroy-method="close">


### PR DESCRIPTION
For cases where the options are not present in *hbase.properties*.