### PR TITLE
Creates bootstrap-core-optional that has optional classes for Java7+

### DIFF
--- a/agent/pom.xml
+++ b/agent/pom.xml
@@ -35,6 +35,12 @@
             <scope>runtime</scope>
         </dependency>
 
+        <dependency>
+            <groupId>com.navercorp.pinpoint</groupId>
+            <artifactId>pinpoint-bootstrap-core-optional</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
         <!-- tools -->
         <dependency>
             <groupId>com.navercorp.pinpoint</groupId>

--- a/agent/src/assembly/distribution.xml
+++ b/agent/src/assembly/distribution.xml
@@ -33,6 +33,7 @@
     <dependencySet>
         <includes>
             <include>com.navercorp.pinpoint:pinpoint-bootstrap-core</include>
+            <include>com.navercorp.pinpoint:pinpoint-bootstrap-core-optional</include>
         </includes>
         <outputDirectory>boot</outputDirectory>
     </dependencySet>
@@ -40,6 +41,7 @@
         <excludes>
             <exclude>com.navercorp.pinpoint:pinpoint-commons</exclude>
             <exclude>com.navercorp.pinpoint:pinpoint-bootstrap-core</exclude>
+            <exclude>com.navercorp.pinpoint:pinpoint-bootstrap-core-optional</exclude>
             <exclude>com.navercorp.pinpoint:pinpoint-bootstrap</exclude>
             <exclude>com.navercorp.pinpoint:pinpoint-plugins</exclude>
             <exclude>*:pom</exclude>

--- a/agent/src/assembly/distribution.xml
+++ b/agent/src/assembly/distribution.xml
@@ -32,6 +32,7 @@
     </dependencySet>
     <dependencySet>
         <includes>
+            <include>com.navercorp.pinpoint:pinpoint-commons</include>
             <include>com.navercorp.pinpoint:pinpoint-bootstrap-core</include>
             <include>com.navercorp.pinpoint:pinpoint-bootstrap-core-optional</include>
         </includes>

--- a/bootstrap-core-optional/.gitignore
+++ b/bootstrap-core-optional/.gitignore
@@ -1,0 +1,5 @@
+/.settings/
+/*.iml
+/.project
+/target/
+/.classpath

--- a/bootstrap-core-optional/clover.license
+++ b/bootstrap-core-optional/clover.license
@@ -1,0 +1,5 @@
+RMRqrdbgbKFhbaVnDxHUdDQvrOQXxIBklnvcmahheubVC
+mh2KM35CLkwUHS4DH7QVhxy52J5hnWbyEm6Cyd3KkF<mV
+RmmnSVOqOMnOnMMrmMqwXomoroNrqPNRrPSsWwtUxXuUU
+sRONqpnmqmUUnqonmstsmmmmmUUnqonmstsmmmmmUUGfk
+mlfkqUUnmmmm

--- a/bootstrap-core-optional/pom.xml
+++ b/bootstrap-core-optional/pom.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.navercorp.pinpoint</groupId>
+        <artifactId>pinpoint</artifactId>
+        <version>1.6.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>pinpoint-bootstrap-core-optional</artifactId>
+    <name>pinpoint-bootstrap-core-optional</name>
+    <packaging>jar</packaging>
+
+    <properties>
+        <jdk.version>1.7</jdk.version>
+        <jdk.home>${env.JAVA_7_HOME}</jdk.home>
+        <sniffer.artifactid>java17</sniffer.artifactid>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.navercorp.pinpoint</groupId>
+            <artifactId>pinpoint-bootstrap-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/bootstrap-core-optional/src/main/java/com/navercorp/pinpoint/bootstrap/util/jdk/JdkThreadLocalRandomFactory.java
+++ b/bootstrap-core-optional/src/main/java/com/navercorp/pinpoint/bootstrap/util/jdk/JdkThreadLocalRandomFactory.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2016 Naver Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.bootstrap.util.jdk;
+
+import java.util.Random;
+
+/**
+ * @author HyunGil Jeong
+ */
+public class JdkThreadLocalRandomFactory implements ThreadLocalRandomFactory {
+
+    @Override
+    public Random current() {
+        return java.util.concurrent.ThreadLocalRandom.current();
+    }
+}

