### PR TITLE
Support the async put API provided by HTableMultiplexer to improve th…

### DIFF
--- a/collector/src/main/java/com/navercorp/pinpoint/collector/dao/hbase/HbaseAgentStatDao.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/dao/hbase/HbaseAgentStatDao.java
@@ -62,7 +62,11 @@ public class HbaseAgentStatDao implements AgentStatDao {
             throw new NullPointerException("agentStat must not be null");
         }
         Put put = createPut(agentStat);
-        hbaseTemplate.put(AGENT_STAT, put);
+
+        boolean success = hbaseTemplate.asyncPut(AGENT_STAT, put);
+        if (!success) {
+            hbaseTemplate.put(AGENT_STAT, put);
+        }
     }
 
     private Put createPut(TAgentStat agentStat) {

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/dao/hbase/HbaseHostApplicationMapDao.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/dao/hbase/HbaseHostApplicationMapDao.java
@@ -26,7 +26,6 @@ import com.navercorp.pinpoint.common.hbase.HbaseOperations2;
 import com.navercorp.pinpoint.common.util.TimeSlot;
 import com.navercorp.pinpoint.common.util.TimeUtils;
 import com.sematext.hbase.wd.AbstractRowKeyDistributor;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -100,16 +99,10 @@ public class HbaseHostApplicationMapDao implements HostApplicationMapDao {
         byte[] columnName = createColumnName(host, bindApplicationName, bindServiceType);
 
         try {
-            boolean success = hbaseTemplate.asyncPut(HBaseTables.HOST_APPLICATION_MAP_VER2, rowKey, HBaseTables.HOST_APPLICATION_MAP_VER2_CF_MAP, columnName, null);
-            if (!success) {
-                hbaseTemplate.put(HBaseTables.HOST_APPLICATION_MAP_VER2, rowKey, HBaseTables.HOST_APPLICATION_MAP_VER2_CF_MAP, columnName, null);
-            }
+            hbaseTemplate.put(HBaseTables.HOST_APPLICATION_MAP_VER2, rowKey, HBaseTables.HOST_APPLICATION_MAP_VER2_CF_MAP, columnName, null);
         } catch (Exception ex) {
             logger.warn("retry one. Caused:{}", ex.getCause(), ex);
-            boolean success = hbaseTemplate.asyncPut(HBaseTables.HOST_APPLICATION_MAP_VER2, rowKey, HBaseTables.HOST_APPLICATION_MAP_VER2_CF_MAP, columnName, null);
-            if (!success) {
-                hbaseTemplate.put(HBaseTables.HOST_APPLICATION_MAP_VER2, rowKey, HBaseTables.HOST_APPLICATION_MAP_VER2_CF_MAP, columnName, null);
-            }
+            hbaseTemplate.put(HBaseTables.HOST_APPLICATION_MAP_VER2, rowKey, HBaseTables.HOST_APPLICATION_MAP_VER2_CF_MAP, columnName, null);
         }
     }
 

--- a/collector/src/main/resources/applicationContext-hbase.xml
+++ b/collector/src/main/resources/applicationContext-hbase.xml
@@ -52,7 +52,7 @@
         <constructor-arg ref="hbaseConfiguration"/>
     </bean>
 
-    <bean id="hbaseTemplate" class="com.navercorp.pinpoint.common.hbase.HbaseTemplate2">
+    <bean id="hbaseTemplate" class="com.navercorp.pinpoint.common.hbase.HbaseTemplate2" destroy-method="destroy">
         <property name="configuration" ref="hbaseConfiguration"/>
         <property name="tableFactory" ref="connectionFactory"/>
         <property name="asyncOperation" ref="asyncOperation"/>

--- a/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/DisabledHBaseAsyncOperation.java
+++ b/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/DisabledHBaseAsyncOperation.java
@@ -10,6 +10,13 @@ import java.util.List;
  */
 public class DisabledHBaseAsyncOperation implements HBaseAsyncOperation {
 
+    static final DisabledHBaseAsyncOperation INSTANCE = new DisabledHBaseAsyncOperation();
+
+    @Override
+    public boolean isAvailable() {
+        return false;
+    }
+
     @Override
     public boolean put(TableName tableName, Put put) {
         return false;
@@ -18,6 +25,11 @@ public class DisabledHBaseAsyncOperation implements HBaseAsyncOperation {
     @Override
     public List<Put> put(TableName tableName, List<Put> puts) {
         return puts;
+    }
+
+    @Override
+    public Long getCurrentPutOpsCount() {
+        return 0L;
     }
 
 }

--- a/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/HBaseAccessException.java
+++ b/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/HBaseAccessException.java
@@ -1,0 +1,23 @@
+package com.navercorp.pinpoint.common.hbase;
+
+/**
+ * @Author Taejin Koo
+ */
+public class HBaseAccessException extends RuntimeException {
+
+    public HBaseAccessException() {
+    }
+
+    public HBaseAccessException(String message) {
+        super(message);
+    }
+
+    public HBaseAccessException(Throwable cause) {
+        super(cause);
+    }
+
+    public HBaseAccessException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/HBaseAsyncOperation.java
+++ b/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/HBaseAsyncOperation.java
@@ -10,8 +10,12 @@ import java.util.List;
  */
 public interface HBaseAsyncOperation {
 
+    boolean isAvailable();
+
     boolean put(TableName tableName, final Put put);
 
     List<Put> put(TableName tableName, final List<Put> puts);
+
+    Long getCurrentPutOpsCount();
 
 }

--- a/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/HBaseAsyncOperationFactory.java
+++ b/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/HBaseAsyncOperationFactory.java
@@ -28,7 +28,7 @@ public class HBaseAsyncOperationFactory {
     public static HBaseAsyncOperation create(Configuration configuration) throws IOException {
         boolean enableAsyncMethod = configuration.getBoolean(ENABLE_ASYNC_METHOD, DEFAULT_ENABLE_ASYNC_METHOD);
         if (!enableAsyncMethod) {
-            return new DisabledHBaseAsyncOperation();
+            return DisabledHBaseAsyncOperation.INSTANCE;
         }
 
         int queueSize = configuration.getInt(ASYNC_IN_QUEUE_SIZE, DEFAULT_ASYNC_IN_QUEUE_SIZE);

--- a/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/HBaseAsyncTemplate.java
+++ b/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/HBaseAsyncTemplate.java
@@ -20,6 +20,11 @@ public class HBaseAsyncTemplate implements HBaseAsyncOperation {
     }
 
     @Override
+    public boolean isAvailable() {
+        return true;
+    }
+
+    @Override
     public boolean put(TableName tableName, Put put) {
         return hTableMultiplexer.put(tableName, put);
     }
@@ -27,6 +32,11 @@ public class HBaseAsyncTemplate implements HBaseAsyncOperation {
     @Override
     public List<Put> put(TableName tableName, List<Put> puts) {
         return hTableMultiplexer.put(tableName, puts);
+    }
+
+    @Override
+    public Long getCurrentPutOpsCount() {
+        return hTableMultiplexer.getHTableMultiplexerStatus().getTotalBufferedCounter();
     }
 
 }

--- a/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/HBaseTables.java
+++ b/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/HBaseTables.java
@@ -103,7 +103,6 @@ public final class HBaseTables {
     public static final TableName MAP_STATISTICS_CALLEE_VER2 = TableName.valueOf("ApplicationMapStatisticsCallee_Ver2");
     public static final byte[] MAP_STATISTICS_CALLEE_VER2_CF_COUNTER = Bytes.toBytes("C");
 
-
     public static final TableName MAP_STATISTICS_SELF_VER2 = TableName.valueOf("ApplicationMapStatisticsSelf_Ver2");
     public static final byte[] MAP_STATISTICS_SELF_VER2_CF_COUNTER = Bytes.toBytes("C");
 

--- a/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/HbaseOperations2.java
+++ b/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/HbaseOperations2.java
@@ -17,7 +17,6 @@
 package com.navercorp.pinpoint.common.hbase;
 
 import com.sematext.hbase.wd.AbstractRowKeyDistributor;
-
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Delete;
 import org.apache.hadoop.hbase.client.Get;
@@ -75,11 +74,29 @@ public interface HbaseOperations2 {
     void put(TableName tableName, final Put put);
     void put(TableName tableName, final List<Put> puts);
 
+    /**
+     * If asyncOperation is not set, then execute put method instead of asyncPut method.
+     */
     boolean asyncPut(TableName tableName, final byte[] rowName, final byte[] familyName, final byte[] qualifier, final byte[] value);
+    /**
+     * If asyncOperation is not set, then execute put method instead of asyncPut method.
+     */
     boolean asyncPut(TableName tableName, final byte[] rowName, final byte[] familyName, final byte[] qualifier, final Long timestamp, final byte[] value);
+    /**
+     * If asyncOperation is not set, then execute put method instead of asyncPut method.
+     */
     <T> boolean asyncPut(TableName tableName, final byte[] rowName, final byte[] familyName, final byte[] qualifier, final T value, final ValueMapper<T> mapper);
+    /**
+     * If asyncOperation is not set, then execute put method instead of asyncPut method.
+     */
     <T> boolean asyncPut(TableName tableName, final byte[] rowName, final byte[] familyName, final byte[] qualifier, final Long timestamp, final T value, final ValueMapper<T> mapper);
+    /**
+     * If asyncOperation is not set, then execute put method instead of asyncPut method.
+     */
     boolean asyncPut(TableName tableName, final Put put);
+    /**
+     * If asyncOperation is not set, then execute put method instead of asyncPut method.
+     */
     List<Put> asyncPut(TableName tableName, final List<Put> puts);
 
     void delete(TableName tableName, final Delete delete);


### PR DESCRIPTION
…e write throughput in collector. #1683

 - If asyncOperation is not set, then execute put method instead of asyncPut method.
 - wait destory method until async queue is empty.