### PR TITLE
Fixes StandardHostValve.invoke() not being transformed when excludeurl is not set

### DIFF
--- a/plugins/tomcat/src/main/java/com/navercorp/pinpoint/plugin/tomcat/TomcatConfiguration.java
+++ b/plugins/tomcat/src/main/java/com/navercorp/pinpoint/plugin/tomcat/TomcatConfiguration.java
@@ -14,9 +14,9 @@
  */
 package com.navercorp.pinpoint.plugin.tomcat;
 
-import com.navercorp.pinpoint.bootstrap.config.ExcludePathFilter;
 import com.navercorp.pinpoint.bootstrap.config.Filter;
 import com.navercorp.pinpoint.bootstrap.config.ProfilerConfig;
+import com.navercorp.pinpoint.bootstrap.config.SkipFilter;
 
 /**
  * @author Jongho Moon
@@ -24,14 +24,14 @@ import com.navercorp.pinpoint.bootstrap.config.ProfilerConfig;
  */
 public class TomcatConfiguration {
     private final boolean tomcatHidePinpointHeader;
-    private Filter<String> tomcatExcludeUrlFilter;
+    private final Filter<String> tomcatExcludeUrlFilter;
 
     public TomcatConfiguration(ProfilerConfig config) {
         this.tomcatHidePinpointHeader = config.readBoolean("profiler.tomcat.hidepinpointheader", true);
-        final String tomcatExcludeURL = config.readString("profiler.tomcat.excludeurl", "");
-        
-        if (!tomcatExcludeURL.isEmpty()) {
-            this.tomcatExcludeUrlFilter = new ExcludePathFilter(tomcatExcludeURL);
+        if (config.getTomcatExcludeProfileMethodFilter() == null) {
+            this.tomcatExcludeUrlFilter = new SkipFilter<String>();
+        } else {
+            this.tomcatExcludeUrlFilter = config.getTomcatExcludeUrlFilter();
         }
     }
 


### PR DESCRIPTION
`TomcatConfiguration` does not initialize `tomcatExcludeUrlFilter` (remains null) when `profiler.tomcat.excludeurl` is not set. This causes the agent unable to inject `StandardHostValveInvokeInterceptor` when transforming `StandardHostValve.invoke(...)` method.

This makes it so that `TomcatConfiguration`'s `tomcatExcludeFilter` is never null.

Fixes #2077 