### PR TITLE
[no issue] Fixed test case.

### DIFF
--- a/agent/src/test/java/com/navercorp/pinpoint/plugin/httpclient3/HttpClientIT.java
+++ b/agent/src/test/java/com/navercorp/pinpoint/plugin/httpclient3/HttpClientIT.java
@@ -35,10 +35,13 @@ import com.navercorp.pinpoint.test.plugin.PinpointPluginTestSuite;
 @RunWith(PinpointPluginTestSuite.class)
 @Dependency({ "commons-httpclient:commons-httpclient:[3.0],[3.0.1],[3.1]" })
 public class HttpClientIT {
+
+    public static final long CONNECTION_TIMEOUT = 10000;
+
     @Test
     public void test() throws Exception {
-
         HttpClient client = new HttpClient();
+        client.getParams().setConnectionManagerTimeout(CONNECTION_TIMEOUT);
         GetMethod method = new GetMethod("http://google.com");
 
         // Provide custom retry handler is necessary
@@ -60,6 +63,7 @@ public class HttpClientIT {
     @Test
     public void hostConfig() throws Exception {
         HttpClient client = new HttpClient();
+        client.getParams().setConnectionManagerTimeout(CONNECTION_TIMEOUT);
         HostConfiguration config = new HostConfiguration();
         config.setHost("weather.naver.com", 80, "http");
         GetMethod method = new GetMethod("/rgn/cityWetrMain.nhn");


### PR DESCRIPTION
Sometimes HttpClient3 stuck on execute releaseConnection method.
Set the connection timeout to ensure release connection .

```
"main" prio=10 tid=0x00007fb0e800d000 nid=0x1faa runnable [0x00007fb0ec4b1000]
   java.lang.Thread.State: RUNNABLE
        at java.net.SocketInputStream.socketRead0(Native Method)
        at java.net.SocketInputStream.read(SocketInputStream.java:129)
        at java.io.BufferedInputStream.fill(BufferedInputStream.java:218)
        at java.io.BufferedInputStream.read1(BufferedInputStream.java:258)
        at java.io.BufferedInputStream.read(BufferedInputStream.java:317)
        - locked <0x00000007ad42b490> (a java.io.BufferedInputStream)
        at org.apache.commons.httpclient.ChunkedInputStream.read(ChunkedInputStream.java:181)
        at org.apache.commons.httpclient.ChunkedInputStream.read(ChunkedInputStream.java:195)
        at org.apache.commons.httpclient.ChunkedInputStream.exhaustInputStream(ChunkedInputStream.java:368)
        at org.apache.commons.httpclient.ChunkedInputStream.close(ChunkedInputStream.java:345)
        at java.io.FilterInputStream.close(FilterInputStream.java:155)
        at org.apache.commons.httpclient.AutoCloseInputStream.notifyWatcher(AutoCloseInputStream.java:176)
        at org.apache.commons.httpclient.AutoCloseInputStream.close(AutoCloseInputStream.java:140)
        at org.apache.commons.httpclient.HttpMethodBase.releaseConnection(HttpMethodBase.java:1078)
        at com.navercorp.pinpoint.plugin.httpclient3.HttpClientIT.hostConfig(HttpClientIT.java:76)
```