### PR TITLE
Animal Sniffer Plugin applied for Java compatibility test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
         <spring-batch-version>2.2.7.RELEASE</spring-batch-version>
         <docker.maven.plugin.version>0.4.3</docker.maven.plugin.version>
         <cassandra.driver.version>2.1.7.1</cassandra.driver.version>
-
+        <sniffer.artifactid>java16</sniffer.artifactid>
     </properties>
 
     <dependencies>
@@ -885,7 +885,30 @@
                     <failOnError>false</failOnError>
                 </configuration>
             </plugin>
-
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>animal-sniffer-maven-plugin</artifactId>
+                <version>1.9</version>
+                <configuration>
+                    <signature>
+                        <groupId>org.codehaus.mojo.signature</groupId>
+                        <artifactId>${sniffer.artifactid}</artifactId>
+                        <version>1.0</version>
+                    </signature>
+                    <ignores>
+                        <ignore>sun.*</ignore>
+                    </ignores>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>ensure-java-${jdk.version}-class-library</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>      
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -16,6 +16,7 @@
         <jdk.home>${env.JAVA_7_HOME}</jdk.home>
         <buildTime>${maven.build.timestamp}</buildTime>
         <maven.build.timestamp.format>yyyyMMddHHmmss</maven.build.timestamp.format>
+        <sniffer.artifactid>java17</sniffer.artifactid>  
     </properties>
 
     <dependencies>
@@ -397,7 +398,7 @@
                         <run>rm -rf /assets/${project.artifactId}-${project.version}.war</run>
                     </runs>
                 </configuration>
-            </plugin>
+            </plugin> 
         </plugins>
     </build>
     <profiles>


### PR DESCRIPTION
- Now the plugin tests whether APIs used for pinpoint are compatible for java 1.6.
- Two files are modified: pom.xml, web/pom.xml
- This test automatically runs during project build. (ex command/ mvn install -Dmaven.test.skip=true)


***pinpoint-web is tested if it is compatible with java 1.7
***sun libraries are ignored at the test.


https://github.com/naver/kaist-oss-course/issues/65