### PR TITLE
Adds support for TProtocolDecorators

### DIFF
--- a/plugins/thrift/src/main/java/com/navercorp/pinpoint/plugin/thrift/ThriftConstants.java
+++ b/plugins/thrift/src/main/java/com/navercorp/pinpoint/plugin/thrift/ThriftConstants.java
@@ -67,4 +67,5 @@ public final class ThriftConstants {
     private static final String FIELD_GETTER_BASE = "com.navercorp.pinpoint.plugin.thrift.field.getter.";
     public static final String FIELD_GETTER_T_NON_BLOCKING_TRANSPORT = FIELD_GETTER_BASE + "TNonblockingTransportFieldGetter";
     public static final String FIELD_GETTER_T_TRANSPORT = FIELD_GETTER_BASE + "TTransportFieldGetter";
+    public static final String FIELD_GETTER_T_PROTOCOL = FIELD_GETTER_BASE + "TProtocolFieldGetter";
 }

--- a/plugins/thrift/src/main/java/com/navercorp/pinpoint/plugin/thrift/ThriftPlugin.java
+++ b/plugins/thrift/src/main/java/com/navercorp/pinpoint/plugin/thrift/ThriftPlugin.java
@@ -418,6 +418,7 @@ public class ThriftPlugin implements ProfilerPlugin, TransformTemplateAware {
         addTProtocolInterceptors(config, "org.apache.thrift.protocol.TBinaryProtocol");
         addTProtocolInterceptors(config, "org.apache.thrift.protocol.TCompactProtocol");
         addTProtocolInterceptors(config, "org.apache.thrift.protocol.TJSONProtocol");
+        addTProtocolDecoratorEditor();
     }
 
     private void addTProtocolInterceptors(ThriftPluginConfig config, String tProtocolClassName) {
@@ -482,6 +483,20 @@ public class ThriftPlugin implements ProfilerPlugin, TransformTemplateAware {
                 return target.toBytecode();
             }
 
+        });
+    }
+
+    private void addTProtocolDecoratorEditor() {
+        transformTemplate.transform("org.apache.thrift.protocol.TProtocolDecorator", new TransformCallback() {
+            @Override
+            public byte[] doInTransform(Instrumentor instrumentor, ClassLoader loader, String className, Class<?> classBeingRedefined,
+                                        ProtectionDomain protectionDomain, byte[] classfileBuffer) throws InstrumentException {
+
+                final InstrumentClass target = instrumentor.getInstrumentClass(loader, className, classfileBuffer);
+
+                target.addGetter(ThriftConstants.FIELD_GETTER_T_PROTOCOL, "concreteProtocol");
+                return target.toBytecode();
+            }
         });
     }
 

--- a/plugins/thrift/src/main/java/com/navercorp/pinpoint/plugin/thrift/field/getter/TProtocolFieldGetter.java
+++ b/plugins/thrift/src/main/java/com/navercorp/pinpoint/plugin/thrift/field/getter/TProtocolFieldGetter.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2016 Naver Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.plugin.thrift.field.getter;
+
+import org.apache.thrift.protocol.TProtocol;
+
+/**
+ * @author HyunGil Jeong
+ */
+public interface TProtocolFieldGetter {
+    TProtocol _$PINPOINT$_getTProtocol();
+}


### PR DESCRIPTION
`TProtocolDecorator` is added in 0.9.1.
When tracing Thrift processors, the agent marks whether to trace a request by setting an injected field to `TProtocol` instance when `ProcessFunction.process(int, TProtocol, TProtocol, I)` is invoked.
If the input protocol (2nd parameter) is an instance of `TProtocolDecorator`, the `ProcessFunction.process` interceptor marks it to the decorator, and not the actual `TProtocol` it is decorating.
This PR fixes this by retrieving the actual `TProtocol` instance before marking it.

for #2106