### PR TITLE
Adds conditional registration of class transformers for Tomcat and JBoss plugins

### DIFF
--- a/agent/src/main/resources-local/pinpoint.config
+++ b/agent/src/main/resources-local/pinpoint.config
@@ -120,9 +120,17 @@ profiler.entrypoint=
 profiler.tomcat.enable=true
 # Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
 profiler.tomcat.bootstrap.main=org.apache.catalina.startup.Bootstrap
+# Check pre-conditions when registering class file transformers mainly due to JBoss plugin transforming the same class.
+# Setting this to true currently adds transformers only if the application was launched via org.apache.catalina.startup.Bootstrap,
+# or SpringBoot's launchers.
+# Set this to false to bypass this check entirely (such as when launching standalone applications running embedded Tomcat).
+profiler.tomcat.conditional.transform=true
 # Hide pinpoint headers.
 profiler.tomcat.hidepinpointheader=true
+# URLs to exclude from tracing
 profiler.tomcat.excludeurl=/aa/test.html, /bb/exclude.html
+# HTTP Request methods to exclude from tracing
+#profiler.tomcat.excludemethod=
 profiler.tomcat.tracerequestparam=true
 
 # original IP address header
@@ -140,6 +148,7 @@ profiler.tomcat.tracerequestparam=true
 profiler.jetty.enable=true
 # Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
 profiler.jetty.bootstrap.main=org.eclipse.jetty.start.Main
+# URLs to exclude from tracing
 profiler.jetty.excludeUrl=
 
 
@@ -154,9 +163,28 @@ profiler.dubbo.bootstrap.main=com.alibaba.dubbo.container.Main
 ###########################################################
 # JBOSS                                                   #
 ###########################################################
-profiler.jboss.enable=false
+profiler.jboss.enable=true
 # Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
 profiler.jboss.bootstrap.main=org.jboss.modules.Main
+# Check pre-conditions when registering class file transformers mainly due to Tomcat plugin transforming the same class.
+# Setting this to true currently adds transformers only if the application was launched via org.jboss.modules.Main.
+# Set this to false to bypass this check entirely.
+profiler.jboss.conditional.transform=true
+# Hide pinpoint headers.
+profiler.jboss.hidepinpointheader=true
+# URLs to exclude from tracing
+profiler.jboss.excludeurl=
+# HTTP Request methods to exclude from tracing
+#profiler.jboss.excludemethod=
+profiler.jboss.tracerequestparam=true
+
+# original IP address header
+# https://en.wikipedia.org/wiki/X-Forwarded-For
+#profiler.jboss.realipheader=X-Forwarded-For
+# nginx real ip header
+#profiler.jboss.realipheader=X-Real-IP
+# optional parameter, If the header value is ${profiler.jboss.realipemptyvalue}, Ignore header value.
+#profiler.jboss.realipemptyvalue=unknown
 
 
 ###########################################################

--- a/agent/src/main/resources-release/pinpoint.config
+++ b/agent/src/main/resources-release/pinpoint.config
@@ -116,8 +116,14 @@ profiler.entrypoint=
 profiler.tomcat.enable=true
 # Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
 profiler.tomcat.bootstrap.main=org.apache.catalina.startup.Bootstrap
+# Check pre-conditions when registering class file transformers mainly due to JBoss plugin transforming the same class.
+# Setting this to true currently adds transformers only if the application was launched via org.apache.catalina.startup.Bootstrap,
+# or SpringBoot's launchers.
+# Set this to false to bypass this check entirely (such as when launching standalone applications running embedded Tomcat).
+profiler.tomcat.conditional.transform=true
 # Hide pinpoint headers.
 profiler.tomcat.hidepinpointheader=true
+# URLs to exclude from tracing
 profiler.tomcat.excludeurl=/aa/test.html, /bb/exclude.html
 profiler.tomcat.tracerequestparam=true
 
@@ -136,6 +142,7 @@ profiler.tomcat.tracerequestparam=true
 profiler.jetty.enable=true
 # Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
 profiler.jetty.bootstrap.main=org.eclipse.jetty.start.Main
+# URLs to exclude from tracing
 profiler.jetty.excludeUrl=
 
 
@@ -150,9 +157,28 @@ profiler.dubbo.bootstrap.main=com.alibaba.dubbo.container.Main
 ###########################################################
 # JBOSS                                                   #
 ###########################################################
-profiler.jboss.enable=false
+profiler.jboss.enable=true
 # Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
 profiler.jboss.bootstrap.main=org.jboss.modules.Main
+# Check pre-conditions when registering class file transformers mainly due to Tomcat plugin transforming the same class.
+# Setting this to true currently adds transformers only if the application was launched via org.jboss.modules.Main.
+# Set this to false to bypass this check entirely.
+profiler.jboss.conditional.transform=true
+# Hide pinpoint headers.
+profiler.jboss.hidepinpointheader=true
+# URLs to exclude from tracing
+profiler.jboss.excludeurl=
+# HTTP Request methods to exclude from tracing
+#profiler.jboss.excludemethod=
+profiler.jboss.tracerequestparam=true
+
+# original IP address header
+# https://en.wikipedia.org/wiki/X-Forwarded-For
+#profiler.jboss.realipheader=X-Forwarded-For
+# nginx real ip header
+#profiler.jboss.realipheader=X-Real-IP
+# optional parameter, If the header value is ${profiler.jboss.realipemptyvalue}, Ignore header value.
+#profiler.jboss.realipemptyvalue=unknown
 
 
 ###########################################################

--- a/agent/src/main/resources/pinpoint-real-env-lowoverhead-sample.config
+++ b/agent/src/main/resources/pinpoint-real-env-lowoverhead-sample.config
@@ -107,8 +107,14 @@ profiler.entrypoint=
 profiler.tomcat.enable=true
 # Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
 profiler.tomcat.bootstrap.main=org.apache.catalina.startup.Bootstrap
+# Check pre-conditions when registering class file transformers mainly due to JBoss plugin transforming the same class.
+# Setting this to true currently adds transformers only if the application was launched via org.apache.catalina.startup.Bootstrap,
+# or SpringBoot's launchers.
+# Set this to false to bypass this check entirely (such as when launching standalone applications running embedded Tomcat).
+profiler.tomcat.conditional.transform=true
 # Hide pinpoint headers.
 profiler.tomcat.hidepinpointheader=true
+# URLs to exclude from tracing
 profiler.tomcat.excludeurl=/aa/test.html, /bb/exclude.html
 profiler.tomcat.tracerequestparam=true
 
@@ -127,6 +133,7 @@ profiler.tomcat.tracerequestparam=true
 profiler.jetty.enable=true
 # Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
 profiler.jetty.bootstrap.main=org.eclipse.jetty.start.Main
