### PR TITLE
JDK logger conflict in JBoss #2026

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -426,7 +426,7 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty</artifactId>
-                <version>3.6.6.Final</version>
+                <version>3.10.6.Final</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>


### PR DESCRIPTION
1. upgrage netty (3.6.6.Final -> 3.10.6.Final) to avoid JDK logger conflict with JBOSS.