### PR TITLE
Makes password for admin APIs optional

### DIFF
--- a/web/src/main/java/com/navercorp/pinpoint/web/controller/AdminController.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/controller/AdminController.java
@@ -20,6 +20,7 @@ import com.navercorp.pinpoint.web.vo.Application;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -35,6 +36,7 @@ import java.util.Map;
  * @author HyunGil Jeong
  */
 @Controller
+@PreAuthorize("hasPermission(null, null, 'admin')")
 @RequestMapping("/admin")
 public class AdminController {
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/interceptor/AdminAuthInterceptor.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/interceptor/AdminAuthInterceptor.java
@@ -22,7 +22,13 @@ import javax.servlet.http.HttpServletResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.server.ServletServerHttpResponse;
+import org.springframework.util.StringUtils;
 import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
 
 /**
  * FIXME temporary interceptor for admin operations.
@@ -31,9 +37,11 @@ import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
  */
 public class AdminAuthInterceptor extends HandlerInterceptorAdapter {
 
+    private static final Charset UTF_8 = Charset.forName("UTF-8");
+
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
     
-    @Value("#{pinpointWebProps['admin.password']}")
+    @Value("#{pinpointWebProps['admin.password'] ?: ''}")
     private String password;
     
     @Override
@@ -41,12 +49,36 @@ public class AdminAuthInterceptor extends HandlerInterceptorAdapter {
         String requestUri = request.getRequestURI();
         String requestIp = request.getRemoteAddr();
         logger.info("{} called from {}", requestUri, requestIp);
-        String requestPassword = request.getParameter("password");
-        if (password.equals(requestPassword)) {
+        if (StringUtils.isEmpty(password)) {
             return true;
         }
-        response.sendRedirect("/");
-        return false;
+        return checkAuthorization(request, response);
+    }
+
+    private boolean checkAuthorization(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        String requestPassword = request.getParameter("password");
+        if (requestPassword == null) {
+            handleMissingPassword(response);
+            return false;
+        }
+        if (password.equals(requestPassword)) {
+            return true;
+        } else {
+            handleInvalidPassword(response);
+            return false;
+        }
+    }
+
+    private void handleMissingPassword(HttpServletResponse response) throws IOException {
+        ServletServerHttpResponse serverResponse = new ServletServerHttpResponse(response);
+        serverResponse.setStatusCode(HttpStatus.BAD_REQUEST);
+        serverResponse.getBody().write("Missing password.".getBytes(UTF_8));
+    }
+
+    private void handleInvalidPassword(HttpServletResponse response) throws IOException {
+        ServletServerHttpResponse serverResponse = new ServletServerHttpResponse(response);
+        serverResponse.setStatusCode(HttpStatus.FORBIDDEN);
+        serverResponse.getBody().write("Invalid password.".getBytes(UTF_8));
     }
 
     


### PR DESCRIPTION
If `admin.password` is not set in *pinpoint-web.properties*, admin APIs do not require password parameter.