+# URLs to exclude from tracing
 profiler.jetty.excludeUrl=
 
 
@@ -141,9 +148,28 @@ profiler.dubbo.bootstrap.main=com.alibaba.dubbo.container.Main
 ###########################################################
 # JBOSS                                                   #
 ###########################################################
-profiler.jboss.enable=false
+profiler.jboss.enable=true
 # Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
 profiler.jboss.bootstrap.main=org.jboss.modules.Main
+# Check pre-conditions when registering class file transformers mainly due to Tomcat plugin transforming the same class.
+# Setting this to true currently adds transformers only if the application was launched via org.jboss.modules.Main.
+# Set this to false to bypass this check entirely.
+profiler.jboss.conditional.transform=true
+# Hide pinpoint headers.
+profiler.jboss.hidepinpointheader=true
+# URLs to exclude from tracing
+profiler.jboss.excludeurl=
+# HTTP Request methods to exclude from tracing
+#profiler.jboss.excludemethod=
+profiler.jboss.tracerequestparam=true
+
+# original IP address header
+# https://en.wikipedia.org/wiki/X-Forwarded-For
+#profiler.jboss.realipheader=X-Forwarded-For
+# nginx real ip header
+#profiler.jboss.realipheader=X-Real-IP
+# optional parameter, If the header value is ${profiler.jboss.realipemptyvalue}, Ignore header value.
+#profiler.jboss.realipemptyvalue=unknown
 
 
 ###########################################################

--- a/agent/src/test/resources/activemq/client/pinpoint-activemq-client.config
+++ b/agent/src/test/resources/activemq/client/pinpoint-activemq-client.config
@@ -101,8 +101,14 @@ profiler.entrypoint=
 profiler.tomcat.enable=true
 # Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
 profiler.tomcat.bootstrap.main=org.apache.catalina.startup.Bootstrap
+# Check pre-conditions when registering class file transformers mainly due to JBoss plugin transforming the same class.
+# Setting this to true currently adds transformers only if the application was launched via org.apache.catalina.startup.Bootstrap,
+# or SpringBoot's launchers.
+# Set this to false to bypass this check entirely (such as when launching standalone applications running embedded Tomcat).
+profiler.tomcat.conditional.transform=true
 # Hide pinpoint headers.
 profiler.tomcat.hidepinpointheader=true
+# URLs to exclude from tracing
 profiler.tomcat.excludeurl=/aa/test.html, /bb/exclude.html
 profiler.tomcat.tracerequestparam=true
 
@@ -121,6 +127,7 @@ profiler.tomcat.tracerequestparam=true
 profiler.jetty.enable=true
 # Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
 profiler.jetty.bootstrap.main=org.eclipse.jetty.start.Main
+# URLs to exclude from tracing
 profiler.jetty.excludeUrl=
 
 
@@ -135,9 +142,28 @@ profiler.dubbo.bootstrap.main=com.alibaba.dubbo.container.Main
 ###########################################################
 # JBOSS                                                   #
 ###########################################################
-profiler.jboss.enable=false
+profiler.jboss.enable=true
 # Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
 profiler.jboss.bootstrap.main=org.jboss.modules.Main
+# Check pre-conditions when registering class file transformers mainly due to Tomcat plugin transforming the same class.
+# Setting this to true currently adds transformers only if the application was launched via org.jboss.modules.Main.
+# Set this to false to bypass this check entirely.
+profiler.jboss.conditional.transform=true
+# Hide pinpoint headers.
+profiler.jboss.hidepinpointheader=true
+# URLs to exclude from tracing
+profiler.jboss.excludeurl=
+# HTTP Request methods to exclude from tracing
+#profiler.jboss.excludemethod=
+profiler.jboss.tracerequestparam=true
+
+# original IP address header
+# https://en.wikipedia.org/wiki/X-Forwarded-For
+#profiler.jboss.realipheader=X-Forwarded-For
+# nginx real ip header
+#profiler.jboss.realipheader=X-Real-IP
+# optional parameter, If the header value is ${profiler.jboss.realipemptyvalue}, Ignore header value.
+#profiler.jboss.realipemptyvalue=unknown
 
 
 ###########################################################

--- a/agent/src/test/resources/pinpoint-disabled-plugin-test.config
+++ b/agent/src/test/resources/pinpoint-disabled-plugin-test.config
@@ -78,8 +78,14 @@ profiler.include=
 profiler.tomcat.enable=true
 # Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
 profiler.tomcat.bootstrap.main=org.apache.catalina.startup.Bootstrap
+# Check pre-conditions when registering class file transformers mainly due to JBoss plugin transforming the same class.
+# Setting this to true currently adds transformers only if the application was launched via org.apache.catalina.startup.Bootstrap,
+# or SpringBoot's launchers.
+# Set this to false to bypass this check entirely (such as when launching standalone applications running embedded Tomcat).
+profiler.tomcat.conditional.transform=true
 # Hide pinpoint headers.
 profiler.tomcat.hidepinpointheader=true
+# URLs to exclude from tracing
 profiler.tomcat.excludeurl=/aa/test.html, /bb/exclude.html
 profiler.tomcat.tracerequestparam=true
 
@@ -98,6 +104,7 @@ profiler.tomcat.tracerequestparam=true
 profiler.jetty.enable=true
 # Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
 profiler.jetty.bootstrap.main=org.eclipse.jetty.start.Main
+# URLs to exclude from tracing
 profiler.jetty.excludeUrl=
 
 
@@ -112,9 +119,28 @@ profiler.dubbo.bootstrap.main=com.alibaba.dubbo.container.Main
 ###########################################################
 # JBOSS                                                   #
 ###########################################################
-profiler.jboss.enable=false
+profiler.jboss.enable=true
 # Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
 profiler.jboss.bootstrap.main=org.jboss.modules.Main
+# Check pre-conditions when registering class file transformers mainly due to Tomcat plugin transforming the same class.
+# Setting this to true currently adds transformers only if the application was launched via org.jboss.modules.Main.
+# Set this to false to bypass this check entirely.
+profiler.jboss.conditional.transform=true
+# Hide pinpoint headers.
+profiler.jboss.hidepinpointheader=true
+# URLs to exclude from tracing
+profiler.jboss.excludeurl=
+# HTTP Request methods to exclude from tracing
+#profiler.jboss.excludemethod=
+profiler.jboss.tracerequestparam=true
+
+# original IP address header
+# https://en.wikipedia.org/wiki/X-Forwarded-For
+#profiler.jboss.realipheader=X-Forwarded-For
+# nginx real ip header
+#profiler.jboss.realipheader=X-Real-IP
+# optional parameter, If the header value is ${profiler.jboss.realipemptyvalue}, Ignore header value.
+#profiler.jboss.realipemptyvalue=unknown
 
 
 ###########################################################

