### PR TITLE
Updates mariaDB4j dependency

### DIFF
--- a/agent/pom.xml
+++ b/agent/pom.xml
@@ -85,7 +85,7 @@
         <dependency>
             <groupId>ch.vorburger.mariaDB4j</groupId>
             <artifactId>mariaDB4j</artifactId>
-            <version>2.1.3</version>
+            <version>2.2.2</version>
             <scope>test</scope>
         </dependency>
 

--- a/agent/src/test/java/com/navercorp/pinpoint/plugin/jdbc/mariadb/MariaDB_1_3_x_IT.java
+++ b/agent/src/test/java/com/navercorp/pinpoint/plugin/jdbc/mariadb/MariaDB_1_3_x_IT.java
@@ -13,12 +13,10 @@ import com.navercorp.pinpoint.bootstrap.plugin.test.PluginTestVerifierHolder;
 import com.navercorp.pinpoint.test.plugin.Dependency;
 import com.navercorp.pinpoint.test.plugin.JvmVersion;
 import com.navercorp.pinpoint.test.plugin.PinpointPluginTestSuite;
-import com.navercorp.pinpoint.test.plugin.Repository;
 
 @RunWith(PinpointPluginTestSuite.class)
 @JvmVersion(7)
-@Repository("http://jcenter.bintray.com")
-@Dependency({"org.mariadb.jdbc:mariadb-java-client:[1.3.0,1.3.max]", "ch.vorburger.mariaDB4j:mariaDB4j:2.1.3"})
+@Dependency({"org.mariadb.jdbc:mariadb-java-client:[1.3.0,1.3.max]", "ch.vorburger.mariaDB4j:mariaDB4j:2.2.2"})
 public class MariaDB_1_3_x_IT extends MariaDB_IT_Base {
 
     // see CallableParameterMetaData#queryMetaInfos

--- a/agent/src/test/java/com/navercorp/pinpoint/plugin/jdbc/mariadb/MariaDB_1_4_x_IT.java
+++ b/agent/src/test/java/com/navercorp/pinpoint/plugin/jdbc/mariadb/MariaDB_1_4_x_IT.java
@@ -21,7 +21,6 @@ import com.navercorp.pinpoint.bootstrap.plugin.test.PluginTestVerifierHolder;
 import com.navercorp.pinpoint.test.plugin.Dependency;
 import com.navercorp.pinpoint.test.plugin.JvmVersion;
 import com.navercorp.pinpoint.test.plugin.PinpointPluginTestSuite;
-import com.navercorp.pinpoint.test.plugin.Repository;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -36,8 +35,7 @@ import static com.navercorp.pinpoint.bootstrap.plugin.test.Expectations.*;
 
 @RunWith(PinpointPluginTestSuite.class)
 @JvmVersion(7)
-@Repository("http://jcenter.bintray.com")
-@Dependency({ "org.mariadb.jdbc:mariadb-java-client:[1.4.min,1.4.max]", "ch.vorburger.mariaDB4j:mariaDB4j:2.1.3" })
+@Dependency({ "org.mariadb.jdbc:mariadb-java-client:[1.4.min,1.4.max]", "ch.vorburger.mariaDB4j:mariaDB4j:2.2.2" })
 public class MariaDB_1_4_x_IT extends MariaDB_IT_Base {
 
     // see CallableParameterMetaData#queryMetaInfos


### PR DESCRIPTION
mariaDB4j is pulled from maven central.

Fixes #2072 