### PR TITLE
Adds enable/disable configurations for mariadb and cassandra plugins

### DIFF
--- a/agent/src/main/resources-local/pinpoint.config
+++ b/agent/src/main/resources-local/pinpoint.config
@@ -159,6 +159,8 @@ profiler.jdbc.mysql.rollback=true
 #
 # MARIADB
 #
+# Profile MariaDB
+profiler.jdbc.mariadb=true
 # Allow profiling of setautocommit.
 profiler.jdbc.mariadb.setautocommit=true
 # Allow profiling of commit.

--- a/agent/src/main/resources-release/pinpoint.config
+++ b/agent/src/main/resources-release/pinpoint.config
@@ -155,6 +155,8 @@ profiler.jdbc.mysql.rollback=true
 #
 # MARIADB
 #
+# Profile MariaDB
+profiler.jdbc.mariadb=true
 # Allow profiling of setautocommit.
 profiler.jdbc.mariadb.setautocommit=true
 # Allow profiling of commit.

--- a/agent/src/main/resources/pinpoint-real-env-lowoverhead-sample.config
+++ b/agent/src/main/resources/pinpoint-real-env-lowoverhead-sample.config
@@ -141,6 +141,8 @@ profiler.jdbc.mysql.rollback=false
 #
 # MARIADB
 #
+# Profile MariaDB
+profiler.jdbc.mariadb=true
 # Allow profiling of setautocommit.
 profiler.jdbc.mariadb.setautocommit=false
 # Allow profiling of commit.
@@ -191,6 +193,14 @@ profiler.jdbc.cubrid.rollback=false
 # Profile DBCP.
 profiler.jdbc.dbcp=true
 profiler.jdbc.dbcp.connectionclose=false
+
+#
+# CASSANDRA
+#
+# Profile CASSANDRA.
+profiler.cassandra=true
+# Trace bindvalues for CASSANDRA PreparedStatements (overrides profiler.jdbc.tracesqlbindvalue)
+#profiler.cassandra.tracecqlbindvalue=true
 
 #
 # PostgreSQL

--- a/agent/src/test/java/com/navercorp/pinpoint/plugin/jdbc/mariadb/MariaDB_1_4_x_IT.java
+++ b/agent/src/test/java/com/navercorp/pinpoint/plugin/jdbc/mariadb/MariaDB_1_4_x_IT.java
@@ -35,7 +35,7 @@ import static com.navercorp.pinpoint.bootstrap.plugin.test.Expectations.*;
 
 @RunWith(PinpointPluginTestSuite.class)
 @JvmVersion(7)
-@Dependency({ "org.mariadb.jdbc:mariadb-java-client:[1.4.min,1.4.max]", "ch.vorburger.mariaDB4j:mariaDB4j:2.2.2" })
+@Dependency({ "org.mariadb.jdbc:mariadb-java-client:[1.4.min,)", "ch.vorburger.mariaDB4j:mariaDB4j:2.2.2" })
 public class MariaDB_1_4_x_IT extends MariaDB_IT_Base {
 
     // see CallableParameterMetaData#queryMetaInfos


### PR DESCRIPTION
This pull request adds configuration options to enable/disable mariadb and cassandra client tracing, as well as expanding integration test coverage to cover mariadb-java-client version 1.5+.