--- a/agent/src/test/resources/pinpoint-spring-bean-test.config
+++ b/agent/src/test/resources/pinpoint-spring-bean-test.config
@@ -77,8 +77,14 @@ profiler.include=
 profiler.tomcat.enable=true
 # Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
 profiler.tomcat.bootstrap.main=org.apache.catalina.startup.Bootstrap
+# Check pre-conditions when registering class file transformers mainly due to JBoss plugin transforming the same class.
+# Setting this to true currently adds transformers only if the application was launched via org.apache.catalina.startup.Bootstrap,
+# or SpringBoot's launchers.
+# Set this to false to bypass this check entirely (such as when launching standalone applications running embedded Tomcat).
+profiler.tomcat.conditional.transform=true
 # Hide pinpoint headers.
 profiler.tomcat.hidepinpointheader=true
+# URLs to exclude from tracing
 profiler.tomcat.excludeurl=/aa/test.html, /bb/exclude.html
 profiler.tomcat.tracerequestparam=true
 
@@ -97,6 +103,7 @@ profiler.tomcat.tracerequestparam=true
 profiler.jetty.enable=true
 # Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
 profiler.jetty.bootstrap.main=org.eclipse.jetty.start.Main
+# URLs to exclude from tracing
 profiler.jetty.excludeUrl=
 
 
@@ -111,9 +118,28 @@ profiler.dubbo.bootstrap.main=com.alibaba.dubbo.container.Main
 ###########################################################
 # JBOSS                                                   #
 ###########################################################
-profiler.jboss.enable=false
+profiler.jboss.enable=true
 # Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
 profiler.jboss.bootstrap.main=org.jboss.modules.Main
+# Check pre-conditions when registering class file transformers mainly due to Tomcat plugin transforming the same class.
+# Setting this to true currently adds transformers only if the application was launched via org.jboss.modules.Main.
+# Set this to false to bypass this check entirely.
+profiler.jboss.conditional.transform=true
+# Hide pinpoint headers.
+profiler.jboss.hidepinpointheader=true
+# URLs to exclude from tracing
+profiler.jboss.excludeurl=
+# HTTP Request methods to exclude from tracing
+#profiler.jboss.excludemethod=
+profiler.jboss.tracerequestparam=true
+
+# original IP address header
+# https://en.wikipedia.org/wiki/X-Forwarded-For
+#profiler.jboss.realipheader=X-Forwarded-For
+# nginx real ip header
+#profiler.jboss.realipheader=X-Real-IP
+# optional parameter, If the header value is ${profiler.jboss.realipemptyvalue}, Ignore header value.
+#profiler.jboss.realipemptyvalue=unknown
 
 
 ###########################################################

--- a/plugins/google-httpclient/src/test/resources/pinpoint.config
+++ b/plugins/google-httpclient/src/test/resources/pinpoint.config
@@ -67,8 +67,14 @@ profiler.include=com.navercorp.pinpoint.testweb.controller.*,com.navercorp.pinpo
 profiler.tomcat.enable=true
 # Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
 profiler.tomcat.bootstrap.main=org.apache.catalina.startup.Bootstrap
+# Check pre-conditions when registering class file transformers mainly due to JBoss plugin transforming the same class.
+# Setting this to true currently adds transformers only if the application was launched via org.apache.catalina.startup.Bootstrap,
+# or SpringBoot's launchers.
+# Set this to false to bypass this check entirely (such as when launching standalone applications running embedded Tomcat).
+profiler.tomcat.conditional.transform=true
 # Hide pinpoint headers.
 profiler.tomcat.hidepinpointheader=true
+# URLs to exclude from tracing
 profiler.tomcat.excludeurl=/aa/test.html, /bb/exclude.html
 profiler.tomcat.tracerequestparam=true
 
@@ -87,6 +93,7 @@ profiler.tomcat.tracerequestparam=true
 profiler.jetty.enable=true
 # Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
 profiler.jetty.bootstrap.main=org.eclipse.jetty.start.Main
+# URLs to exclude from tracing
 profiler.jetty.excludeUrl=
 
 
@@ -101,9 +108,28 @@ profiler.dubbo.bootstrap.main=com.alibaba.dubbo.container.Main
 ###########################################################
 # JBOSS                                                   #
 ###########################################################
-profiler.jboss.enable=false
+profiler.jboss.enable=true
 # Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
 profiler.jboss.bootstrap.main=org.jboss.modules.Main
+# Check pre-conditions when registering class file transformers mainly due to Tomcat plugin transforming the same class.
+# Setting this to true currently adds transformers only if the application was launched via org.jboss.modules.Main.
+# Set this to false to bypass this check entirely.
+profiler.jboss.conditional.transform=true
+# Hide pinpoint headers.
+profiler.jboss.hidepinpointheader=true
+# URLs to exclude from tracing
+profiler.jboss.excludeurl=
+# HTTP Request methods to exclude from tracing
+#profiler.jboss.excludemethod=
+profiler.jboss.tracerequestparam=true
+
+# original IP address header
+# https://en.wikipedia.org/wiki/X-Forwarded-For
+#profiler.jboss.realipheader=X-Forwarded-For
+# nginx real ip header
+#profiler.jboss.realipheader=X-Real-IP
+# optional parameter, If the header value is ${profiler.jboss.realipemptyvalue}, Ignore header value.
+#profiler.jboss.realipemptyvalue=unknown
 
 
 ###########################################################

--- a/plugins/httpclient3/src/test/resources/pinpoint.config
+++ b/plugins/httpclient3/src/test/resources/pinpoint.config
@@ -67,8 +67,14 @@ profiler.include=com.navercorp.pinpoint.testweb.controller.*,com.navercorp.pinpo
 profiler.tomcat.enable=true
 # Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
 profiler.tomcat.bootstrap.main=org.apache.catalina.startup.Bootstrap
+# Check pre-conditions when registering class file transformers mainly due to JBoss plugin transforming the same class.
+# Setting this to true currently adds transformers only if the application was launched via org.apache.catalina.startup.Bootstrap,
+# or SpringBoot's launchers.
+# Set this to false to bypass this check entirely (such as when launching standalone applications running embedded Tomcat).
+profiler.tomcat.conditional.transform=true
 # Hide pinpoint headers.
 profiler.tomcat.hidepinpointheader=true
+# URLs to exclude from tracing
 profiler.tomcat.excludeurl=/aa/test.html, /bb/exclude.html
 profiler.tomcat.tracerequestparam=true
 
