### PR TITLE
#1362 Make scanner creation run parallel

### DIFF
--- a/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/parallel/ScanTask.java
+++ b/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/parallel/ScanTask.java
@@ -93,7 +93,7 @@ public class ScanTask implements Runnable {
             this.resultQueue.clear();
             this.resultQueue.offer(END_RESULT);
         } finally {
-            HbaseUtils.releaseTable(this.tableName, table);
+            HbaseUtils.releaseTable(this.tableName, table, this.tableFactory);
         }
     }
 


### PR DESCRIPTION
include tableFactory object when to execute releaseTable method.