--- a/bootstrap-core/pom.xml
+++ b/bootstrap-core/pom.xml
@@ -57,27 +57,6 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
-                <version>2.4.3</version>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>shade</goal>
-                        </goals>
-                        <configuration>
-                            <dependencyReducedPomLocation>${basedir}/target/dependency-reduced-pom.xml</dependencyReducedPomLocation>
-                            <filters>
-                                <filter>
-                                    <artifact>com.navercorp.pinpoint:pinpoint-commons</artifact>
-                                </filter>
-                            </filters>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <executions>
                     <execution>

--- a/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/context/SpanId.java
+++ b/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/context/SpanId.java
@@ -18,7 +18,7 @@ package com.navercorp.pinpoint.bootstrap.context;
 
 import java.util.Random;
 
-import com.navercorp.pinpoint.bootstrap.util.jdk.ThreadLocalRandom;
+import com.navercorp.pinpoint.bootstrap.util.jdk.ThreadLocalRandomUtils;
 
 /**
  * @author emeroad
@@ -38,7 +38,7 @@ public class SpanId {
     // Changed to ThreadLocalRandom because unique value per thread will be enough.
     // If you need to change Random implementation, modify this method.
     private static Random getRandom() {
-        return ThreadLocalRandom.current();
+        return ThreadLocalRandomUtils.current();
     }
 
     private static long createSpanId(Random seed) {

--- a/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/util/jdk/PinpointThreadLocalRandomFactory.java
+++ b/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/util/jdk/PinpointThreadLocalRandomFactory.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2016 Naver Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.bootstrap.util.jdk;
+
+import java.util.Random;
+
+/**
+ * @author HyunGil Jeong
+ */
+public class PinpointThreadLocalRandomFactory implements ThreadLocalRandomFactory {
+
+    @Override
+    public Random current() {
+        return ThreadLocalRandom.current();
+    }
+}

--- a/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/util/jdk/ThreadLocalRandomFactory.java
+++ b/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/util/jdk/ThreadLocalRandomFactory.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2016 Naver Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.bootstrap.util.jdk;
+
+import java.util.Random;
+
+/**
+ * @author HyunGil Jeong
+ */
+public interface ThreadLocalRandomFactory {
+    Random current();
+}

--- a/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/util/jdk/ThreadLocalRandomUtils.java
+++ b/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/util/jdk/ThreadLocalRandomUtils.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2016 Naver Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.bootstrap.util.jdk;
+
+import com.navercorp.pinpoint.bootstrap.logging.PLogger;
+import com.navercorp.pinpoint.bootstrap.logging.PLoggerFactory;
+import com.navercorp.pinpoint.common.util.JvmUtils;
+import com.navercorp.pinpoint.common.util.JvmVersion;
+
+import java.util.Random;
+
+/**
+ * @author HyunGil Jeong
+ */
+public class ThreadLocalRandomUtils {
+
+    private static final PLogger LOGGER = PLoggerFactory.getLogger(ThreadLocalRandomUtils.class);
+
+    private static final ThreadLocalRandomFactory THREAD_LOCAL_RANDOM_FACTORY = createThreadLocalRandomFactory();
+
+    // Jdk 7+
+    private static final String DEFAULT_THREAD_LOCAL_RANDOM_FACTORY = "com.navercorp.pinpoint.bootstrap.util.jdk.JdkThreadLocalRandomFactory";
+
+    private ThreadLocalRandomUtils() {
+        throw new IllegalAccessError();
+    }
+
+    private static final ThreadLocalRandomFactory createThreadLocalRandomFactory() {
+        final JvmVersion jvmVersion = JvmUtils.getVersion();
+        if (jvmVersion == JvmVersion.JAVA_6) {
+            return new PinpointThreadLocalRandomFactory();
+        } else if (jvmVersion.onOrAfter(JvmVersion.JAVA_7)) {
+            try {
+                final Class<? extends ThreadLocalRandomFactory> threadLocalRandomFactoryClass =
+                        (Class<? extends ThreadLocalRandomFactory>) Class.forName(DEFAULT_THREAD_LOCAL_RANDOM_FACTORY, true, null);
+                return threadLocalRandomFactoryClass.newInstance();
+            } catch (ClassNotFoundException e) {
+                logError(e);
+            } catch (InstantiationException e) {
+                logError(e);
+            } catch (IllegalAccessException e) {
+                logError(e);
+            }
+            return new PinpointThreadLocalRandomFactory();
+        } else {
+            throw new RuntimeException("Unsupported jvm version " + jvmVersion);
+        }
+
+    }
+
+    private static void logError(Exception e) {
+        LOGGER.warn("Error creating JdkThreadLocalRandomFactory", e);
+    }
+
+    public static Random current() {
+        return THREAD_LOCAL_RANDOM_FACTORY.current();
+    }
+}