@@ -87,6 +93,7 @@ profiler.tomcat.tracerequestparam=true
 profiler.jetty.enable=true
 # Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
 profiler.jetty.bootstrap.main=org.eclipse.jetty.start.Main
+# URLs to exclude from tracing
 profiler.jetty.excludeUrl=
 
 
@@ -101,9 +108,28 @@ profiler.dubbo.bootstrap.main=com.alibaba.dubbo.container.Main
 ###########################################################
 # JBOSS                                                   #
 ###########################################################
-profiler.jboss.enable=false
+profiler.jboss.enable=true
 # Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
 profiler.jboss.bootstrap.main=org.jboss.modules.Main
+# Check pre-conditions when registering class file transformers mainly due to Tomcat plugin transforming the same class.
+# Setting this to true currently adds transformers only if the application was launched via org.jboss.modules.Main.
+# Set this to false to bypass this check entirely.
+profiler.jboss.conditional.transform=true
+# Hide pinpoint headers.
+profiler.jboss.hidepinpointheader=true
+# URLs to exclude from tracing
+profiler.jboss.excludeurl=
+# HTTP Request methods to exclude from tracing
+#profiler.jboss.excludemethod=
+profiler.jboss.tracerequestparam=true
+
+# original IP address header
+# https://en.wikipedia.org/wiki/X-Forwarded-For
+#profiler.jboss.realipheader=X-Forwarded-For
+# nginx real ip header
+#profiler.jboss.realipheader=X-Real-IP
+# optional parameter, If the header value is ${profiler.jboss.realipemptyvalue}, Ignore header value.
+#profiler.jboss.realipemptyvalue=unknown
 
 
 ###########################################################

--- a/plugins/httpclient4/src/test/resources/pinpoint.config
+++ b/plugins/httpclient4/src/test/resources/pinpoint.config
@@ -67,8 +67,14 @@ profiler.include=com.navercorp.pinpoint.testweb.controller.*,com.navercorp.pinpo
 profiler.tomcat.enable=true
 # Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
 profiler.tomcat.bootstrap.main=org.apache.catalina.startup.Bootstrap
+# Check pre-conditions when registering class file transformers mainly due to JBoss plugin transforming the same class.
+# Setting this to true currently adds transformers only if the application was launched via org.apache.catalina.startup.Bootstrap,
+# or SpringBoot's launchers.
+# Set this to false to bypass this check entirely (such as when launching standalone applications running embedded Tomcat).
+profiler.tomcat.conditional.transform=true
 # Hide pinpoint headers.
 profiler.tomcat.hidepinpointheader=true
+# URLs to exclude from tracing
 profiler.tomcat.excludeurl=/aa/test.html, /bb/exclude.html
 profiler.tomcat.tracerequestparam=true
 
@@ -87,6 +93,7 @@ profiler.tomcat.tracerequestparam=true
 profiler.jetty.enable=true
 # Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
 profiler.jetty.bootstrap.main=org.eclipse.jetty.start.Main
+# URLs to exclude from tracing
 profiler.jetty.excludeUrl=
 
 
@@ -101,9 +108,28 @@ profiler.dubbo.bootstrap.main=com.alibaba.dubbo.container.Main
 ###########################################################
 # JBOSS                                                   #
 ###########################################################
-profiler.jboss.enable=false
+profiler.jboss.enable=true
 # Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
 profiler.jboss.bootstrap.main=org.jboss.modules.Main
+# Check pre-conditions when registering class file transformers mainly due to Tomcat plugin transforming the same class.
+# Setting this to true currently adds transformers only if the application was launched via org.jboss.modules.Main.
+# Set this to false to bypass this check entirely.
+profiler.jboss.conditional.transform=true
+# Hide pinpoint headers.
+profiler.jboss.hidepinpointheader=true
+# URLs to exclude from tracing
+profiler.jboss.excludeurl=
+# HTTP Request methods to exclude from tracing
+#profiler.jboss.excludemethod=
+profiler.jboss.tracerequestparam=true
+
+# original IP address header
+# https://en.wikipedia.org/wiki/X-Forwarded-For
+#profiler.jboss.realipheader=X-Forwarded-For
+# nginx real ip header
+#profiler.jboss.realipheader=X-Real-IP
+# optional parameter, If the header value is ${profiler.jboss.realipemptyvalue}, Ignore header value.
+#profiler.jboss.realipemptyvalue=unknown
 
 
 ###########################################################

