### PR TITLE
#2312 Deprecated StringUtils.drop() api

### DIFF
--- a/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/jdbc/bindvalue/BindValueUtils.java
+++ b/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/jdbc/bindvalue/BindValueUtils.java
@@ -77,7 +77,7 @@ public final class BindValueUtils {
                 break;
             }
             final String bindValue = StringUtils.defaultString(bindValueArray[i], "");
-            StringUtils.appendDrop(sb, bindValue, limit);
+            StringUtils.appendAbbreviate(sb, bindValue, limit);
             if (i < end) {
                 sb.append(", ");
             }

--- a/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/jdbc/bindvalue/ClassNameConverter.java
+++ b/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/jdbc/bindvalue/ClassNameConverter.java
@@ -28,10 +28,10 @@ public class ClassNameConverter implements Converter {
             return "null";
         }
         if (args.length == 2) {
-            return StringUtils.drop(getClassName(args[1]));
+            return StringUtils.abbreviate(getClassName(args[1]));
         } else if(args.length == 3) {
            // need to handle 3rd arg?
-            return StringUtils.drop(getClassName(args[1]));
+            return StringUtils.abbreviate(getClassName(args[1]));
         }
         return "error";
     }

--- a/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/jdbc/bindvalue/ObjectConverter.java
+++ b/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/jdbc/bindvalue/ObjectConverter.java
@@ -90,7 +90,7 @@ public class ObjectConverter implements Converter {
     }
 
     private String dropToString(Object param) {
-        return StringUtils.drop(param.toString());
+        return StringUtils.abbreviate(param.toString());
     }
 
     private String getClassName(Object param) {

--- a/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/jdbc/bindvalue/SimpleTypeConverter.java
+++ b/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/jdbc/bindvalue/SimpleTypeConverter.java
@@ -28,10 +28,10 @@ public class SimpleTypeConverter implements Converter {
             return "null";
         }
         if (args.length == 2) {
-            return StringUtils.drop(StringUtils.toString(args[1]));
+            return StringUtils.abbreviate(StringUtils.toString(args[1]));
         } else if (args.length == 3) {
             // need to handle 3rd arg?
-            return StringUtils.drop(StringUtils.toString(args[1]));
+            return StringUtils.abbreviate(StringUtils.toString(args[1]));
         }
         return "error";
     }

