### PR TITLE
[PinpiontWeb] fix a ActiveThread concurrency problem #1482

### DIFF
--- a/web/src/main/java/com/navercorp/pinpoint/web/websocket/ActiveThreadCountHandler.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/websocket/ActiveThreadCountHandler.java
@@ -214,7 +214,11 @@ public class ActiveThreadCountHandler extends TextWebSocketHandler implements Pi
                     }
 
                     unbindingResponseAggregator(webSocketSession);
-                    bindingResponseAggregator(webSocketSession, applicationName);
+                    if (webSocketSession.isOpen()) {
+                        bindingResponseAggregator(webSocketSession, applicationName);
+                    } else {
+                        logger.warn("WebSocketSession is not opened. skip binding.");
+                    }
                 }
             }
         }


### PR DESCRIPTION
If webSocketSession status is not opened, then do not binding to flush aggregator.