### PR TITLE
Updated README.md

### DIFF
--- a/quickstart/README.md
+++ b/quickstart/README.md
@@ -42,9 +42,10 @@ The following script downloads HBase standalone from [Apache download site](http
 
 **Collector** - Run `quickstart/bin/start-collector.sh`
 
+**TestApp** - Run `quickstart/bin/start-testapp.sh`
+
 **Web UI** - Run `quickstart/bin/start-web.sh`
 
-**TestApp** - Run `quickstart/bin/start-testapp.sh`
 
 Once the startup scripts are completed, the last 10 lines of the Tomcat log are tailed to the console:
 


### PR DESCRIPTION
Changed the order of the *Start Pinpoint Daemons* from

**Collector** - Run `quickstart/bin/start-collector.sh`

**Web UI** - Run `quickstart/bin/start-web.sh`

**TestApp** - Run `quickstart/bin/start-testapp.sh`

_______________________________
TO:


**Collector** - Run `quickstart/bin/start-collector.sh`

**TestApp** - Run `quickstart/bin/start-testapp.sh`

**Web UI** - Run `quickstart/bin/start-web.sh`


Which is the correct order