--- a/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/util/StringUtils.java
+++ b/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/util/StringUtils.java
@@ -23,6 +23,8 @@ import java.util.List;
 
 public final class StringUtils {
 
+    private static final int DEFAULT_ABBREVIATE_MAX_WIDTH = 64;
+
     private StringUtils() {
     }
 
@@ -64,47 +66,70 @@ public final class StringUtils {
         return result;
     }
 
-
-
+    /**
+     * @deprecated Since 1.6.1. Use {@link StringUtils#abbreviate(String)}
+     */
+    @Deprecated
     public static String drop(final String str) {
-        return drop(str, 64);
+        return abbreviate(str);
     }
 
-    public static String drop(final String str, final int length) {
+
+    public static String abbreviate(final String str) {
+        return abbreviate(str, DEFAULT_ABBREVIATE_MAX_WIDTH);
+    }
+
+    /**
+     * @deprecated Since 1.6.1. Use {@link StringUtils#abbreviate(String, int)}
+     */
+    @Deprecated
+    public static String drop(final String str, final int maxWidth) {
+        return abbreviate(str, maxWidth);
+    }
+
+    public static String abbreviate(final String str, final int maxWidth) {
         if (str == null) {
             return "null";
         }
-        if (length < 0) {
-            throw new IllegalArgumentException("negative length:" + length);
+        if (maxWidth < 0) {
+            throw new IllegalArgumentException("negative maxWidth:" + maxWidth);
         }
-        if (str.length() > length) {
-            StringBuilder buffer = new StringBuilder(length + 10);
-            buffer.append(str, 0, length);
-            appendDropMessage(buffer, str.length());
+        if (str.length() > maxWidth) {
+            StringBuilder buffer = new StringBuilder(maxWidth + 10);
+            buffer.append(str, 0, maxWidth);
+            appendAbbreviateMessage(buffer, str.length());
             return buffer.toString();
         } else {
             return str;
         }
     }
 
-    public static void appendDrop(StringBuilder builder, final String str, final int length) {
+    /**
+     * @deprecated Since 1.6.1. Use {@link StringUtils#appendAbbreviate(StringBuilder, String, int)}
+     */
+    @Deprecated
+    public static void appendDrop(StringBuilder builder, final String str, final int maxWidth) {
+        appendAbbreviate(builder, str, maxWidth);
+    }
+
+    public static void appendAbbreviate(StringBuilder builder, final String str, final int maxWidth) {
         if (str == null) {
             return;
         }
-        if (length < 0) {
+        if (maxWidth < 0) {
             return;
         }
-        if (str.length() > length) {
-            builder.append(str, 0, length);
-            appendDropMessage(builder, str.length());
+        if (str.length() > maxWidth) {
+            builder.append(str, 0, maxWidth);
+            appendAbbreviateMessage(builder, str.length());
         } else {
             builder.append(str);
         }
     }
 
-    private static void appendDropMessage(StringBuilder buffer, int length) {
+    private static void appendAbbreviateMessage(StringBuilder buffer, int strLength) {
         buffer.append("...(");
-        buffer.append(length);
+        buffer.append(strLength);
         buffer.append(')');
     }
 }

--- a/bootstrap-core/src/test/java/com/navercorp/pinpoint/bootstrap/util/StringUtilsTest.java
+++ b/bootstrap-core/src/test/java/com/navercorp/pinpoint/bootstrap/util/StringUtilsTest.java
@@ -49,29 +49,29 @@ public class StringUtilsTest {
     }
 
     @Test
-    public void drop() {
+    public void abbreviate() {
 
-        Assert.assertEquals(StringUtils.drop(null), "null");
-        Assert.assertEquals(StringUtils.drop(null, 4), "null");
-        Assert.assertEquals(StringUtils.drop(null, 0), "null");
-        Assert.assertEquals(StringUtils.drop(null, -4), "null");
+        Assert.assertEquals(StringUtils.abbreviate(null), "null");
+        Assert.assertEquals(StringUtils.abbreviate(null, 4), "null");
+        Assert.assertEquals(StringUtils.abbreviate(null, 0), "null");
+        Assert.assertEquals(StringUtils.abbreviate(null, -4), "null");
 
-        Assert.assertEquals(StringUtils.drop(longString), "This is a very long string for testing drop function. Length of ...(100)");
-        Assert.assertEquals(StringUtils.drop(longString, 4), "This...(100)");
-        Assert.assertEquals(StringUtils.drop(longString, 0), "...(100)");
+        Assert.assertEquals(StringUtils.abbreviate(longString), "This is a very long string for testing drop function. Length of ...(100)");
+        Assert.assertEquals(StringUtils.abbreviate(longString, 4), "This...(100)");
+        Assert.assertEquals(StringUtils.abbreviate(longString, 0), "...(100)");
         try {
-            StringUtils.drop(longString, -4);
+            StringUtils.abbreviate(longString, -4);
             Assert.fail();
         } catch (IllegalArgumentException ignored) {
         } catch (Exception e) {
             Assert.fail();
         }
 
-        Assert.assertEquals(StringUtils.drop(shortString), shortString);
-        Assert.assertEquals(StringUtils.drop(shortString, 4), "This...(22)");
-        Assert.assertEquals(StringUtils.drop(shortString, 0), "...(22)");
+        Assert.assertEquals(StringUtils.abbreviate(shortString), shortString);
+        Assert.assertEquals(StringUtils.abbreviate(shortString, 4), "This...(22)");
+        Assert.assertEquals(StringUtils.abbreviate(shortString, 0), "...(22)");
         try {
-            StringUtils.drop(shortString, -4);
+            StringUtils.abbreviate(shortString, -4);
             Assert.fail();
         } catch (IllegalArgumentException ignored) {
         } catch (Exception e) {
@@ -80,60 +80,60 @@ public class StringUtilsTest {
     }
 
     @Test
-    public void appendDrop() {
+    public void appendAbbreviate() {
         StringBuilder buffer = new StringBuilder();
 
-        StringUtils.appendDrop(buffer, null, 4);
+        StringUtils.appendAbbreviate(buffer, null, 4);
         Assert.assertEquals(buffer.toString(), "");
 
-        StringUtils.appendDrop(buffer, null, 0);
+        StringUtils.appendAbbreviate(buffer, null, 0);
         Assert.assertEquals(buffer.toString(), "");
 
-        StringUtils.appendDrop(buffer, null, -4);
+        StringUtils.appendAbbreviate(buffer, null, -4);
         Assert.assertEquals(buffer.toString(), "");
 
-        StringUtils.appendDrop(buffer, shortString, 4);
+        StringUtils.appendAbbreviate(buffer, shortString, 4);
         Assert.assertEquals(buffer.toString(), "This...(22)");
 
-        StringUtils.appendDrop(buffer, longString, 16);
+        StringUtils.appendAbbreviate(buffer, longString, 16);
         Assert.assertEquals(buffer.toString(), "This...(22)This is a very l...(100)");
     }
 
 
     @Test
-    public void testDrop1() throws Exception {
+    public void testAbbreviate1() throws Exception {
         String string = "abc";
-        String drop = StringUtils.drop(string, 1);
+        String drop = StringUtils.abbreviate(string, 1);
         Assert.assertEquals("a...(3)", drop);
     }
 
     @Test
-    public void testDrop2() throws Exception {
+    public void testAbbreviate2() throws Exception {
         String string = "abc";
-        String drop = StringUtils.drop(string, 5);
+        String drop = StringUtils.abbreviate(string, 5);
         Assert.assertEquals("abc", drop);
     }
 
     @Test
-    public void testDrop3() throws Exception {
+    public void testAbbreviate3() throws Exception {
         String string = "abc";
-        String drop = StringUtils.drop(string, 3);
+        String drop = StringUtils.abbreviate(string, 3);
         Assert.assertEquals("abc", drop);
     }
 
     @Test
-    public void testDrop4() throws Exception {
+    public void testAbbreviate4() throws Exception {
         String string = "abc";
-        String drop = StringUtils.drop(string, 0);
+        String drop = StringUtils.abbreviate(string, 0);
         Assert.assertEquals("...(3)", drop);
 
     }
 
     @Test
-    public void testDropNegative() throws Exception {
+    public void testAbbreviateNegative() throws Exception {
         String string = "abc";
         try {
-            StringUtils.drop(string, -1);
+            StringUtils.abbreviate(string, -1);
             Assert.fail();
         } catch (Exception ignore) {
             // skip

--- a/plugins/httpclient3/src/main/java/com/navercorp/pinpoint/plugin/httpclient3/interceptor/HttpMethodBaseExecuteMethodInterceptor.java
+++ b/plugins/httpclient3/src/main/java/com/navercorp/pinpoint/plugin/httpclient3/interceptor/HttpMethodBaseExecuteMethodInterceptor.java
@@ -385,7 +385,7 @@ public class HttpMethodBaseExecuteMethodInterceptor implements AroundInterceptor
         if (value != null && !value.isEmpty()) {
             if (cookieSampler.isSampling()) {
                 final SpanEventRecorder recorder = trace.currentSpanEventRecorder();
-                recorder.recordAttribute(AnnotationKey.HTTP_COOKIE, StringUtils.drop(value, MAX_READ_SIZE));
+                recorder.recordAttribute(AnnotationKey.HTTP_COOKIE, StringUtils.abbreviate(value, MAX_READ_SIZE));
             }
         }
     }

--- a/plugins/httpclient4/src/main/java/com/navercorp/pinpoint/plugin/httpclient4/interceptor/DefaultClientExchangeHandlerImplStartMethodInterceptor.java
+++ b/plugins/httpclient4/src/main/java/com/navercorp/pinpoint/plugin/httpclient4/interceptor/DefaultClientExchangeHandlerImplStartMethodInterceptor.java
@@ -281,7 +281,7 @@ public class DefaultClientExchangeHandlerImplStartMethodInterceptor implements A
             final String value = header.getValue();
             if (value != null && !value.isEmpty()) {
                 if (cookieSampler.isSampling()) {
-                    recorder.recordAttribute(AnnotationKey.HTTP_COOKIE, StringUtils.drop(value, 1024));
+                    recorder.recordAttribute(AnnotationKey.HTTP_COOKIE, StringUtils.abbreviate(value, 1024));
                 }
 
                 // Can a cookie have 2 or more values?

--- a/plugins/httpclient4/src/main/java/com/navercorp/pinpoint/plugin/httpclient4/interceptor/HttpRequestExecutorExecuteMethodInterceptor.java
+++ b/plugins/httpclient4/src/main/java/com/navercorp/pinpoint/plugin/httpclient4/interceptor/HttpRequestExecutorExecuteMethodInterceptor.java
@@ -300,7 +300,7 @@ public class HttpRequestExecutorExecuteMethodInterceptor implements AroundInterc
             if (value != null && !value.isEmpty()) {
                 if (cookieSampler.isSampling()) {
                     final SpanEventRecorder recorder = trace.currentSpanEventRecorder();
-                    recorder.recordAttribute(AnnotationKey.HTTP_COOKIE, StringUtils.drop(value, 1024));
+                    recorder.recordAttribute(AnnotationKey.HTTP_COOKIE, StringUtils.abbreviate(value, 1024));
                 }
 
                 // Can a cookie have 2 or more values?

--- a/plugins/jboss/src/main/java/com/navercorp/pinpoint/plugin/jboss/interceptor/StandardHostValveInvokeInterceptor.java
+++ b/plugins/jboss/src/main/java/com/navercorp/pinpoint/plugin/jboss/interceptor/StandardHostValveInvokeInterceptor.java
@@ -21,7 +21,6 @@ import java.util.Enumeration;
 import javax.servlet.http.HttpServletRequest;
 
 import com.navercorp.pinpoint.bootstrap.config.Filter;
-import com.navercorp.pinpoint.bootstrap.config.ProfilerConfig;
 import com.navercorp.pinpoint.bootstrap.context.Header;
 import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
 import com.navercorp.pinpoint.bootstrap.context.RemoteAddressResolver;
@@ -46,7 +45,6 @@ import com.navercorp.pinpoint.plugin.jboss.JbossConstants;
 import com.navercorp.pinpoint.plugin.jboss.ServletAsyncMethodDescriptor;
 import com.navercorp.pinpoint.plugin.jboss.ServletSyncMethodDescriptor;
 import com.navercorp.pinpoint.plugin.jboss.TraceAccessor;
-import com.navercorp.pinpoint.plugin.jboss.util.JbossUtility;
 
 /**
  * The Class StandardHostValveInvokeInterceptor.
@@ -530,11 +528,11 @@ public class StandardHostValveInvokeInterceptor implements AroundInterceptor {
                 return params.toString();
             }
             final String key = attrs.nextElement().toString();
-            params.append(StringUtils.drop(key, eachLimit));
+            params.append(StringUtils.abbreviate(key, eachLimit));
             params.append("=");
             final Object value = request.getParameter(key);
             if (value != null) {
-                params.append(StringUtils.drop(StringUtils.toString(value), eachLimit));
+                params.append(StringUtils.abbreviate(StringUtils.toString(value), eachLimit));
             }
         }
         return params.toString();

--- a/plugins/jetty/src/main/java/com/navercorp/pinpoint/plugin/jetty/interceptor/AbstractServerHandleInterceptor.java
+++ b/plugins/jetty/src/main/java/com/navercorp/pinpoint/plugin/jetty/interceptor/AbstractServerHandleInterceptor.java
@@ -192,11 +192,11 @@ public abstract class AbstractServerHandleInterceptor implements AroundIntercept
                 return params.toString();
             }
             String key = attrs.nextElement().toString();
-            params.append(StringUtils.drop(key, eachLimit));
+            params.append(StringUtils.abbreviate(key, eachLimit));
             params.append("=");
             Object value = request.getParameter(key);
             if (value != null) {
-                params.append(StringUtils.drop(StringUtils.toString(value), eachLimit));
+                params.append(StringUtils.abbreviate(StringUtils.toString(value), eachLimit));
             }
         }
         return params.toString();

--- a/plugins/ning-asynchttpclient/src/main/java/com/navercorp/pinpoint/plugin/ning/asynchttpclient/interceptor/ExecuteRequestInterceptor.java
+++ b/plugins/ning-asynchttpclient/src/main/java/com/navercorp/pinpoint/plugin/ning/asynchttpclient/interceptor/ExecuteRequestInterceptor.java
@@ -241,7 +241,7 @@ public class ExecuteRequestInterceptor implements AroundInterceptor {
                     sb.append(",");
                 }
             }
-            recorder.recordAttribute(AnnotationKey.HTTP_COOKIE, StringUtils.drop(sb.toString(), config.getCookieDumpSize()));
+            recorder.recordAttribute(AnnotationKey.HTTP_COOKIE, StringUtils.abbreviate(sb.toString(), config.getCookieDumpSize()));
         }
     }
 
@@ -264,7 +264,7 @@ public class ExecuteRequestInterceptor implements AroundInterceptor {
     protected void recordNonMultipartData(final com.ning.http.client.Request httpRequest, final SpanEventRecorder recorder) {
         final String stringData = httpRequest.getStringData();
         if (stringData != null) {
-            recorder.recordAttribute(AnnotationKey.HTTP_PARAM_ENTITY, StringUtils.drop(stringData, config.getEntityDumpSize()));
+            recorder.recordAttribute(AnnotationKey.HTTP_PARAM_ENTITY, StringUtils.abbreviate(stringData, config.getEntityDumpSize()));
             return;
         }
 
@@ -335,7 +335,7 @@ public class ExecuteRequestInterceptor implements AroundInterceptor {
                     sb.append(",");
                 }
             }
-            recorder.recordAttribute(AnnotationKey.HTTP_PARAM_ENTITY, StringUtils.drop(sb.toString(), config.getEntityDumpSize()));
+            recorder.recordAttribute(AnnotationKey.HTTP_PARAM_ENTITY, StringUtils.abbreviate(sb.toString(), config.getEntityDumpSize()));
         }
     }
 
@@ -350,7 +350,7 @@ public class ExecuteRequestInterceptor implements AroundInterceptor {
             FluentStringsMap requestParams = httpRequest.getParams();
             if (requestParams != null) {
                 String params = paramsToString(requestParams, config.getParamDumpSize());
-                recorder.recordAttribute(AnnotationKey.HTTP_PARAM, StringUtils.drop(params, config.getParamDumpSize()));
+                recorder.recordAttribute(AnnotationKey.HTTP_PARAM, StringUtils.abbreviate(params, config.getParamDumpSize()));
             }
         }
     }

--- a/plugins/okhttp/src/main/java/com/navercorp/pinpoint/plugin/okhttp/interceptor/HttpEngineSendRequestMethodInterceptor.java
+++ b/plugins/okhttp/src/main/java/com/navercorp/pinpoint/plugin/okhttp/interceptor/HttpEngineSendRequestMethodInterceptor.java
@@ -195,7 +195,7 @@ public class HttpEngineSendRequestMethodInterceptor implements AroundInterceptor
         for(String cookie : request.headers("Cookie")) {
             if(cookieSampler.isSampling()) {
                 final SpanEventRecorder recorder = trace.currentSpanEventRecorder();
-                recorder.recordAttribute(AnnotationKey.HTTP_COOKIE, StringUtils.drop(cookie, 1024));
+                recorder.recordAttribute(AnnotationKey.HTTP_COOKIE, StringUtils.abbreviate(cookie, 1024));
             }
 
             return;

--- a/plugins/thrift/src/main/java/com/navercorp/pinpoint/plugin/thrift/interceptor/client/TServiceClientReceiveBaseInterceptor.java
+++ b/plugins/thrift/src/main/java/com/navercorp/pinpoint/plugin/thrift/interceptor/client/TServiceClientReceiveBaseInterceptor.java
@@ -60,6 +60,6 @@ public class TServiceClientReceiveBaseInterceptor extends SpanEventSimpleAroundI
     }
 
     private String getResult(TBase<?, ?> args) {
-        return StringUtils.drop(args.toString(), 256);
+        return StringUtils.abbreviate(args.toString(), 256);
     }
 }

--- a/plugins/thrift/src/main/java/com/navercorp/pinpoint/plugin/thrift/interceptor/client/TServiceClientSendBaseInterceptor.java
+++ b/plugins/thrift/src/main/java/com/navercorp/pinpoint/plugin/thrift/interceptor/client/TServiceClientSendBaseInterceptor.java
@@ -174,7 +174,7 @@ public class TServiceClientSendBaseInterceptor implements AroundInterceptor {
     }
 
     private String getMethodArgs(TBase<?, ?> args) {
-        return StringUtils.drop(args.toString(), 256);
+        return StringUtils.abbreviate(args.toString(), 256);
     }
 
 }

--- a/plugins/tomcat/src/main/java/com/navercorp/pinpoint/plugin/tomcat/interceptor/StandardHostValveInvokeInterceptor.java
+++ b/plugins/tomcat/src/main/java/com/navercorp/pinpoint/plugin/tomcat/interceptor/StandardHostValveInvokeInterceptor.java
@@ -383,11 +383,11 @@ public class StandardHostValveInvokeInterceptor implements AroundInterceptor {
                 return params.toString();
             }
             String key = attrs.nextElement().toString();
-            params.append(StringUtils.drop(key, eachLimit));
+            params.append(StringUtils.abbreviate(key, eachLimit));
             params.append("=");
             Object value = request.getParameter(key);
             if (value != null) {
-                params.append(StringUtils.drop(StringUtils.toString(value), eachLimit));
+                params.append(StringUtils.abbreviate(StringUtils.toString(value), eachLimit));
             }
         }
         return params.toString();

--- a/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/AbstractRecorder.java
+++ b/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/AbstractRecorder.java
@@ -42,7 +42,7 @@ public abstract class AbstractRecorder {
         if (throwable == null) {
             return;
         }
-        final String drop = StringUtils.drop(throwable.getMessage(), 256);
+        final String drop = StringUtils.abbreviate(throwable.getMessage(), 256);
         // An exception that is an instance of a proxy class could make something wrong because the class name will vary.
         final int exceptionId = traceContext.cacheString(throwable.getClass().getName());
         setExceptionInfo(markError, exceptionId, drop);

--- a/profiler/src/main/java/com/navercorp/pinpoint/profiler/util/AnnotationValueMapper.java
+++ b/profiler/src/main/java/com/navercorp/pinpoint/profiler/util/AnnotationValueMapper.java
@@ -65,7 +65,7 @@ public final class AnnotationValueMapper {
         } else if (value instanceof TBase) {
             throw new IllegalArgumentException("TBase not supported. Class:" + value.getClass());
         }
-        String str = StringUtils.drop(value.toString());
+        String str = StringUtils.abbreviate(value.toString());
         annotation.setValue(TAnnotationValue.stringValue(str));
     }
 


### PR DESCRIPTION
#2312
 - drop() -> abbreviate()
 - Similar to apache-common-lang StringUtils.abbreviate()