### PR TITLE
Adds GC type back into JvmGc serialization

### DIFF
--- a/collector/src/main/java/com/navercorp/pinpoint/collector/mapper/thrift/stat/JvmGcBoMapper.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/mapper/thrift/stat/JvmGcBoMapper.java
@@ -17,6 +17,7 @@
 package com.navercorp.pinpoint.collector.mapper.thrift.stat;
 
 import com.navercorp.pinpoint.collector.mapper.thrift.ThriftBoMapper;
+import com.navercorp.pinpoint.common.server.bo.JvmGcType;
 import com.navercorp.pinpoint.common.server.bo.stat.JvmGcBo;
 import com.navercorp.pinpoint.thrift.dto.TJvmGc;
 import org.springframework.stereotype.Component;
@@ -30,6 +31,7 @@ public class JvmGcBoMapper implements ThriftBoMapper<JvmGcBo, TJvmGc> {
     @Override
     public JvmGcBo map(TJvmGc tJvmGc) {
         JvmGcBo jvmGcBo = new JvmGcBo();
+        jvmGcBo.setGcType(JvmGcType.valueOf(tJvmGc.getType().name()));
         jvmGcBo.setHeapUsed(tJvmGc.getJvmMemoryHeapUsed());
         jvmGcBo.setHeapMax(tJvmGc.getJvmMemoryHeapMax());
         jvmGcBo.setNonHeapUsed(tJvmGc.getJvmMemoryNonHeapUsed());

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/JvmGcType.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/JvmGcType.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2016 Naver Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.common.server.bo;
+
+/**
+ * @author HyunGil Jeong
+ */
+public enum JvmGcType {
+    UNKNOWN(0),
+    SERIAL(1),
+    PARALLEL(2),
+    CMS(3),
+    G1(4);
+
+    private final int typeCode;
+
+    JvmGcType(int typeCode) {
+        this.typeCode = typeCode;
+    }
+
+    public int getTypeCode() {
+        return this.typeCode;
+    }
+
+    public static JvmGcType getTypeByCode(int typeCode) {
+        for (JvmGcType gcType : JvmGcType.values()) {
+            if (gcType.typeCode == typeCode) {
+                return gcType;
+            }
+        }
+        return JvmGcType.UNKNOWN;
+    }
+}

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/codec/stat/v1/JvmGcCodecV1.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/codec/stat/v1/JvmGcCodecV1.java
@@ -17,6 +17,7 @@
 package com.navercorp.pinpoint.common.server.bo.codec.stat.v1;
 
 import com.navercorp.pinpoint.common.buffer.Buffer;
+import com.navercorp.pinpoint.common.server.bo.JvmGcType;
 import com.navercorp.pinpoint.common.server.bo.codec.stat.AgentStatCodec;
 import com.navercorp.pinpoint.common.server.bo.codec.stat.AgentStatDataPointCodec;
 import com.navercorp.pinpoint.common.server.bo.codec.stat.v1.strategy.UnsignedLongEncodingStrategy;
@@ -61,6 +62,8 @@ public class JvmGcCodecV1 implements AgentStatCodec<JvmGcBo> {
         if (CollectionUtils.isEmpty(jvmGcBos)) {
             throw new IllegalArgumentException("jvmGcBos must not be empty");
         }
+        final int gcTypeCode = jvmGcBos.get(0).getGcType().getTypeCode();
+        valueBuffer.putVInt(gcTypeCode);
         final int numValues = jvmGcBos.size();
         valueBuffer.putVInt(numValues);
 
@@ -126,6 +129,7 @@ public class JvmGcCodecV1 implements AgentStatCodec<JvmGcBo> {
 
     @Override
     public List<JvmGcBo> decodeValues(Buffer valueBuffer, long initialTimestamp) {
+        final JvmGcType gcType = JvmGcType.getTypeByCode(valueBuffer.readVInt());
         int numValues = valueBuffer.readVInt();
 
         List<Long> timestamps = this.codec.decodeTimestamps(initialTimestamp, valueBuffer, numValues);
@@ -156,6 +160,7 @@ public class JvmGcCodecV1 implements AgentStatCodec<JvmGcBo> {
         for (int i = 0; i < numValues; ++i) {
             JvmGcBo jvmGcBo = new JvmGcBo();
             jvmGcBo.setTimestamp(timestamps.get(i));
+            jvmGcBo.setGcType(gcType);
             jvmGcBo.setHeapUsed(heapUseds.get(i));
             jvmGcBo.setHeapMax(heapMaxes.get(i));
             jvmGcBo.setNonHeapUsed(nonHeapUseds.get(i));

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/stat/JvmGcBo.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/stat/JvmGcBo.java
@@ -16,6 +16,8 @@
 
 package com.navercorp.pinpoint.common.server.bo.stat;
 
+import com.navercorp.pinpoint.common.server.bo.JvmGcType;
+
 /**
  * @author HyunGil Jeong
  */
@@ -25,6 +27,7 @@ public class JvmGcBo implements AgentStatDataPoint {
 
     private String agentId;
     private long timestamp;
+    private JvmGcType gcType = JvmGcType.UNKNOWN;
     private long heapUsed = UNCOLLECTED_VALUE;
     private long heapMax = UNCOLLECTED_VALUE;
     private long nonHeapUsed = UNCOLLECTED_VALUE;
@@ -55,6 +58,14 @@ public class JvmGcBo implements AgentStatDataPoint {
     @Override
     public AgentStatType getAgentStatType() {
         return AgentStatType.JVM_GC;
+    }
+
+    public JvmGcType getGcType() {
+        return gcType;
+    }
+
+    public void setGcType(JvmGcType gcType) {
+        this.gcType = gcType;
     }
 
     public long getHeapUsed() {
@@ -119,13 +130,15 @@ public class JvmGcBo implements AgentStatDataPoint {
         if (nonHeapMax != jvmGcBo.nonHeapMax) return false;
         if (gcOldCount != jvmGcBo.gcOldCount) return false;
         if (gcOldTime != jvmGcBo.gcOldTime) return false;
-        return agentId != null ? agentId.equals(jvmGcBo.agentId) : jvmGcBo.agentId == null;
+        if (agentId != null ? !agentId.equals(jvmGcBo.agentId) : jvmGcBo.agentId != null) return false;
+        return gcType == jvmGcBo.gcType;
     }
 
     @Override
     public int hashCode() {
         int result = agentId != null ? agentId.hashCode() : 0;
         result = 31 * result + (int) (timestamp ^ (timestamp >>> 32));
+        result = 31 * result + (gcType != null ? gcType.hashCode() : 0);
         result = 31 * result + (int) (heapUsed ^ (heapUsed >>> 32));
         result = 31 * result + (int) (heapMax ^ (heapMax >>> 32));
         result = 31 * result + (int) (nonHeapUsed ^ (nonHeapUsed >>> 32));
@@ -140,6 +153,7 @@ public class JvmGcBo implements AgentStatDataPoint {
         return "JvmGcBo{" +
                 "agentId='" + agentId + '\'' +
                 ", timestamp=" + timestamp +
+                ", gcType=" + gcType +
                 ", heapUsed=" + heapUsed +
                 ", heapMax=" + heapMax +
                 ", nonHeapUsed=" + nonHeapUsed +

--- a/commons-server/src/test/java/com/navercorp/pinpoint/common/server/bo/codec/stat/TestAgentStatFactory.java
+++ b/commons-server/src/test/java/com/navercorp/pinpoint/common/server/bo/codec/stat/TestAgentStatFactory.java
@@ -16,6 +16,7 @@
 
 package com.navercorp.pinpoint.common.server.bo.codec.stat;
 
+import com.navercorp.pinpoint.common.server.bo.JvmGcType;
 import com.navercorp.pinpoint.common.server.bo.stat.ActiveTraceBo;
 import com.navercorp.pinpoint.common.server.bo.stat.CpuLoadBo;
 import com.navercorp.pinpoint.common.server.bo.stat.JvmGcBo;
@@ -82,6 +83,7 @@ public class TestAgentStatFactory {
                 numValues);
         for (int i = 0; i < numValues; ++i) {
             JvmGcBo jvmGcBo = new JvmGcBo();
+            jvmGcBo.setGcType(JvmGcType.CMS);
             jvmGcBo.setTimestamp(timestamps.get(i));
             jvmGcBo.setHeapUsed(heapUseds.get(i));
             jvmGcBo.setHeapMax(heapMaxes.get(i));

--- a/web/src/main/java/com/navercorp/pinpoint/web/controller/AgentStatController.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/controller/AgentStatController.java
@@ -26,12 +26,16 @@ import com.navercorp.pinpoint.common.server.bo.stat.JvmGcBo;
 import com.navercorp.pinpoint.common.server.bo.stat.JvmGcDetailedBo;
 import com.navercorp.pinpoint.common.server.bo.stat.TransactionBo;
 import com.navercorp.pinpoint.web.service.stat.ActiveTraceChartService;
+import com.navercorp.pinpoint.web.service.stat.ActiveTraceService;
 import com.navercorp.pinpoint.web.service.stat.AgentStatChartService;
 import com.navercorp.pinpoint.web.service.stat.CpuLoadChartService;
+import com.navercorp.pinpoint.web.service.stat.CpuLoadService;
 import com.navercorp.pinpoint.web.service.stat.JvmGcChartService;
 import com.navercorp.pinpoint.web.service.stat.JvmGcDetailedChartService;
+import com.navercorp.pinpoint.web.service.stat.JvmGcDetailedService;
 import com.navercorp.pinpoint.web.service.stat.JvmGcService;
 import com.navercorp.pinpoint.web.service.stat.TransactionChartService;
+import com.navercorp.pinpoint.web.service.stat.TransactionService;
 import com.navercorp.pinpoint.web.util.TimeWindowSampler;
 import com.navercorp.pinpoint.web.vo.stat.chart.AgentStatChartGroup;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -119,7 +123,7 @@ public abstract class AgentStatController<T extends AgentStatDataPoint> {
     @RequestMapping("/getAgentStat/jvmGcDetailed")
     public static class JvmGcDetailedController extends AgentStatController<JvmGcDetailedBo> {
         @Autowired
-        public JvmGcDetailedController(AgentStatService<JvmGcDetailedBo> jvmGcDetailedService, JvmGcDetailedChartService jvmGcDetailedChartService) {
+        public JvmGcDetailedController(JvmGcDetailedService jvmGcDetailedService, JvmGcDetailedChartService jvmGcDetailedChartService) {
             super(jvmGcDetailedService, jvmGcDetailedChartService);
         }
     }
@@ -128,7 +132,7 @@ public abstract class AgentStatController<T extends AgentStatDataPoint> {
     @RequestMapping("/getAgentStat/cpuLoad")
     public static class CpuLoadController extends AgentStatController<CpuLoadBo> {
         @Autowired
-        public CpuLoadController(AgentStatService<CpuLoadBo> cpuLoadService, CpuLoadChartService cpuLoadChartService) {
+        public CpuLoadController(CpuLoadService cpuLoadService, CpuLoadChartService cpuLoadChartService) {
             super(cpuLoadService, cpuLoadChartService);
         }
     }
@@ -137,7 +141,7 @@ public abstract class AgentStatController<T extends AgentStatDataPoint> {
     @RequestMapping("/getAgentStat/transaction")
     public static class TransactionController extends AgentStatController<TransactionBo> {
         @Autowired
-        public TransactionController(AgentStatService<TransactionBo> transactionService, TransactionChartService transactionChartService) {
+        public TransactionController(TransactionService transactionService, TransactionChartService transactionChartService) {
             super(transactionService, transactionChartService);
         }
     }
@@ -146,7 +150,7 @@ public abstract class AgentStatController<T extends AgentStatDataPoint> {
     @RequestMapping("/getAgentStat/activeTrace")
     public static class ActiveTraceController extends AgentStatController<ActiveTraceBo> {
         @Autowired
-        public ActiveTraceController(AgentStatService<ActiveTraceBo> activeTraceService, ActiveTraceChartService activeTraceChartService) {
+        public ActiveTraceController(ActiveTraceService activeTraceService, ActiveTraceChartService activeTraceChartService) {
             super(activeTraceService, activeTraceChartService);
         }
     }

--- a/web/src/main/java/com/navercorp/pinpoint/web/dao/hbase/stat/v1/Aggregator.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/dao/hbase/stat/v1/Aggregator.java
@@ -132,6 +132,7 @@ public interface Aggregator<T extends AgentStatDataPoint> {
             JvmGcBo normalized = new JvmGcBo();
             normalized.setAgentId(src.getAgentId());
             normalized.setTimestamp(normalizedTimestamp);
+            normalized.setGcType(src.getGcType());
             normalized.setHeapUsed(src.getHeapUsed());
             normalized.setHeapMax(src.getHeapMax());
             normalized.setNonHeapUsed(src.getNonHeapUsed());
@@ -147,6 +148,7 @@ public interface Aggregator<T extends AgentStatDataPoint> {
             JvmGcBo merged = new JvmGcBo();
             merged.setAgentId(latest.getAgentId());
             merged.setTimestamp(latest.getTimestamp());
+            merged.setGcType(latest.getGcType());
             merged.setHeapUsed(latest.getHeapUsed());
             merged.setHeapMax(maxUnsignedLongs(s1.getHeapMax(), s2.getHeapMax()));
             merged.setNonHeapUsed(latest.getNonHeapUsed());

--- a/web/src/main/java/com/navercorp/pinpoint/web/mapper/stat/AgentStatMapperV1.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/mapper/stat/AgentStatMapperV1.java
@@ -27,7 +27,7 @@ import java.util.NavigableMap;
 import com.navercorp.pinpoint.common.server.bo.ActiveTraceHistogramBo;
 import com.navercorp.pinpoint.common.server.bo.AgentStatCpuLoadBo;
 import com.navercorp.pinpoint.common.server.bo.AgentStatMemoryGcBo;
-import com.navercorp.pinpoint.common.hbase.RowMapper;
+import com.navercorp.pinpoint.common.server.bo.JvmGcType;
 import com.navercorp.pinpoint.common.server.bo.stat.ActiveTraceBo;
 import com.navercorp.pinpoint.common.server.bo.stat.AgentStatDataPoint;
 import com.navercorp.pinpoint.common.server.bo.stat.CpuLoadBo;
@@ -121,6 +121,7 @@ public abstract class AgentStatMapperV1<T extends AgentStatDataPoint> implements
             JvmGcBo jvmGcBo = new JvmGcBo();
             jvmGcBo.setAgentId(agentStatMemoryGcBo.getAgentId());
             jvmGcBo.setTimestamp(agentStatMemoryGcBo.getTimestamp());
+            jvmGcBo.setGcType(JvmGcType.valueOf(agentStatMemoryGcBo.getGcType()));
             jvmGcBo.setGcOldCount(agentStatMemoryGcBo.getJvmGcOldCount());
             jvmGcBo.setGcOldTime(agentStatMemoryGcBo.getJvmGcOldTime());
             jvmGcBo.setHeapUsed(agentStatMemoryGcBo.getJvmMemoryHeapUsed());
@@ -138,6 +139,7 @@ public abstract class AgentStatMapperV1<T extends AgentStatDataPoint> implements
                 JvmGcBo jvmGcBo = new JvmGcBo();
                 jvmGcBo.setAgentId(agentStatMemoryGcBo.getAgentId());
                 jvmGcBo.setTimestamp(agentStatMemoryGcBo.getTimestamp());
+                jvmGcBo.setGcType(JvmGcType.valueOf(agentStatMemoryGcBo.getGcType()));
                 jvmGcBo.setGcOldCount(agentStatMemoryGcBo.getJvmGcOldCount());
                 jvmGcBo.setGcOldTime(agentStatMemoryGcBo.getJvmGcOldTime());
                 jvmGcBo.setHeapUsed(agentStatMemoryGcBo.getJvmMemoryHeapUsed());
@@ -155,6 +157,9 @@ public abstract class AgentStatMapperV1<T extends AgentStatDataPoint> implements
             JvmGcBo jvmGcBo = new JvmGcBo();
             jvmGcBo.setAgentId(agentId);
             jvmGcBo.setTimestamp(timestamp);
+            if (qualifierMap.containsKey(AGENT_STAT_COL_GC_TYPE)) {
+                jvmGcBo.setGcType(JvmGcType.valueOf(Bytes.toString(qualifierMap.get(AGENT_STAT_COL_GC_TYPE))));
+            }
             if (qualifierMap.containsKey(AGENT_STAT_COL_GC_OLD_COUNT)) {
                 jvmGcBo.setGcOldCount(Bytes.toLong(qualifierMap.get(AGENT_STAT_COL_GC_OLD_COUNT)));
             }

--- a/web/src/main/java/com/navercorp/pinpoint/web/mapper/stat/AgentStatMapperV2.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/mapper/stat/AgentStatMapperV2.java
@@ -32,7 +32,6 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 
-
 /**
  * @author HyunGil Jeong
  */

--- a/web/src/main/java/com/navercorp/pinpoint/web/mapper/stat/SampledJvmGcResultExtractor.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/mapper/stat/SampledJvmGcResultExtractor.java
@@ -16,6 +16,7 @@
 
 package com.navercorp.pinpoint.web.mapper.stat;
 
+import com.navercorp.pinpoint.common.server.bo.JvmGcType;
 import com.navercorp.pinpoint.common.server.bo.stat.JvmGcBo;
 import com.navercorp.pinpoint.web.util.TimeWindow;
 import com.navercorp.pinpoint.web.vo.chart.Point;
@@ -40,6 +41,7 @@ public class SampledJvmGcResultExtractor extends SampledAgentStatResultExtractor
 
     @Override
     protected SampledJvmGc sampleCurrentBatch(long timestamp, List<JvmGcBo> dataPointsToSample) {
+        JvmGcType jvmGcType = JvmGcType.UNKNOWN;
         List<Long> heapUseds = new ArrayList<>(dataPointsToSample.size());
         List<Long> heapMaxes = new ArrayList<>(dataPointsToSample.size());
         List<Long> nonHeapUseds = new ArrayList<>(dataPointsToSample.size());
@@ -47,6 +49,7 @@ public class SampledJvmGcResultExtractor extends SampledAgentStatResultExtractor
         List<Long> gcOldCounts = new ArrayList<>(dataPointsToSample.size());
         List<Long> gcOldTimes = new ArrayList<>(dataPointsToSample.size());
         for (JvmGcBo jvmGcBo : dataPointsToSample) {
+            jvmGcType = jvmGcBo.getGcType();
             heapUseds.add(jvmGcBo.getHeapUsed());
             heapMaxes.add(jvmGcBo.getHeapMax());
             nonHeapUseds.add(jvmGcBo.getNonHeapUsed());
@@ -55,6 +58,7 @@ public class SampledJvmGcResultExtractor extends SampledAgentStatResultExtractor
             gcOldTimes.add(jvmGcBo.getGcOldTime());
         }
         SampledJvmGc sampledJvmGc = new SampledJvmGc();
+        sampledJvmGc.setJvmGcType(jvmGcType);
         sampledJvmGc.setHeapUsed(createPoint(timestamp, heapUseds));
         sampledJvmGc.setHeapMax(createPoint(timestamp, heapMaxes));
         sampledJvmGc.setNonHeapUsed(createPoint(timestamp, nonHeapUseds));

--- a/web/src/main/java/com/navercorp/pinpoint/web/vo/stat/SampledJvmGc.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/vo/stat/SampledJvmGc.java
@@ -16,6 +16,7 @@
 
 package com.navercorp.pinpoint.web.vo.stat;
 
+import com.navercorp.pinpoint.common.server.bo.JvmGcType;
 import com.navercorp.pinpoint.web.vo.chart.Point;
 
 /**
@@ -23,12 +24,21 @@ import com.navercorp.pinpoint.web.vo.chart.Point;
  */
 public class SampledJvmGc implements SampledAgentStatDataPoint {
 
+    private JvmGcType jvmGcType;
     private Point<Long, Long> heapUsed;
     private Point<Long, Long> heapMax;
     private Point<Long, Long> nonHeapUsed;
     private Point<Long, Long> nonHeapMax;
     private Point<Long, Long> gcOldCount;
     private Point<Long, Long> gcOldTime;
+
+    public JvmGcType getJvmGcType() {
+        return jvmGcType;
+    }
+
+    public void setJvmGcType(JvmGcType jvmGcType) {
+        this.jvmGcType = jvmGcType;
+    }
 
     public Point<Long, Long> getHeapUsed() {
         return heapUsed;

--- a/web/src/main/java/com/navercorp/pinpoint/web/vo/stat/chart/JvmGcChartGroup.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/vo/stat/chart/JvmGcChartGroup.java
@@ -16,6 +16,7 @@
 
 package com.navercorp.pinpoint.web.vo.stat.chart;
 
+import com.navercorp.pinpoint.common.server.bo.JvmGcType;
 import com.navercorp.pinpoint.web.util.TimeWindow;
 import com.navercorp.pinpoint.web.vo.chart.Chart;
 import com.navercorp.pinpoint.web.vo.chart.Point;
@@ -36,6 +37,8 @@ public class JvmGcChartGroup implements AgentStatChartGroup {
 
     private final Map<ChartType, Chart> jvmGcCharts;
 
+    private final String type;
+
     public enum JvmGcChartType implements ChartType {
         JVM_MEMORY_HEAP_USED,
         JVM_MEMORY_HEAP_MAX,
@@ -47,6 +50,7 @@ public class JvmGcChartGroup implements AgentStatChartGroup {
 
     public JvmGcChartGroup(TimeWindow timeWindow, List<SampledJvmGc> sampledJvmGcs) {
         this.jvmGcCharts = new HashMap<>();
+        JvmGcType jvmGcType = JvmGcType.UNKNOWN;
         List<Point<Long, Long>> heapUseds = new ArrayList<>(sampledJvmGcs.size());
         List<Point<Long, Long>> heapMaxes = new ArrayList<>(sampledJvmGcs.size());
         List<Point<Long, Long>> nonHeapUseds = new ArrayList<>(sampledJvmGcs.size());
@@ -60,6 +64,7 @@ public class JvmGcChartGroup implements AgentStatChartGroup {
             nonHeapMaxes.add(sampledJvmGc.getNonHeapMax());
             gcOldCounts.add(sampledJvmGc.getGcOldCount());
             gcOldTimes.add(sampledJvmGc.getGcOldTime());
+            jvmGcType = sampledJvmGc.getJvmGcType();
         }
         jvmGcCharts.put(JvmGcChartType.JVM_MEMORY_HEAP_USED, new TimeSeriesChartBuilder<>(timeWindow, UNCOLLECTED_VALUE).build(heapUseds));
         jvmGcCharts.put(JvmGcChartType.JVM_MEMORY_HEAP_MAX, new TimeSeriesChartBuilder<>(timeWindow, UNCOLLECTED_VALUE).build(heapMaxes));
@@ -67,10 +72,15 @@ public class JvmGcChartGroup implements AgentStatChartGroup {
         jvmGcCharts.put(JvmGcChartType.JVM_MEMORY_NON_HEAP_MAX, new TimeSeriesChartBuilder<>(timeWindow, UNCOLLECTED_VALUE).build(nonHeapMaxes));
         jvmGcCharts.put(JvmGcChartType.JVM_GC_OLD_COUNT, new TimeSeriesChartBuilder<>(timeWindow, UNCOLLECTED_VALUE).build(gcOldCounts));
         jvmGcCharts.put(JvmGcChartType.JVM_GC_OLD_TIME, new TimeSeriesChartBuilder<>(timeWindow, UNCOLLECTED_VALUE).build(gcOldTimes));
+        this.type = jvmGcType.name();
     }
 
     @Override
     public Map<ChartType, Chart> getCharts() {
         return this.jvmGcCharts;
+    }
+
+    public String getType() {
+        return this.type;
     }
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/vo/stat/chart/LegacyAgentStatChartGroup.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/vo/stat/chart/LegacyAgentStatChartGroup.java
@@ -30,7 +30,6 @@ import com.navercorp.pinpoint.web.vo.stat.SampledActiveTrace;
 import com.navercorp.pinpoint.web.vo.stat.SampledCpuLoad;
 import com.navercorp.pinpoint.web.vo.stat.SampledJvmGc;
 import com.navercorp.pinpoint.web.vo.stat.SampledTransaction;
-import org.apache.commons.collections.CollectionUtils;
 
 import java.util.HashMap;
 import java.util.List;
@@ -93,8 +92,9 @@ public class LegacyAgentStatChartGroup implements AgentStatChartGroup {
 
     private final Map<ChartType, Chart> charts;
 
-    private LegacyAgentStatChartGroup(Map<ChartType, Chart> charts) {
+    private LegacyAgentStatChartGroup(Map<ChartType, Chart> charts, String gcType) {
         this.charts = charts;
+        this.type = gcType;
     }
 
     public LegacyAgentStatChartGroup(TimeWindow timeWindow) {
@@ -296,11 +296,13 @@ public class LegacyAgentStatChartGroup implements AgentStatChartGroup {
 
         public LegacyAgentStatChartGroup build() {
             Map<ChartType, Chart> charts = new HashMap<>();
-            charts.putAll(new JvmGcChartGroup(this.timeWindow, this.jvmGcs).getCharts());
+            JvmGcChartGroup jvmGcChartGroup = new JvmGcChartGroup(this.timeWindow, this.jvmGcs);
+            String gcType = jvmGcChartGroup.getType();
+            charts.putAll(jvmGcChartGroup.getCharts());
             charts.putAll(new CpuLoadChartGroup(this.timeWindow, this.cpuLoads).getCharts());
             charts.putAll(new TransactionChartGroup(this.timeWindow, this.transactions).getCharts());
             charts.putAll(new ActiveTraceChartGroup(this.timeWindow, this.activeTraces).getCharts());
-            return new LegacyAgentStatChartGroup(charts);
+            return new LegacyAgentStatChartGroup(charts, gcType);
         }
     }
 }


### PR DESCRIPTION
Gc Type serialization was removed when storing agent stat data (in particular for Memory/GC data) due to it being stored in *AgentInfo* table. However, Gc type is stored in *AgentInfo* table only for 1.5.2+ agents.
In order to maintain compatibility a bit longer, GC type is added back to *AgentStatV2* table alongside Memory/GC serialization.

related to #1533 