### PR TITLE
Add file appender to local, console appender to release

### DIFF
--- a/agent/src/main/resources-local/lib/log4j.xml
+++ b/agent/src/main/resources-local/lib/log4j.xml
@@ -37,21 +37,13 @@
     <logger name="com.navercorp.pinpoint" additivity="false">
         <level value="DEBUG" />
         <appender-ref ref="console" />
-    </logger>
-
-    <logger name="org.apache.zookeeper" additivity="false">
-        <level value="INFO"/>
-        <appender-ref ref="console" />
-    </logger>
-
-    <logger name="org.apache.hadoop.hbase" additivity="false">
-        <level value="INFO"/>
-        <appender-ref ref="console" />
+        <appender-ref ref="rollingFile" />
     </logger>
 
     <root>
         <level value="DEBUG" />
         <appender-ref ref="console" />
+        <appender-ref ref="rollingFile" />
     </root>
 
 </log4j:configuration>

--- a/agent/src/main/resources-release/lib/log4j.xml
+++ b/agent/src/main/resources-release/lib/log4j.xml
@@ -3,6 +3,7 @@
 <log4j:configuration xmlns:log4j='http://jakarta.apache.org/log4j/'>
 
     <appender name="console" class="org.apache.log4j.ConsoleAppender">
+        <param name="Threshold" value="WARN" />
         <layout class="org.apache.log4j.EnhancedPatternLayout">
             <param name="ConversionPattern" value="%d{yyyy-MM-dd HH:mm:ss} [%-5p](%-35c{1.}:%-3L) %m%n" />
             <!-- %L(line number) option is extremely slow. -->
@@ -36,16 +37,7 @@
 
     <logger name="com.navercorp.pinpoint" additivity="false">
         <level value="INFO" />
-        <appender-ref ref="rollingFile" />
-    </logger>
-
-    <logger name="org.apache.zookeeper" additivity="false">
-        <level value="INFO"/>
-        <appender-ref ref="rollingFile" />
-    </logger>
-
-    <logger name="org.apache.hadoop.hbase" additivity="false">
-        <level value="INFO"/>
+        <appender-ref ref="console" />
         <appender-ref ref="rollingFile" />
     </logger>
 


### PR DESCRIPTION
Agents built with local profile logs to a separate log file.
Agents built with release profile writes WARN/ERROR logs generated by the agent to console as well.

Related to #1822 