### PR TITLE
Add APIs for detecting inactive and duplicate agents

### DIFF
--- a/web/src/main/java/com/navercorp/pinpoint/web/controller/AdminController.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/controller/AdminController.java
@@ -26,6 +26,9 @@ import org.springframework.web.bind.annotation.ResponseBody;
 
 import com.navercorp.pinpoint.web.service.AdminService;
 
+import java.util.List;
+import java.util.Map;
+
 /**
  * @author netspider
  * @author HyunGil Jeong
@@ -65,6 +68,27 @@ public class AdminController {
             logger.error("error while removing agentId", e);
             return e.getMessage();
         }
+    }
+
+    @RequestMapping(value = "/agentIdMap")
+    @ResponseBody
+    public Map<String, List<String>> agentIdMap() {
+        return this.adminService.getAgentIdMap();
+    }
+
+    @RequestMapping(value = "/duplicateAgentIdMap")
+    @ResponseBody
+    public Map<String, List<String>> duplicateAgentIdMap() {
+        return this.adminService.getDuplicateAgentIdMap();
+    }
+
+    @RequestMapping(value = "/getInactiveAgents")
+    @ResponseBody
+    public Map<String, List<String>> getInactiveAgents(
+            @RequestParam(value = "applicationName", required = true) String applicationName,
+            @RequestParam(value = "durationDays", defaultValue = "30") int durationDays) {
+        logger.info("get inactive agents - applicationName: [{}], duration: {} days.", applicationName, durationDays);
+        return this.adminService.getInactiveAgents(applicationName, durationDays);
     }
 
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/dao/AgentStatDao.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/dao/AgentStatDao.java
@@ -28,4 +28,6 @@ public interface AgentStatDao {
 
     List<AgentStat> scanAgentStatList(String agentId, Range range);
 
+    boolean agentStatExists(String agentId, Range range);
+
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/AdminService.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/AdminService.java
@@ -16,6 +16,9 @@
 
 package com.navercorp.pinpoint.web.service;
 
+import java.util.List;
+import java.util.Map;
+
 /**
  * @author netspider
  * @author HyunGil Jeong
@@ -25,5 +28,11 @@ public interface AdminService {
     void removeApplicationName(String applicationName);
 
     void removeAgentId(String applicationName, String agentId);
-    
+
+    Map<String, List<String>> getAgentIdMap();
+
+    Map<String, List<String>> getDuplicateAgentIdMap();
+
+    Map<String, List<String>> getInactiveAgents(String applicationName, int durationDays);
+
 }

--- a/web/src/test/java/com/navercorp/pinpoint/web/alarm/AlarmPartitionerTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/alarm/AlarmPartitionerTest.java
@@ -26,7 +26,6 @@ import org.junit.Test;
 import org.springframework.batch.item.ExecutionContext;
 
 import com.navercorp.pinpoint.common.trace.ServiceType;
-import com.navercorp.pinpoint.web.alarm.AlarmPartitioner;
 import com.navercorp.pinpoint.web.dao.ApplicationIndexDao;
 import com.navercorp.pinpoint.web.vo.Application;
 
@@ -55,7 +54,7 @@ public class AlarmPartitionerTest {
                 
                 return apps;
             }
-            
+
             @Override
             public List<String> selectAgentIds(String applicationName) {
                 return null;

--- a/web/src/test/java/com/navercorp/pinpoint/web/alarm/checker/GcCountCheckerTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/alarm/checker/GcCountCheckerTest.java
@@ -53,6 +53,11 @@ public class GcCountCheckerTest {
                 
                 return agentStatList;
             }
+
+            @Override
+            public boolean agentStatExists(String agentId, Range range) {
+                return true;
+            }
         };
         
         applicationIndexDao = new ApplicationIndexDao() {

--- a/web/src/test/java/com/navercorp/pinpoint/web/alarm/checker/HeapUsageRateCheckerTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/alarm/checker/HeapUsageRateCheckerTest.java
@@ -29,8 +29,6 @@ import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.web.alarm.CheckerCategory;
 import com.navercorp.pinpoint.web.alarm.DataCollectorFactory;
 import com.navercorp.pinpoint.web.alarm.DataCollectorFactory.DataCollectorCategory;
-import com.navercorp.pinpoint.web.alarm.checker.AgentChecker;
-import com.navercorp.pinpoint.web.alarm.checker.HeapUsageRateChecker;
 import com.navercorp.pinpoint.web.alarm.collector.AgentStatDataCollector;
 import com.navercorp.pinpoint.web.alarm.vo.Rule;
 import com.navercorp.pinpoint.web.dao.AgentStatDao;
@@ -65,6 +63,11 @@ public class HeapUsageRateCheckerTest {
                 }
                 
                 return agentStatList;
+            }
+
+            @Override
+            public boolean agentStatExists(String agentId, Range range) {
+                return true;
             }
         };
         

--- a/web/src/test/java/com/navercorp/pinpoint/web/alarm/checker/JvmCpuUsageRateCheckerTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/alarm/checker/JvmCpuUsageRateCheckerTest.java
@@ -28,8 +28,6 @@ import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.web.alarm.CheckerCategory;
 import com.navercorp.pinpoint.web.alarm.DataCollectorFactory;
 import com.navercorp.pinpoint.web.alarm.DataCollectorFactory.DataCollectorCategory;
-import com.navercorp.pinpoint.web.alarm.checker.AgentChecker;
-import com.navercorp.pinpoint.web.alarm.checker.JvmCpuUsageRateChecker;
 import com.navercorp.pinpoint.web.alarm.collector.AgentStatDataCollector;
 import com.navercorp.pinpoint.web.alarm.vo.Rule;
 import com.navercorp.pinpoint.web.dao.AgentStatDao;
@@ -62,6 +60,11 @@ public class JvmCpuUsageRateCheckerTest {
                 }
                 
                 return agentStatList;
+            }
+
+            @Override
+            public boolean agentStatExists(String agentId, Range range) {
+                return true;
             }
         };
         


### PR DESCRIPTION
Adds the following APIs:
1. `/agentIdMap.pinpoint` : Returns the mapping of agent ids and application names.
2. `/duplicateAgentIdMap.pinpoint` : Identical to above except that this returns the agent ids that are mapped to more than 1 application names.
3. `getInactiveAgents.pinpoint` : Returns the list of agents for the given application that does not have agent stat data for longer than the given duration in days.

Resolves #1462 

@emeroad 