--- a/bootstrap/src/main/java/com/navercorp/pinpoint/bootstrap/AgentOption.java
+++ b/bootstrap/src/main/java/com/navercorp/pinpoint/bootstrap/AgentOption.java
@@ -18,6 +18,7 @@ package com.navercorp.pinpoint.bootstrap;
 
 import java.lang.instrument.Instrumentation;
 import java.net.URL;
+import java.util.List;
 
 import com.navercorp.pinpoint.bootstrap.config.ProfilerConfig;
 import com.navercorp.pinpoint.common.service.AnnotationKeyRegistryService;
@@ -36,7 +37,7 @@ public interface AgentOption {
 
     URL[] getPluginJars();
 
-    String getBootStrapCoreJarPath();
+    List<String> getBootstrapJarPaths();
 
     ServiceTypeRegistryService getServiceTypeRegistryService();
     

--- a/bootstrap/src/main/java/com/navercorp/pinpoint/bootstrap/DefaultAgentOption.java
+++ b/bootstrap/src/main/java/com/navercorp/pinpoint/bootstrap/DefaultAgentOption.java
@@ -18,6 +18,8 @@ package com.navercorp.pinpoint.bootstrap;
 
 import java.lang.instrument.Instrumentation;
 import java.net.URL;
+import java.util.Collections;
+import java.util.List;
 
 import com.navercorp.pinpoint.bootstrap.config.ProfilerConfig;
 import com.navercorp.pinpoint.common.service.AnnotationKeyRegistryService;
@@ -31,11 +33,11 @@ public class DefaultAgentOption implements AgentOption {
     private final Instrumentation instrumentation;
     private final ProfilerConfig profilerConfig;
     private final URL[] pluginJars;
-    private final String bootStrapJarCorePath;
+    private final List<String> bootstrapJarPaths;
     private final ServiceTypeRegistryService serviceTypeRegistryService;
     private final AnnotationKeyRegistryService annotationKeyRegistryService;
 
-    public DefaultAgentOption(final String agentArgs, final Instrumentation instrumentation, final ProfilerConfig profilerConfig, final URL[] pluginJars, final String bootStrapJarCorePath, final ServiceTypeRegistryService serviceTypeRegistryService, final AnnotationKeyRegistryService annotationKeyRegistryService) {
+    public DefaultAgentOption(final String agentArgs, final Instrumentation instrumentation, final ProfilerConfig profilerConfig, final URL[] pluginJars, final List<String> bootstrapJarPaths, final ServiceTypeRegistryService serviceTypeRegistryService, final AnnotationKeyRegistryService annotationKeyRegistryService) {
         if (instrumentation == null) {
             throw new NullPointerException("instrumentation must not be null");
         }
@@ -45,9 +47,6 @@ public class DefaultAgentOption implements AgentOption {
         if (pluginJars == null) {
             throw new NullPointerException("pluginJars must not be null");
         }
-//        if (bootStrapJarCorePath == null) {
-//            throw new NullPointerException("bootStrapJarCorePath must not be null");
-//        }
         if (annotationKeyRegistryService == null) {
             throw new NullPointerException("annotationKeyRegistryService must not be null");
         }
@@ -58,7 +57,11 @@ public class DefaultAgentOption implements AgentOption {
         this.instrumentation = instrumentation;
         this.profilerConfig = profilerConfig;
         this.pluginJars = pluginJars;
-        this.bootStrapJarCorePath = bootStrapJarCorePath;
+        if (bootstrapJarPaths == null) {
+            this.bootstrapJarPaths = Collections.emptyList();
+        } else {
+            this.bootstrapJarPaths = bootstrapJarPaths;
+        }
         this.serviceTypeRegistryService = serviceTypeRegistryService;
         this.annotationKeyRegistryService = annotationKeyRegistryService;
     }
@@ -79,8 +82,8 @@ public class DefaultAgentOption implements AgentOption {
     }
 
     @Override
-    public String getBootStrapCoreJarPath() {
-        return this.bootStrapJarCorePath;
+    public List<String> getBootstrapJarPaths() {
+        return this.bootstrapJarPaths;
     }
 
     @Override
@@ -104,7 +107,7 @@ public class DefaultAgentOption implements AgentOption {
                 "agentArgs='" + agentArgs + '\'' +
                 ", instrumentation=" + instrumentation +
                 ", profilerConfig=" + profilerConfig +
-                ", bootStrapJarCorePath='" + bootStrapJarCorePath +
+                ", bootstrapJarPaths='" + bootstrapJarPaths +
                 '}';
     }
 }

--- a/bootstrap/src/main/java/com/navercorp/pinpoint/bootstrap/PinpointBootStrap.java
+++ b/bootstrap/src/main/java/com/navercorp/pinpoint/bootstrap/PinpointBootStrap.java
@@ -65,29 +65,44 @@ public class PinpointBootStrap {
             return;
         }
 
-        // 2nd find boot-strap-core.jar
+        // 2nd find pinpoint-commons.jar
+        final String pinpointCommonsJar = classPathResolver.getPinpointCommonsJar();
+        if (pinpointCommonsJar == null) {
+            logger.warn("pinpoint-commons-x.x.x(-SNAPSHOT).jar not found");
+            logPinpointAgentLoadFail();
+            return;
+        }
+        JarFile pinpointCommonsJarFile = getJarFile(pinpointCommonsJar);
+        if (pinpointCommonsJarFile == null) {
+            logger.warn("pinpoint-commons-x.x.x(-SNAPSHOT).jar not found");
+            logPinpointAgentLoadFail();
+            return;
+        }
+        logger.info("load pinpoint-commons-x.x.x(-SNAPSHOT).jar : " + pinpointCommonsJar);
+        instrumentation.appendToBootstrapClassLoaderSearch(pinpointCommonsJarFile);
+
+        // 3rd find bootstrap-core.jar
         final String bootStrapCoreJar = classPathResolver.getBootStrapCoreJar();
         if (bootStrapCoreJar == null) {
             logger.warn("pinpoint-bootstrap-core-x.x.x(-SNAPSHOT).jar not found");
             logPinpointAgentLoadFail();
             return;
         }
-
-        JarFile bootStrapCoreJarFile = getBootStrapJarFile(bootStrapCoreJar);
+        JarFile bootStrapCoreJarFile = getJarFile(bootStrapCoreJar);
         if (bootStrapCoreJarFile == null) {
             logger.warn("pinpoint-bootstrap-core-x.x.x(-SNAPSHOT).jar not found");
             logPinpointAgentLoadFail();
             return;
         }
-        logger.info("load pinpoint-bootstrap-core-x.x.x(-SNAPSHOT).jar :" + bootStrapCoreJar);
+        logger.info("load pinpoint-bootstrap-core-x.x.x(-SNAPSHOT).jar : " + bootStrapCoreJar);
         instrumentation.appendToBootstrapClassLoaderSearch(bootStrapCoreJarFile);
 
-        // 3rd find boot-strap-core-optional.jar
+        // 4th find bootstrap-core-optional.jar
         final String bootStrapCoreOptionalJar = classPathResolver.getBootStrapCoreOptionalJar();
         if (bootStrapCoreOptionalJar == null) {
             logger.info("pinpoint-bootstrap-core-optional-x.x.x(-SNAPSHOT).jar not found");
         } else {
-            JarFile bootStrapCoreOptionalJarFile = getBootStrapCoreOptionalJarFile(bootStrapCoreOptionalJar);
+            JarFile bootStrapCoreOptionalJarFile = getJarFile(bootStrapCoreOptionalJar);
             if (bootStrapCoreOptionalJarFile == null) {
                 logger.info("pinpoint-bootstrap-core-optional-x.x.x(-SNAPSHOT).jar not found");
             } else {
@@ -122,21 +137,11 @@ public class PinpointBootStrap {
         System.err.println(errorLog);
     }
 
-
-    private static JarFile getBootStrapJarFile(String bootStrapCoreJar) {
+    private static JarFile getJarFile(String jarFilePath) {
         try {
-            return new JarFile(bootStrapCoreJar);
+            return new JarFile(jarFilePath);
         } catch (IOException ioe) {
-            logger.warn(bootStrapCoreJar + " file not found.", ioe);
-            return null;
-        }
-    }
-
-    private static JarFile getBootStrapCoreOptionalJarFile(String bootStrapCoreOptionalJar) {
-        try {
-            return new JarFile(bootStrapCoreOptionalJar);
-        } catch (IOException ioe) {
-            logger.log(Level.SEVERE, bootStrapCoreOptionalJar + " file not found.", ioe);
+            logger.warn(jarFilePath + " file not found.", ioe);
             return null;
         }
     }

--- a/bootstrap/src/main/java/com/navercorp/pinpoint/bootstrap/PinpointBootStrap.java
+++ b/bootstrap/src/main/java/com/navercorp/pinpoint/bootstrap/PinpointBootStrap.java
@@ -81,6 +81,20 @@ public class PinpointBootStrap {
         }
         logger.info("load pinpoint-bootstrap-core-x.x.x(-SNAPSHOT).jar :" + bootStrapCoreJar);
         instrumentation.appendToBootstrapClassLoaderSearch(bootStrapCoreJarFile);
+
+        // 3rd find boot-strap-core-optional.jar
+        final String bootStrapCoreOptionalJar = classPathResolver.getBootStrapCoreOptionalJar();
+        if (bootStrapCoreOptionalJar == null) {
+            logger.info("pinpoint-bootstrap-core-optional-x.x.x(-SNAPSHOT).jar not found");
+        } else {
+            JarFile bootStrapCoreOptionalJarFile = getBootStrapCoreOptionalJarFile(bootStrapCoreOptionalJar);
+            if (bootStrapCoreOptionalJarFile == null) {
+                logger.info("pinpoint-bootstrap-core-optional-x.x.x(-SNAPSHOT).jar not found");
+            } else {
+                logger.info("load pinpoint-bootstrap-core-optional-x.x.x(-SNAPSHOT).jar : " + bootStrapCoreOptionalJar);
+                instrumentation.appendToBootstrapClassLoaderSearch(bootStrapCoreOptionalJarFile);
+            }
+        }
     }
 
     // for test
@@ -114,6 +128,15 @@ public class PinpointBootStrap {
             return new JarFile(bootStrapCoreJar);
         } catch (IOException ioe) {
             logger.warn(bootStrapCoreJar + " file not found.", ioe);
+            return null;
+        }
+    }
+
+    private static JarFile getBootStrapCoreOptionalJarFile(String bootStrapCoreOptionalJar) {
+        try {
+            return new JarFile(bootStrapCoreOptionalJar);
+        } catch (IOException ioe) {
+            logger.log(Level.SEVERE, bootStrapCoreOptionalJar + " file not found.", ioe);
             return null;
         }
     }

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,7 @@
     <modules>
         <module>agent</module>
         <module>bootstrap-core</module>
+        <module>bootstrap-core-optional</module>
         <module>bootstrap</module>
         <module>collector</module>
         <module>commons</module>
@@ -129,6 +130,11 @@
             <dependency>
                 <groupId>com.navercorp.pinpoint</groupId>
                 <artifactId>pinpoint-bootstrap-core</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.navercorp.pinpoint</groupId>
+                <artifactId>pinpoint-bootstrap-core-optional</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>

--- a/profiler-optional/profiler-optional-parent/pom.xml
+++ b/profiler-optional/profiler-optional-parent/pom.xml
@@ -23,10 +23,6 @@
             <exclusions>
                 <exclusion>
                     <groupId>com.navercorp.pinpoint</groupId>
-                    <artifactId>pinpoint-commons</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.navercorp.pinpoint</groupId>
                     <artifactId>pinpoint-bootstrap</artifactId>
                 </exclusion>
                 <exclusion>

--- a/profiler/src/main/java/com/navercorp/pinpoint/profiler/DefaultAgent.java
+++ b/profiler/src/main/java/com/navercorp/pinpoint/profiler/DefaultAgent.java
@@ -174,9 +174,9 @@ public class DefaultAgent implements Agent {
 
         if(this.profilerConfig.isProfileInstrumentASM()) {
             logger.info("ASM class pool.");
-            this.classPool = new ASMClassPool(interceptorRegistryBinder, agentOption.getBootStrapCoreJarPath());
+            this.classPool = new ASMClassPool(interceptorRegistryBinder, agentOption.getBootstrapJarPaths());
         } else {
-            this.classPool = new JavassistClassPool(interceptorRegistryBinder, agentOption.getBootStrapCoreJarPath());
+            this.classPool = new JavassistClassPool(interceptorRegistryBinder, agentOption.getBootstrapJarPaths());
         }
 
         if (logger.isInfoEnabled()) {
@@ -237,8 +237,8 @@ public class DefaultAgent implements Agent {
         return classFileTransformerDispatcher;
     }
 
-    public String getBootstrapCoreJar() {
-        return agentOption.getBootStrapCoreJarPath();
+    public List<String> getBootstrapJarPaths() {
+        return agentOption.getBootstrapJarPaths();
     }
 
     protected List<DefaultProfilerPluginContext> loadPlugins(AgentOption agentOption) {

--- a/profiler/src/main/java/com/navercorp/pinpoint/profiler/instrument/ASMClassPool.java
+++ b/profiler/src/main/java/com/navercorp/pinpoint/profiler/instrument/ASMClassPool.java
@@ -25,6 +25,8 @@ import org.objectweb.asm.tree.ClassNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.List;
+
 /**
  * @author jaehong.kim
  */
@@ -35,7 +37,7 @@ public class ASMClassPool implements InstrumentClassPool {
 
     private final InterceptorRegistryBinder interceptorRegistryBinder;
 
-    public ASMClassPool(final InterceptorRegistryBinder interceptorRegistryBinder, final String bootStrapJar) {
+    public ASMClassPool(final InterceptorRegistryBinder interceptorRegistryBinder, final List<String> bootStrapJars) {
         if (interceptorRegistryBinder == null) {
             throw new NullPointerException("interceptorRegistryBinder must not be null");
         }

--- a/profiler/src/main/java/com/navercorp/pinpoint/profiler/instrument/JavassistClassPool.java
+++ b/profiler/src/main/java/com/navercorp/pinpoint/profiler/instrument/JavassistClassPool.java
@@ -18,6 +18,7 @@ package com.navercorp.pinpoint.profiler.instrument;
 
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.util.List;
 
 import com.navercorp.pinpoint.bootstrap.instrument.*;
 import com.navercorp.pinpoint.profiler.util.JavaAssistUtils;
@@ -69,7 +70,7 @@ public class JavassistClassPool implements InstrumentClassPool {
         }
     };
 
-    public JavassistClassPool(InterceptorRegistryBinder interceptorRegistryBinder, final String bootStrapJar) {
+    public JavassistClassPool(InterceptorRegistryBinder interceptorRegistryBinder, final List<String> bootStrapJars) {
         if (interceptorRegistryBinder == null) {
             throw new NullPointerException("interceptorRegistryBinder must not be null");
         }
@@ -78,9 +79,11 @@ public class JavassistClassPool implements InstrumentClassPool {
             @Override
             public void handleClassPool(NamedClassPool systemClassPool) {
                 try {
-                    if (bootStrapJar != null) {
-                        // append bootstarp-core
-                        systemClassPool.appendClassPath(bootStrapJar);
+                    if (bootStrapJars != null) {
+                        // append bootstarp jars
+                        for (String bootStrapJar : bootStrapJars) {
+                            systemClassPool.appendClassPath(bootStrapJar);
+                        }
                     }
                 } catch (NotFoundException ex) {
                     throw new PinpointException("bootStrapJar not found. Caused by:" + ex.getMessage(), ex);

--- a/profiler/src/main/java/com/navercorp/pinpoint/profiler/instrument/PlainClassLoaderHandler.java
+++ b/profiler/src/main/java/com/navercorp/pinpoint/profiler/instrument/PlainClassLoaderHandler.java
@@ -31,6 +31,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
 import java.util.Collection;
+import java.util.List;
 
 /**
  * @author Woonduk Kang(emeroad)
@@ -75,7 +76,7 @@ public class PlainClassLoaderHandler implements ClassInjector {
         if (isDebug) {
             logger.debug("injectClass0 className:{} cl:{}", className, classLoader);
         }
-        logger.info("bootstrapCoreJarPath:{}", pluginConfig.getBootstrapCoreJarPath());
+        logger.info("bootstrapJarPaths:{}", pluginConfig.getBootstrapJarPaths());
 
         final ClassPool pool = createClassPool(classLoader);
 
@@ -88,8 +89,10 @@ public class PlainClassLoaderHandler implements ClassInjector {
 
     private ClassPool createClassPool(ClassLoader classLoader) throws NotFoundException {
         final ClassPool pool = new ClassPool();
-        final String bootstrapCoreJarPath = pluginConfig.getBootstrapCoreJarPath();
-        pool.appendClassPath(bootstrapCoreJarPath);
+        final List<String> bootstrapJarPaths = pluginConfig.getBootstrapJarPaths();
+        for (String bootstrapJarPath : bootstrapJarPaths) {
+            pool.appendClassPath(bootstrapJarPath);
+        }
 
         final LoaderClassPath loaderClassPath = new LoaderClassPath(classLoader);
         pool.appendClassPath(loaderClassPath);

--- a/profiler/src/main/java/com/navercorp/pinpoint/profiler/plugin/PluginConfig.java
+++ b/profiler/src/main/java/com/navercorp/pinpoint/profiler/plugin/PluginConfig.java
@@ -49,16 +49,19 @@ public class PluginConfig {
 
     private final Instrumentation instrumentation;
     private final InstrumentClassPool classPool;
-    private final String bootstrapCoreJarPath;
+    private final List<String> bootstrapJarPaths;
 
     private final ClassNameFilter pluginPackageFilter;
 
-    public PluginConfig(URL pluginJar, ProfilerPlugin plugin, Instrumentation instrumentation, InstrumentClassPool classPool, String bootstrapCoreJarPath, ClassNameFilter pluginPackageFilter) {
+    public PluginConfig(URL pluginJar, ProfilerPlugin plugin, Instrumentation instrumentation, InstrumentClassPool classPool, List<String> bootstrapJarPaths, ClassNameFilter pluginPackageFilter) {
         if (pluginJar == null) {
             throw new NullPointerException("pluginJar must not be null");
         }
         if (plugin == null) {
             throw new NullPointerException("plugin must not be null");
+        }
+        if (bootstrapJarPaths == null) {
+            throw new NullPointerException("bootstrapJarPaths must not be null");
         }
         this.pluginJar = pluginJar;
         this.pluginJarFile = createJarFile(pluginJar);
@@ -66,7 +69,7 @@ public class PluginConfig {
 
         this.instrumentation = instrumentation;
         this.classPool = classPool;
-        this.bootstrapCoreJarPath = bootstrapCoreJarPath;
+        this.bootstrapJarPaths = bootstrapJarPaths;
 
         this.pluginPackageFilter = pluginPackageFilter;
     }
@@ -112,8 +115,8 @@ public class PluginConfig {
         return classPool;
     }
 
-    public String getBootstrapCoreJarPath() {
-        return bootstrapCoreJarPath;
+    public List<String> getBootstrapJarPaths() {
+        return bootstrapJarPaths;
     }
 
     public ClassNameFilter getPluginPackageFilter() {

--- a/profiler/src/main/java/com/navercorp/pinpoint/profiler/plugin/ProfilerPluginLoader.java
+++ b/profiler/src/main/java/com/navercorp/pinpoint/profiler/plugin/ProfilerPluginLoader.java
@@ -81,7 +81,7 @@ public class ProfilerPluginLoader {
                 
                 logger.info("Loading plugin:{} pluginPackage:{}", plugin.getClass().getName(), plugin);
 
-                PluginConfig pluginConfig = new PluginConfig(jar, plugin, agent.getInstrumentation(), agent.getClassPool(), agent.getBootstrapCoreJar(), pluginFilterChain);
+                PluginConfig pluginConfig = new PluginConfig(jar, plugin, agent.getInstrumentation(), agent.getClassPool(), agent.getBootstrapJarPaths(), pluginFilterChain);
                 final DefaultProfilerPluginContext context = setupPlugin(pluginConfig);
                 pluginContexts.add(context);
             }

--- a/profiler/src/test/java/com/navercorp/pinpoint/profiler/instrument/JarProfilerPluginClassInjectorTest.java
+++ b/profiler/src/test/java/com/navercorp/pinpoint/profiler/instrument/JarProfilerPluginClassInjectorTest.java
@@ -57,7 +57,7 @@ public class JarProfilerPluginClassInjectorTest {
 //        final PluginPackageFilter filter = new PluginPackageFilter(Arrays.asList("test"));
         final String packageName = logger.getClass().getPackage().getName();
         final PluginPackageFilter filter = new PluginPackageFilter(Arrays.asList(packageName));
-        PluginConfig pluginConfig = new PluginConfig(sampleJar, profilerPlugin, instrumentation, pool, sampleJar.getPath(), filter);
+        PluginConfig pluginConfig = new PluginConfig(sampleJar, profilerPlugin, instrumentation, pool, Arrays.asList(sampleJar.getPath()), filter);
 
         PlainClassLoaderHandler injector = new PlainClassLoaderHandler(pluginConfig);
         final Class<?> loggerClass = injector.injectClass(contextTypeMatchClassLoader, logger.getClass().getName());

--- a/quickstart/agent/pom.xml
+++ b/quickstart/agent/pom.xml
@@ -24,6 +24,12 @@
             <scope>runtime</scope>
             <type>pom</type>
         </dependency>
+        <dependency>
+            <groupId>com.navercorp.pinpoint</groupId>
+            <artifactId>pinpoint-bootstrap-core-optional</artifactId>
+            <version>${project.version}</version>
+            <scope>runtime</scope>
+        </dependency>
 
         <!-- plug-ins -->
         <dependency>

--- a/quickstart/agent/src/assembly/distribution.xml
+++ b/quickstart/agent/src/assembly/distribution.xml
@@ -22,7 +22,9 @@
     </dependencySet>
     <dependencySet>
         <includes>
+            <include>com.navercorp.pinpoint:pinpoint-commons</include>
             <include>com.navercorp.pinpoint:pinpoint-bootstrap-core</include>
+            <include>com.navercorp.pinpoint:pinpoint-bootstrap-core-optional</include>
         </includes>
         <outputDirectory>boot</outputDirectory>
     </dependencySet>
@@ -30,6 +32,7 @@
         <excludes>
             <exclude>com.navercorp.pinpoint:pinpoint-commons</exclude>
             <exclude>com.navercorp.pinpoint:pinpoint-bootstrap-core</exclude>
+            <exclude>com.navercorp.pinpoint:pinpoint-bootstrap-core-optional</exclude>
             <exclude>com.navercorp.pinpoint:pinpoint-bootstrap</exclude>
             <exclude>com.navercorp.pinpoint:pinpoint-plugins</exclude>
             <exclude>*:pom</exclude>


### PR DESCRIPTION
This allows for the agent to use enhancements made in JDK7+ if it is running on Java7 and above.
In order to do this, a new module is added(*bootstrap-core-optional*) in which the classes here are compiled using JDK7. The agent then links these classes during runtime only if it is running on Java7+.

Also removed the shading of *pinpoint-commons* module from *bootstrap-core*, so that *pinpoint-commons.jar*, *bootstrap-core.jar*, and *bootstrap-core-optional.jar* are all packaged separately into the agent's *boot* directory. The agent now finds these and adds them to the bootstrap classloader's search path.

Care must be taken when implementing new classes in *bootstrap-core-optional* so that:
1. classes in *bootstrap-core* should not statically reference classes in *bootstrap-core-optional*. This is prevented currently by *bootstrap-core* not having a dependency to *bootstrap-core-optional*.
2. classes in *bootstrap-core-optional* are optional. Failure to load them should not stop the agent from starting (and should fall back to default implementation that would be implemented in *bootstrap-core*).

Resolves #2027 