### PR TITLE
alarm mysql, table name error: change date_val to date_time

### DIFF
--- a/web/src/main/resources/sql/CreateTableStatement-mysql.sql
+++ b/web/src/main/resources/sql/CreateTableStatement-mysql.sql
@@ -56,6 +56,6 @@ ALTER TABLE alarm_history ADD UNIQUE KEY application_id_checker_name_idx (applic
 
 CREATE TABLE `agent_statistics` (
 	`agent_count` INT(10) UNSIGNED NOT NULL,
-	`date_val`DATETIME NOT NULL,
-	PRIMARY KEY (`date_val`)
+	`date_time`DATETIME NOT NULL,
+	PRIMARY KEY (`date_time`)
 );


### PR DESCRIPTION
Hi,I have tried the alarm system, and found this error from logs.  I had a look at the AgentStaticsMapper.xml and then made this change.