### PR TITLE
Modified Hbase version to 1.0.3 to fix docker:build error.

### DIFF
--- a/hbase/pom.xml
+++ b/hbase/pom.xml
@@ -25,8 +25,8 @@
                     <entryPoint>/opt/hbase/hbase-$HBASE_VERSION/bin/hbase master start</entryPoint>
                     <env>
                         <JAVA_HOME>/usr/lib/jvm/java-8-openjdk-amd64</JAVA_HOME>
-                        <HBASE_VERSION>1.0.2</HBASE_VERSION>
-                        <HBASE_HOME>/opt/hbase/hbase-1.0.2</HBASE_HOME>
+                        <HBASE_VERSION>1.0.3</HBASE_VERSION>
+                        <HBASE_HOME>/opt/hbase/hbase-1.0.3</HBASE_HOME>
                     </env>
                     <exposes>
                         <expose>2181</expose>


### PR DESCRIPTION
There  is no Hbase 1.0.2 from apache.mirrors.pair.com/hbase.