### PR TITLE
Fix rejected puts check when all puts are successfully queued

### DIFF
--- a/collector/src/main/java/com/navercorp/pinpoint/collector/dao/hbase/stat/HbaseActiveTraceDao.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/dao/hbase/stat/HbaseActiveTraceDao.java
@@ -23,6 +23,7 @@ import com.navercorp.pinpoint.common.server.bo.serializer.stat.ActiveTraceSerial
 import com.navercorp.pinpoint.common.server.bo.serializer.stat.AgentStatHbaseOperationFactory;
 import com.navercorp.pinpoint.common.server.bo.stat.ActiveTraceBo;
 import com.navercorp.pinpoint.common.server.bo.stat.AgentStatType;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.hadoop.hbase.client.Put;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
@@ -55,7 +56,7 @@ public class HbaseActiveTraceDao implements AgentStatDaoV2<ActiveTraceBo> {
         List<Put> activeTracePuts = this.agentStatHbaseOperationFactory.createPuts(agentId, AgentStatType.ACTIVE_TRACE, agentStatDataPoints, this.activeTraceSerializer);
         if (!activeTracePuts.isEmpty()) {
             List<Put> rejectedPuts = this.hbaseTemplate.asyncPut(HBaseTables.AGENT_STAT_VER2, activeTracePuts);
-            if (!rejectedPuts.isEmpty()) {
+            if (CollectionUtils.isNotEmpty(rejectedPuts)) {
                 this.hbaseTemplate.put(HBaseTables.AGENT_STAT_VER2, rejectedPuts);
             }
         }

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/dao/hbase/stat/HbaseCpuLoadDao.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/dao/hbase/stat/HbaseCpuLoadDao.java
@@ -23,6 +23,7 @@ import com.navercorp.pinpoint.common.server.bo.serializer.stat.AgentStatHbaseOpe
 import com.navercorp.pinpoint.common.server.bo.serializer.stat.CpuLoadSerializer;
 import com.navercorp.pinpoint.common.server.bo.stat.AgentStatType;
 import com.navercorp.pinpoint.common.server.bo.stat.CpuLoadBo;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.hadoop.hbase.client.Put;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
@@ -55,7 +56,7 @@ public class HbaseCpuLoadDao implements AgentStatDaoV2<CpuLoadBo> {
         List<Put> cpuLoadPuts = this.agentStatHbaseOperationFactory.createPuts(agentId, AgentStatType.CPU_LOAD, cpuLoadBos, this.cpuLoadSerializer);
         if (!cpuLoadPuts.isEmpty()) {
             List<Put> rejectedPuts = this.hbaseTemplate.asyncPut(HBaseTables.AGENT_STAT_VER2, cpuLoadPuts);
-            if (!rejectedPuts.isEmpty()) {
+            if (CollectionUtils.isNotEmpty(rejectedPuts)) {
                 this.hbaseTemplate.put(HBaseTables.AGENT_STAT_VER2, rejectedPuts);
             }
         }

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/dao/hbase/stat/HbaseJvmGcDao.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/dao/hbase/stat/HbaseJvmGcDao.java
@@ -23,6 +23,7 @@ import com.navercorp.pinpoint.common.server.bo.serializer.stat.AgentStatHbaseOpe
 import com.navercorp.pinpoint.common.server.bo.serializer.stat.JvmGcSerializer;
 import com.navercorp.pinpoint.common.server.bo.stat.AgentStatType;
 import com.navercorp.pinpoint.common.server.bo.stat.JvmGcBo;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.hadoop.hbase.client.Put;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
@@ -55,7 +56,7 @@ public class HbaseJvmGcDao implements AgentStatDaoV2<JvmGcBo> {
         List<Put> jvmGcBoPuts = this.agentStatHbaseOperationFactory.createPuts(agentId, AgentStatType.JVM_GC, jvmGcBos, this.jvmGcSerializer);
         if (!jvmGcBoPuts.isEmpty()) {
             List<Put> rejectedPuts = this.hbaseTemplate.asyncPut(HBaseTables.AGENT_STAT_VER2, jvmGcBoPuts);
-            if (!rejectedPuts.isEmpty()) {
+            if (CollectionUtils.isNotEmpty(rejectedPuts)) {
                 this.hbaseTemplate.put(HBaseTables.AGENT_STAT_VER2, rejectedPuts);
             }
         }

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/dao/hbase/stat/HbaseJvmGcDetailedDao.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/dao/hbase/stat/HbaseJvmGcDetailedDao.java
@@ -23,6 +23,7 @@ import com.navercorp.pinpoint.common.server.bo.serializer.stat.AgentStatHbaseOpe
 import com.navercorp.pinpoint.common.server.bo.serializer.stat.JvmGcDetailedSerializer;
 import com.navercorp.pinpoint.common.server.bo.stat.AgentStatType;
 import com.navercorp.pinpoint.common.server.bo.stat.JvmGcDetailedBo;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.hadoop.hbase.client.Put;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
@@ -55,7 +56,7 @@ public class HbaseJvmGcDetailedDao implements AgentStatDaoV2<JvmGcDetailedBo> {
         List<Put> jvmGcDetailedPuts = this.agentStatHbaseOperationFactory.createPuts(agentId, AgentStatType.JVM_GC_DETAILED, jvmGcDetailedBos, this.jvmGcDetailedSerializer);
         if (!jvmGcDetailedPuts.isEmpty()) {
             List<Put> rejectedPuts = this.hbaseTemplate.asyncPut(HBaseTables.AGENT_STAT_VER2, jvmGcDetailedPuts);
-            if (!rejectedPuts.isEmpty()) {
+            if (CollectionUtils.isNotEmpty(rejectedPuts)) {
                 this.hbaseTemplate.put(HBaseTables.AGENT_STAT_VER2, rejectedPuts);
             }
         }

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/dao/hbase/stat/HbaseTransactionDao.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/dao/hbase/stat/HbaseTransactionDao.java
@@ -23,6 +23,7 @@ import com.navercorp.pinpoint.common.server.bo.serializer.stat.AgentStatHbaseOpe
 import com.navercorp.pinpoint.common.server.bo.serializer.stat.TransactionSerializer;
 import com.navercorp.pinpoint.common.server.bo.stat.AgentStatType;
 import com.navercorp.pinpoint.common.server.bo.stat.TransactionBo;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.hadoop.hbase.client.Put;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
@@ -55,7 +56,7 @@ public class HbaseTransactionDao implements AgentStatDaoV2<TransactionBo> {
         List<Put> transactionPuts = this.agentStatHbaseOperationFactory.createPuts(agentId, AgentStatType.TRANSACTION, transactionBos, this.transactionSerializer);
         if (!transactionPuts.isEmpty()) {
             List<Put> rejectedPuts = this.hbaseTemplate.asyncPut(HBaseTables.AGENT_STAT_VER2, transactionPuts);
-            if (!rejectedPuts.isEmpty()) {
+            if (CollectionUtils.isNotEmpty(rejectedPuts)) {
                 this.hbaseTemplate.put(HBaseTables.AGENT_STAT_VER2, rejectedPuts);
             }
         }

--- a/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/HbaseOperations2.java
+++ b/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/HbaseOperations2.java
@@ -94,8 +94,12 @@ public interface HbaseOperations2 {
      * If asyncOperation is not set, then execute put method instead of asyncPut method.
      */
     boolean asyncPut(TableName tableName, final Put put);
+
     /**
      * If asyncOperation is not set, then execute put method instead of asyncPut method.
+     * @param tableName
+     * @param puts
+     * @return the list of puts which could not be queued or put serially. May be null if all put operations were successfully queued.
      */
     List<Put> asyncPut(TableName tableName, final List<Put> puts);
 


### PR DESCRIPTION
`List<Put> HbaseTemplate2.asyncPut(TableName, List<Put>)` method may return null instead of an empty collection.
This fixes agent stat daos so that they handle nulls when checking for rejected puts.
Also adds documentation mentioning the possible null return.

related to #1533