--- a/plugins/jboss/src/main/java/com/navercorp/pinpoint/plugin/jboss/JbossConfig.java
+++ b/plugins/jboss/src/main/java/com/navercorp/pinpoint/plugin/jboss/JbossConfig.java
@@ -42,6 +42,7 @@ public class JbossConfig {
     private final boolean jbossEnable;
 
     private final List<String> jbossBootstrapMains;
+    private final boolean jbossConditionalTransformEnable;
 
     private final String jbossRealIpHeader;
     private final String jbossRealIpEmptyValue;
@@ -58,6 +59,7 @@ public class JbossConfig {
         this.jbossTraceEjb = config.readBoolean("profiler.jboss.traceEjb", false);
 
         this.jbossBootstrapMains = config.readList("profiler.jboss.bootstrap.main");
+        this.jbossConditionalTransformEnable = config.readBoolean("profiler.jboss.conditional.transform", true);
         this.jbossHidePinpointHeader = config.readBoolean("profiler.jboss.hidepinpointheader", true);
 
         this.jbossTraceRequestParam = config.readBoolean("profiler.jboss.tracerequestparam", true);
@@ -84,6 +86,10 @@ public class JbossConfig {
 
     public List<String> getJbossBootstrapMains() {
         return jbossBootstrapMains;
+    }
+
+    public boolean isJbossConditionalTransformEnable() {
+        return jbossConditionalTransformEnable;
     }
 
     /**

--- a/plugins/jboss/src/test/resources/pinpoint.config
+++ b/plugins/jboss/src/test/resources/pinpoint.config
@@ -71,8 +71,14 @@ profiler.include=com.navercorp.pinpoint.testweb.controller.*,com.navercorp.pinpo
 profiler.tomcat.enable=true
 # Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
 profiler.tomcat.bootstrap.main=org.apache.catalina.startup.Bootstrap
+# Check pre-conditions when registering class file transformers mainly due to JBoss plugin transforming the same class.
+# Setting this to true currently adds transformers only if the application was launched via org.apache.catalina.startup.Bootstrap,
+# or SpringBoot's launchers.
+# Set this to false to bypass this check entirely (such as when launching standalone applications running embedded Tomcat).
+profiler.tomcat.conditional.transform=true
 # Hide pinpoint headers.
 profiler.tomcat.hidepinpointheader=true
+# URLs to exclude from tracing
 profiler.tomcat.excludeurl=/aa/test.html, /bb/exclude.html
 profiler.tomcat.tracerequestparam=true
 
@@ -91,6 +97,7 @@ profiler.tomcat.tracerequestparam=true
 profiler.jetty.enable=true
 # Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
 profiler.jetty.bootstrap.main=org.eclipse.jetty.start.Main
+# URLs to exclude from tracing
 profiler.jetty.excludeUrl=
 
 
@@ -108,6 +115,25 @@ profiler.dubbo.bootstrap.main=com.alibaba.dubbo.container.Main
 profiler.jboss.enable=true
 # Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
 profiler.jboss.bootstrap.main=org.jboss.modules.Main
+# Check pre-conditions when registering class file transformers mainly due to Tomcat plugin transforming the same class.
+# Setting this to true currently adds transformers only if the application was launched via org.jboss.modules.Main.
+# Set this to false to bypass this check entirely.
+profiler.jboss.conditional.transform=false
+# Hide pinpoint headers.
+profiler.jboss.hidepinpointheader=true
+# URLs to exclude from tracing
+profiler.jboss.excludeurl=
+# HTTP Request methods to exclude from tracing
+#profiler.jboss.excludemethod=
+profiler.jboss.tracerequestparam=true
+
+# original IP address header
+# https://en.wikipedia.org/wiki/X-Forwarded-For
+#profiler.jboss.realipheader=X-Forwarded-For
+# nginx real ip header
+#profiler.jboss.realipheader=X-Real-IP
+# optional parameter, If the header value is ${profiler.jboss.realipemptyvalue}, Ignore header value.
+#profiler.jboss.realipemptyvalue=unknown
 
 
 ###########################################################

--- a/plugins/redis/src/test/resources/pinpoint.config
+++ b/plugins/redis/src/test/resources/pinpoint.config
@@ -67,8 +67,14 @@ profiler.include=com.navercorp.pinpoint.testweb.controller.*,com.navercorp.pinpo
 profiler.tomcat.enable=true
 # Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
 profiler.tomcat.bootstrap.main=org.apache.catalina.startup.Bootstrap
+# Check pre-conditions when registering class file transformers mainly due to JBoss plugin transforming the same class.
+# Setting this to true currently adds transformers only if the application was launched via org.apache.catalina.startup.Bootstrap,
+# or SpringBoot's launchers.
+# Set this to false to bypass this check entirely (such as when launching standalone applications running embedded Tomcat).
+profiler.tomcat.conditional.transform=true
 # Hide pinpoint headers.
 profiler.tomcat.hidepinpointheader=true
+# URLs to exclude from tracing
 profiler.tomcat.excludeurl=/aa/test.html, /bb/exclude.html
 profiler.tomcat.tracerequestparam=true
 
@@ -87,6 +93,7 @@ profiler.tomcat.tracerequestparam=true
 profiler.jetty.enable=true
 # Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
 profiler.jetty.bootstrap.main=org.eclipse.jetty.start.Main
+# URLs to exclude from tracing
 profiler.jetty.excludeUrl=
 
 
@@ -101,9 +108,28 @@ profiler.dubbo.bootstrap.main=com.alibaba.dubbo.container.Main
 ###########################################################
 # JBOSS                                                   #
 ###########################################################
-profiler.jboss.enable=false
+profiler.jboss.enable=true
 # Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
 profiler.jboss.bootstrap.main=org.jboss.modules.Main
+# Check pre-conditions when registering class file transformers mainly due to Tomcat plugin transforming the same class.
+# Setting this to true currently adds transformers only if the application was launched via org.jboss.modules.Main.
+# Set this to false to bypass this check entirely.
+profiler.jboss.conditional.transform=true
+# Hide pinpoint headers.
+profiler.jboss.hidepinpointheader=true
+# URLs to exclude from tracing
+profiler.jboss.excludeurl=
+# HTTP Request methods to exclude from tracing
+#profiler.jboss.excludemethod=
+profiler.jboss.tracerequestparam=true
+
+# original IP address header
+# https://en.wikipedia.org/wiki/X-Forwarded-For
+#profiler.jboss.realipheader=X-Forwarded-For
+# nginx real ip header
+#profiler.jboss.realipheader=X-Real-IP
+# optional parameter, If the header value is ${profiler.jboss.realipemptyvalue}, Ignore header value.
+#profiler.jboss.realipemptyvalue=unknown
 
 
 ###########################################################

--- a/plugins/tomcat/src/main/java/com/navercorp/pinpoint/plugin/tomcat/TomcatConfig.java
+++ b/plugins/tomcat/src/main/java/com/navercorp/pinpoint/plugin/tomcat/TomcatConfig.java
@@ -32,6 +32,7 @@ public class TomcatConfig {
 
     private final boolean tomcatEnable;
     private final List<String> tomcatBootstrapMains;
+    private final boolean tomcatConditionalTransformEnable;
     private final boolean tomcatHidePinpointHeader;
 
     private final boolean tomcatTraceRequestParam;
@@ -39,6 +40,9 @@ public class TomcatConfig {
     private final String tomcatRealIpHeader;
     private final String tomcatRealIpEmptyValue;
     private final Filter<String> tomcatExcludeProfileMethodFilter;
+
+    // for transform conditional check
+    private final List<String> springBootBootstrapMains;
 
     public TomcatConfig(ProfilerConfig config) {
         if (config == null) {
@@ -48,6 +52,7 @@ public class TomcatConfig {
         // plugin
         this.tomcatEnable = config.readBoolean("profiler.tomcat.enable", true);
         this.tomcatBootstrapMains = config.readList("profiler.tomcat.bootstrap.main");
+        this.tomcatConditionalTransformEnable = config.readBoolean("profiler.tomcat.conditional.transform", true);
         this.tomcatHidePinpointHeader = config.readBoolean("profiler.tomcat.hidepinpointheader", true);
 
         // runtime
@@ -67,6 +72,8 @@ public class TomcatConfig {
         } else {
             this.tomcatExcludeProfileMethodFilter = new SkipFilter<String>();
         }
+
+        this.springBootBootstrapMains = config.readList("profiler.springboot.bootstrap.main");
     }
 
     public boolean isTomcatEnable() {
@@ -75,6 +82,10 @@ public class TomcatConfig {
 
     public List<String> getTomcatBootstrapMains() {
         return tomcatBootstrapMains;
+    }
+
+    public boolean isTomcatConditionalTransformEnable() {
+        return tomcatConditionalTransformEnable;
     }
 
     public boolean isTomcatHidePinpointHeader() {
@@ -101,12 +112,16 @@ public class TomcatConfig {
         return tomcatExcludeProfileMethodFilter;
     }
 
+    public List<String> getSpringBootBootstrapMains() {
+        return springBootBootstrapMains;
+    }
 
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder("TomcatConfig{");
         sb.append("tomcatEnable=").append(tomcatEnable);
         sb.append(", tomcatBootstrapMains=").append(tomcatBootstrapMains);
+        sb.append(", tomcatConditionalTransformEnable=").append(tomcatConditionalTransformEnable);
         sb.append(", tomcatHidePinpointHeader=").append(tomcatHidePinpointHeader);
         sb.append(", tomcatTraceRequestParam=").append(tomcatTraceRequestParam);
         sb.append(", tomcatExcludeUrlFilter=").append(tomcatExcludeUrlFilter);

--- a/plugins/tomcat/src/test/resources/pinpoint.config
+++ b/plugins/tomcat/src/test/resources/pinpoint.config
@@ -71,8 +71,14 @@ profiler.include=com.navercorp.pinpoint.testweb.controller.*,com.navercorp.pinpo
 profiler.tomcat.enable=true
 # Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
 profiler.tomcat.bootstrap.main=org.apache.catalina.startup.Bootstrap
+# Check pre-conditions when registering class file transformers mainly due to JBoss plugin transforming the same class.
+# Setting this to true currently adds transformers only if the application was launched via org.apache.catalina.startup.Bootstrap,
+# or SpringBoot's launchers.
+# Set this to false to bypass this check entirely (such as when launching standalone applications running embedded Tomcat).
+profiler.tomcat.conditional.transform=false
 # Hide pinpoint headers.
 profiler.tomcat.hidepinpointheader=true
+# URLs to exclude from tracing
 profiler.tomcat.excludeurl=/aa/test.html, /bb/exclude.html
 profiler.tomcat.tracerequestparam=true
 
@@ -91,6 +97,7 @@ profiler.tomcat.tracerequestparam=true
 profiler.jetty.enable=true
 # Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
 profiler.jetty.bootstrap.main=org.eclipse.jetty.start.Main
+# URLs to exclude from tracing
 profiler.jetty.excludeUrl=
 
 
@@ -105,9 +112,28 @@ profiler.dubbo.bootstrap.main=com.alibaba.dubbo.container.Main
 ###########################################################
 # JBOSS                                                   #
 ###########################################################
-profiler.jboss.enable=false
+profiler.jboss.enable=true
 # Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
 profiler.jboss.bootstrap.main=org.jboss.modules.Main
+# Check pre-conditions when registering class file transformers mainly due to Tomcat plugin transforming the same class.
+# Setting this to true currently adds transformers only if the application was launched via org.jboss.modules.Main.
+# Set this to false to bypass this check entirely.
+profiler.jboss.conditional.transform=true
+# Hide pinpoint headers.
+profiler.jboss.hidepinpointheader=true
+# URLs to exclude from tracing
+profiler.jboss.excludeurl=
+# HTTP Request methods to exclude from tracing
+#profiler.jboss.excludemethod=
+profiler.jboss.tracerequestparam=true
+
+# original IP address header
+# https://en.wikipedia.org/wiki/X-Forwarded-For
+#profiler.jboss.realipheader=X-Forwarded-For
+# nginx real ip header
+#profiler.jboss.realipheader=X-Real-IP
+# optional parameter, If the header value is ${profiler.jboss.realipemptyvalue}, Ignore header value.
+#profiler.jboss.realipemptyvalue=unknown
 
 
 ###########################################################

--- a/plugins/user/src/test/resources/pinpoint.config
+++ b/plugins/user/src/test/resources/pinpoint.config
@@ -67,8 +67,14 @@ profiler.include=com.navercorp.pinpoint.testweb.controller.*,com.navercorp.pinpo
 profiler.tomcat.enable=true
 # Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
 profiler.tomcat.bootstrap.main=org.apache.catalina.startup.Bootstrap
+# Check pre-conditions when registering class file transformers mainly due to JBoss plugin transforming the same class.
+# Setting this to true currently adds transformers only if the application was launched via org.apache.catalina.startup.Bootstrap,
+# or SpringBoot's launchers.
+# Set this to false to bypass this check entirely (such as when launching standalone applications running embedded Tomcat).
+profiler.tomcat.conditional.transform=true
 # Hide pinpoint headers.
 profiler.tomcat.hidepinpointheader=true
+# URLs to exclude from tracing
 profiler.tomcat.excludeurl=/aa/test.html, /bb/exclude.html
 profiler.tomcat.tracerequestparam=true
 
@@ -87,6 +93,7 @@ profiler.tomcat.tracerequestparam=true
 profiler.jetty.enable=true
 # Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
 profiler.jetty.bootstrap.main=org.eclipse.jetty.start.Main
+# URLs to exclude from tracing
 profiler.jetty.excludeUrl=
 
 
@@ -101,9 +108,28 @@ profiler.dubbo.bootstrap.main=com.alibaba.dubbo.container.Main
 ###########################################################
 # JBOSS                                                   #
 ###########################################################
-profiler.jboss.enable=false
+profiler.jboss.enable=true
 # Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
 profiler.jboss.bootstrap.main=org.jboss.modules.Main
+# Check pre-conditions when registering class file transformers mainly due to Tomcat plugin transforming the same class.
+# Setting this to true currently adds transformers only if the application was launched via org.jboss.modules.Main.
+# Set this to false to bypass this check entirely.
+profiler.jboss.conditional.transform=true
+# Hide pinpoint headers.
+profiler.jboss.hidepinpointheader=true
+# URLs to exclude from tracing
+profiler.jboss.excludeurl=
+# HTTP Request methods to exclude from tracing
+#profiler.jboss.excludemethod=
+profiler.jboss.tracerequestparam=true
+
+# original IP address header
+# https://en.wikipedia.org/wiki/X-Forwarded-For
+#profiler.jboss.realipheader=X-Forwarded-For
+# nginx real ip header
+#profiler.jboss.realipheader=X-Real-IP
+# optional parameter, If the header value is ${profiler.jboss.realipemptyvalue}, Ignore header value.
+#profiler.jboss.realipemptyvalue=unknown
 
 
 ###########################################################

--- a/profiler-optional/profiler-optional-jdk8/src/test/resources/pinpoint-lambda-test.config
+++ b/profiler-optional/profiler-optional-jdk8/src/test/resources/pinpoint-lambda-test.config
@@ -74,8 +74,14 @@ profiler.include=
 profiler.tomcat.enable=true
 # Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
 profiler.tomcat.bootstrap.main=org.apache.catalina.startup.Bootstrap
+# Check pre-conditions when registering class file transformers mainly due to JBoss plugin transforming the same class.
+# Setting this to true currently adds transformers only if the application was launched via org.apache.catalina.startup.Bootstrap,
+# or SpringBoot's launchers.
+# Set this to false to bypass this check entirely (such as when launching standalone applications running embedded Tomcat).
+profiler.tomcat.conditional.transform=true
 # Hide pinpoint headers.
 profiler.tomcat.hidepinpointheader=true
+# URLs to exclude from tracing
 profiler.tomcat.excludeurl=/aa/test.html, /bb/exclude.html
 profiler.tomcat.tracerequestparam=true
 
@@ -94,6 +100,7 @@ profiler.tomcat.tracerequestparam=true
 profiler.jetty.enable=true
 # Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
 profiler.jetty.bootstrap.main=org.eclipse.jetty.start.Main
+# URLs to exclude from tracing
 profiler.jetty.excludeUrl=
 
 
@@ -108,9 +115,28 @@ profiler.dubbo.bootstrap.main=com.alibaba.dubbo.container.Main
 ###########################################################
 # JBOSS                                                   #
 ###########################################################
-profiler.jboss.enable=false
+profiler.jboss.enable=true
 # Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
 profiler.jboss.bootstrap.main=org.jboss.modules.Main
+# Check pre-conditions when registering class file transformers mainly due to Tomcat plugin transforming the same class.
+# Setting this to true currently adds transformers only if the application was launched via org.jboss.modules.Main.
+# Set this to false to bypass this check entirely.
+profiler.jboss.conditional.transform=true
+# Hide pinpoint headers.
+profiler.jboss.hidepinpointheader=true
+# URLs to exclude from tracing
+profiler.jboss.excludeurl=
+# HTTP Request methods to exclude from tracing
+#profiler.jboss.excludemethod=
+profiler.jboss.tracerequestparam=true
+
+# original IP address header
+# https://en.wikipedia.org/wiki/X-Forwarded-For
+#profiler.jboss.realipheader=X-Forwarded-For
+# nginx real ip header
+#profiler.jboss.realipheader=X-Real-IP
+# optional parameter, If the header value is ${profiler.jboss.realipemptyvalue}, Ignore header value.
+#profiler.jboss.realipemptyvalue=unknown
 
 
 ###########################################################

--- a/profiler/src/test/resources/pinpoint-spring-bean-test.config
+++ b/profiler/src/test/resources/pinpoint-spring-bean-test.config
@@ -72,8 +72,14 @@ profiler.include=
 profiler.tomcat.enable=true
 # Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
 profiler.tomcat.bootstrap.main=org.apache.catalina.startup.Bootstrap
+# Check pre-conditions when registering class file transformers mainly due to JBoss plugin transforming the same class.
+# Setting this to true currently adds transformers only if the application was launched via org.apache.catalina.startup.Bootstrap,
+# or SpringBoot's launchers.
+# Set this to false to bypass this check entirely (such as when launching standalone applications running embedded Tomcat).
+profiler.tomcat.conditional.transform=true
 # Hide pinpoint headers.
 profiler.tomcat.hidepinpointheader=true
+# URLs to exclude from tracing
 profiler.tomcat.excludeurl=/aa/test.html, /bb/exclude.html
 profiler.tomcat.tracerequestparam=true
 
@@ -92,6 +98,7 @@ profiler.tomcat.tracerequestparam=true
 profiler.jetty.enable=true
 # Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
 profiler.jetty.bootstrap.main=org.eclipse.jetty.start.Main
+# URLs to exclude from tracing
 profiler.jetty.excludeUrl=
 
 
@@ -106,9 +113,28 @@ profiler.dubbo.bootstrap.main=com.alibaba.dubbo.container.Main
 ###########################################################
 # JBOSS                                                   #
 ###########################################################
-profiler.jboss.enable=false
+profiler.jboss.enable=true
 # Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
 profiler.jboss.bootstrap.main=org.jboss.modules.Main
+# Check pre-conditions when registering class file transformers mainly due to Tomcat plugin transforming the same class.
+# Setting this to true currently adds transformers only if the application was launched via org.jboss.modules.Main.
+# Set this to false to bypass this check entirely.
+profiler.jboss.conditional.transform=true
+# Hide pinpoint headers.
+profiler.jboss.hidepinpointheader=true
+# URLs to exclude from tracing
+profiler.jboss.excludeurl=
+# HTTP Request methods to exclude from tracing
+#profiler.jboss.excludemethod=
+profiler.jboss.tracerequestparam=true
+
+# original IP address header
+# https://en.wikipedia.org/wiki/X-Forwarded-For
+#profiler.jboss.realipheader=X-Forwarded-For
+# nginx real ip header
+#profiler.jboss.realipheader=X-Real-IP
+# optional parameter, If the header value is ${profiler.jboss.realipemptyvalue}, Ignore header value.
+#profiler.jboss.realipemptyvalue=unknown
 
 
 ###########################################################

--- a/profiler/src/test/resources/pinpoint.config
+++ b/profiler/src/test/resources/pinpoint.config
@@ -71,8 +71,14 @@ profiler.include=com.navercorp.pinpoint.testweb.controller.*,com.navercorp.pinpo
 profiler.tomcat.enable=true
 # Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
 profiler.tomcat.bootstrap.main=org.apache.catalina.startup.Bootstrap
+# Check pre-conditions when registering class file transformers mainly due to JBoss plugin transforming the same class.
+# Setting this to true currently adds transformers only if the application was launched via org.apache.catalina.startup.Bootstrap,
+# or SpringBoot's launchers.
+# Set this to false to bypass this check entirely (such as when launching standalone applications running embedded Tomcat).
+profiler.tomcat.conditional.transform=true
 # Hide pinpoint headers.
 profiler.tomcat.hidepinpointheader=true
+# URLs to exclude from tracing
 profiler.tomcat.excludeurl=/aa/test.html, /bb/exclude.html
 profiler.tomcat.tracerequestparam=true
 
@@ -91,6 +97,7 @@ profiler.tomcat.tracerequestparam=true
 profiler.jetty.enable=true
 # Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
 profiler.jetty.bootstrap.main=org.eclipse.jetty.start.Main
+# URLs to exclude from tracing
 profiler.jetty.excludeUrl=
 
 
@@ -105,9 +112,28 @@ profiler.dubbo.bootstrap.main=com.alibaba.dubbo.container.Main
 ###########################################################
 # JBOSS                                                   #
 ###########################################################
-profiler.jboss.enable=false
+profiler.jboss.enable=true
 # Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
 profiler.jboss.bootstrap.main=org.jboss.modules.Main
+# Check pre-conditions when registering class file transformers mainly due to Tomcat plugin transforming the same class.
+# Setting this to true currently adds transformers only if the application was launched via org.jboss.modules.Main.
+# Set this to false to bypass this check entirely.
+profiler.jboss.conditional.transform=true
+# Hide pinpoint headers.
+profiler.jboss.hidepinpointheader=true
+# URLs to exclude from tracing
+profiler.jboss.excludeurl=
+# HTTP Request methods to exclude from tracing
+#profiler.jboss.excludemethod=
+profiler.jboss.tracerequestparam=true
+
+# original IP address header
+# https://en.wikipedia.org/wiki/X-Forwarded-For
+#profiler.jboss.realipheader=X-Forwarded-For
+# nginx real ip header
+#profiler.jboss.realipheader=X-Real-IP
+# optional parameter, If the header value is ${profiler.jboss.realipemptyvalue}, Ignore header value.
+#profiler.jboss.realipemptyvalue=unknown
 
 
 ###########################################################

--- a/quickstart/agent/src/main/resources/pinpoint.config
+++ b/quickstart/agent/src/main/resources/pinpoint.config
@@ -74,8 +74,14 @@ profiler.entrypoint=
 profiler.tomcat.enable=true
 # Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
 profiler.tomcat.bootstrap.main=org.apache.catalina.startup.Bootstrap
+# Check pre-conditions when registering class file transformers mainly due to JBoss plugin transforming the same class.
+# Setting this to true currently adds transformers only if the application was launched via org.apache.catalina.startup.Bootstrap,
+# or SpringBoot's launchers.
+# Set this to false to bypass this check entirely (such as when launching standalone applications running embedded Tomcat).
+profiler.tomcat.conditional.transform=true
 # Hide pinpoint headers.
 profiler.tomcat.hidepinpointheader=true
+# URLs to exclude from tracing
 profiler.tomcat.excludeurl=/aa/test.html, /bb/exclude.html
 profiler.tomcat.tracerequestparam=true
 
@@ -94,6 +100,7 @@ profiler.tomcat.tracerequestparam=true
 profiler.jetty.enable=true
 # Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
 profiler.jetty.bootstrap.main=org.eclipse.jetty.start.Main
+# URLs to exclude from tracing
 profiler.jetty.excludeUrl=
 
 
@@ -108,9 +115,28 @@ profiler.dubbo.bootstrap.main=com.alibaba.dubbo.container.Main
 ###########################################################
 # JBOSS                                                   #
 ###########################################################
-profiler.jboss.enable=false
+profiler.jboss.enable=true
 # Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
 profiler.jboss.bootstrap.main=org.jboss.modules.Main
+# Check pre-conditions when registering class file transformers mainly due to Tomcat plugin transforming the same class.
+# Setting this to true currently adds transformers only if the application was launched via org.jboss.modules.Main.
+# Set this to false to bypass this check entirely.
+profiler.jboss.conditional.transform=true
+# Hide pinpoint headers.
+profiler.jboss.hidepinpointheader=true
+# URLs to exclude from tracing
+profiler.jboss.excludeurl=
+# HTTP Request methods to exclude from tracing
+#profiler.jboss.excludemethod=
+profiler.jboss.tracerequestparam=true
+
+# original IP address header
+# https://en.wikipedia.org/wiki/X-Forwarded-For
+#profiler.jboss.realipheader=X-Forwarded-For
+# nginx real ip header
+#profiler.jboss.realipheader=X-Real-IP
+# optional parameter, If the header value is ${profiler.jboss.realipemptyvalue}, Ignore header value.
+#profiler.jboss.realipemptyvalue=unknown
 
 
 ###########################################################

--- a/quickstart/conf/pinpoint.config
+++ b/quickstart/conf/pinpoint.config
@@ -73,8 +73,14 @@ profiler.include=
 profiler.tomcat.enable=true
 # Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
 profiler.tomcat.bootstrap.main=org.apache.catalina.startup.Bootstrap
+# Check pre-conditions when registering class file transformers mainly due to JBoss plugin transforming the same class.
+# Setting this to true currently adds transformers only if the application was launched via org.apache.catalina.startup.Bootstrap,
+# or SpringBoot's launchers.
+# Set this to false to bypass this check entirely (such as when launching standalone applications running embedded Tomcat).
+profiler.tomcat.conditional.transform=true
 # Hide pinpoint headers.
 profiler.tomcat.hidepinpointheader=true
+# URLs to exclude from tracing
 profiler.tomcat.excludeurl=/aa/test.html, /bb/exclude.html
 profiler.tomcat.tracerequestparam=true
 
@@ -93,6 +99,7 @@ profiler.tomcat.tracerequestparam=true
 profiler.jetty.enable=true
 # Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
 profiler.jetty.bootstrap.main=org.eclipse.jetty.start.Main
+# URLs to exclude from tracing
 profiler.jetty.excludeUrl=
 
 
@@ -107,9 +114,28 @@ profiler.dubbo.bootstrap.main=com.alibaba.dubbo.container.Main
 ###########################################################
 # JBOSS                                                   #
 ###########################################################
-profiler.jboss.enable=false
+profiler.jboss.enable=true
 # Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
 profiler.jboss.bootstrap.main=org.jboss.modules.Main
+# Check pre-conditions when registering class file transformers mainly due to Tomcat plugin transforming the same class.
+# Setting this to true currently adds transformers only if the application was launched via org.jboss.modules.Main.
+# Set this to false to bypass this check entirely.
+profiler.jboss.conditional.transform=true
+# Hide pinpoint headers.
+profiler.jboss.hidepinpointheader=true
+# URLs to exclude from tracing
+profiler.jboss.excludeurl=
+# HTTP Request methods to exclude from tracing
+#profiler.jboss.excludemethod=
+profiler.jboss.tracerequestparam=true
+
+# original IP address header
+# https://en.wikipedia.org/wiki/X-Forwarded-For
+#profiler.jboss.realipheader=X-Forwarded-For
+# nginx real ip header
+#profiler.jboss.realipheader=X-Real-IP
+# optional parameter, If the header value is ${profiler.jboss.realipemptyvalue}, Ignore header value.
+#profiler.jboss.realipemptyvalue=unknown
 
 
 ###########################################################


### PR DESCRIPTION
This allows Tomcat and JBoss plugins to check the application's main class to determine if they should add class file transformers.
Tomcat plugin checks if the application was launched via Tomcat's Bootstrap, or one of SpringBoot's many launchers.
JBoss plugin checks if the application was launched via JBoss' Main.
Configuration option is also added to disable this check entirely.

resolves #2178 