### PR TITLE
Exposes timeslot index to agent stat samplers

### DIFF
--- a/web/src/main/java/com/navercorp/pinpoint/web/mapper/stat/AbstractAgentStatSampler.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/mapper/stat/AbstractAgentStatSampler.java
@@ -109,7 +109,7 @@ public abstract class AbstractAgentStatSampler<T extends AgentStatDataPoint, S e
             } else if (timeWindowIndex < currentTimeWindowIndex) {
                 previous = dataPoint;
                 // currentBatch shouldn't be empty at this point
-                S sampledBatch = sampleDataPoints(currentTimeslotTimestamp, currentBatch, previous);
+                S sampledBatch = sampleDataPoints(currentTimeWindowIndex, currentTimeslotTimestamp, currentBatch, previous);
                 sampledDataPoints.put(currentTimeslotTimestamp, sampledBatch);
                 currentBatch = new ArrayList<>(currentBatch.size());
                 currentBatch.add(dataPoint);
@@ -122,7 +122,7 @@ public abstract class AbstractAgentStatSampler<T extends AgentStatDataPoint, S e
             currentTimeWindowIndex = timeWindowIndex;
         }
         if (!currentBatch.isEmpty()) {
-            S sampledBatch = sampleDataPoints(currentTimeslotTimestamp, currentBatch, null);
+            S sampledBatch = sampleDataPoints(currentTimeWindowIndex, currentTimeslotTimestamp, currentBatch, null);
             sampledDataPoints.put(currentTimeslotTimestamp, sampledBatch);
         }
         return sampledDataPoints;
@@ -147,5 +147,5 @@ public abstract class AbstractAgentStatSampler<T extends AgentStatDataPoint, S e
         return sampledPointToUse;
     }
 
-    protected abstract S sampleDataPoints(long timestamp, List<T> dataPoints, T previousDataPoint);
+    protected abstract S sampleDataPoints(int timeWindowIndex, long timestamp, List<T> dataPoints, T previousDataPoint);
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/mapper/stat/ActiveTraceSampler.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/mapper/stat/ActiveTraceSampler.java
@@ -41,7 +41,7 @@ public class ActiveTraceSampler extends AbstractAgentStatSampler<ActiveTraceBo, 
     public static final DownSampler<Integer> INTEGER_DOWN_SAMPLER = DownSamplers.getIntegerDownSampler(ActiveTraceBo.UNCOLLECTED_ACTIVE_TRACE_COUNT);
 
     @Override
-    public SampledActiveTrace sampleDataPoints(long timestamp, List<ActiveTraceBo> dataPoints, ActiveTraceBo previousDataPoint) {
+    public SampledActiveTrace sampleDataPoints(int timeWindowIndex, long timestamp, List<ActiveTraceBo> dataPoints, ActiveTraceBo previousDataPoint) {
         SampledActiveTrace sampledActiveTrace = new SampledActiveTrace();
         HistogramSchema schema = BaseHistogramSchema.getDefaultHistogramSchemaByTypeCode(dataPoints.get(0).getHistogramSchemaType());
         if (schema == null) {

--- a/web/src/main/java/com/navercorp/pinpoint/web/mapper/stat/CpuLoadSampler.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/mapper/stat/CpuLoadSampler.java
@@ -37,7 +37,7 @@ public class CpuLoadSampler extends AbstractAgentStatSampler<CpuLoadBo, SampledC
     public static final DownSampler<Double> DOUBLE_DOWN_SAMPLER = DownSamplers.getDoubleDownSampler(CpuLoadBo.UNCOLLECTED_VALUE, NUM_DECIMAL_PLACES);
 
     @Override
-    public SampledCpuLoad sampleDataPoints(long timestamp, List<CpuLoadBo> dataPoints, CpuLoadBo previousDataPoint) {
+    public SampledCpuLoad sampleDataPoints(int timeWindowIndex, long timestamp, List<CpuLoadBo> dataPoints, CpuLoadBo previousDataPoint) {
         List<Double> jvmCpuLoads = new ArrayList<>(dataPoints.size());
         List<Double> systemCpuLoads = new ArrayList<>(dataPoints.size());
         for (CpuLoadBo cpuLoadBo : dataPoints) {

--- a/web/src/main/java/com/navercorp/pinpoint/web/mapper/stat/JvmGcDetailedSampler.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/mapper/stat/JvmGcDetailedSampler.java
@@ -38,7 +38,7 @@ public class JvmGcDetailedSampler extends AbstractAgentStatSampler<JvmGcDetailed
     public static final DownSampler<Double> DOUBLE_DOWN_SAMPLER = DownSamplers.getDoubleDownSampler(JvmGcDetailedBo.UNCOLLECTED_PERCENTAGE, NUM_DECIMAL_PLACES);
 
     @Override
-    public SampledJvmGcDetailed sampleDataPoints(long timestamp, List<JvmGcDetailedBo> dataPoints, JvmGcDetailedBo previousDataPoint) {
+    public SampledJvmGcDetailed sampleDataPoints(int timeWindowIndex, long timestamp, List<JvmGcDetailedBo> dataPoints, JvmGcDetailedBo previousDataPoint) {
         List<Long> gcNewCounts = new ArrayList<>(dataPoints.size());
         List<Long> gcNewTimes = new ArrayList<>(dataPoints.size());
         List<Double> codeCacheUseds = new ArrayList<>(dataPoints.size());

--- a/web/src/main/java/com/navercorp/pinpoint/web/mapper/stat/TransactionSampler.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/mapper/stat/TransactionSampler.java
@@ -39,7 +39,7 @@ public class TransactionSampler extends AbstractAgentStatSampler<TransactionBo, 
     public static final DownSampler<Double> DOUBLE_DOWN_SAMPLER = DownSamplers.getDoubleDownSampler(UNCOLLECTED_TPS, NUM_DECIMAL_PLACES);
 
     @Override
-    public SampledTransaction sampleDataPoints(long timestamp, List<TransactionBo> dataPoints, TransactionBo previousDataPoint) {
+    public SampledTransaction sampleDataPoints(int timeWindowIndex, long timestamp, List<TransactionBo> dataPoints, TransactionBo previousDataPoint) {
         List<Double> sampledNews = new ArrayList<>(dataPoints.size());
         List<Double> sampledContinuations = new ArrayList<>(dataPoints.size());
         List<Double> unsampledNews = new ArrayList<>(dataPoints.size());

--- a/web/src/test/java/com/navercorp/pinpoint/web/mapper/stat/JvmGcSamplerTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/mapper/stat/JvmGcSamplerTest.java
@@ -35,7 +35,7 @@ public class JvmGcSamplerTest {
         List<JvmGcBo> jvmGcBos = Arrays.asList(jvmGcBo);
 
         // When
-        SampledJvmGc sampledJvmGc = sampler.sampleDataPoints(System.currentTimeMillis(), jvmGcBos, previousJvmGcBo);
+        SampledJvmGc sampledJvmGc = sampler.sampleDataPoints(0, System.currentTimeMillis(), jvmGcBos, previousJvmGcBo);
 
         // Then
         long expectedGcCount = gcCount - previousGcCount;
@@ -56,7 +56,7 @@ public class JvmGcSamplerTest {
         List<JvmGcBo> jvmGcBos = Arrays.asList(jvmGcBo);
 
         // When
-        SampledJvmGc sampledJvmGc = sampler.sampleDataPoints(System.currentTimeMillis(), jvmGcBos, null);
+        SampledJvmGc sampledJvmGc = sampler.sampleDataPoints(0, System.currentTimeMillis(), jvmGcBos, null);
 
         // Then
         long expectedGcCount = 0L;
@@ -85,7 +85,7 @@ public class JvmGcSamplerTest {
         List<JvmGcBo> jvmGcBos = Arrays.asList(secondJvmGcBo, firstJvmGcBo);
 
         // When
-        SampledJvmGc sampledJvmGc = sampler.sampleDataPoints(System.currentTimeMillis(), jvmGcBos, previousJvmGcBo);
+        SampledJvmGc sampledJvmGc = sampler.sampleDataPoints(0, System.currentTimeMillis(), jvmGcBos, previousJvmGcBo);
 
         // Then
         long expectedGcCount = secondGcCount - previousGcCount;
@@ -110,7 +110,7 @@ public class JvmGcSamplerTest {
         List<JvmGcBo> jvmGcBos = Arrays.asList(secondJvmGcBo, firstJvmGcBo);
 
         // When
-        SampledJvmGc sampledJvmGc = sampler.sampleDataPoints(System.currentTimeMillis(), jvmGcBos, null);
+        SampledJvmGc sampledJvmGc = sampler.sampleDataPoints(0, System.currentTimeMillis(), jvmGcBos, null);
 
         // Then
         long expectedGcCount = secondGcCount - firstGcCount;
@@ -149,7 +149,7 @@ public class JvmGcSamplerTest {
         List<JvmGcBo> jvmGcBos = Arrays.asList(secondJvmGcBo_2, firstJvmGcBo_2, secondJvmGcBo_1, firstJvmGcBo_1);
 
         // When
-        SampledJvmGc sampledJvmGc = sampler.sampleDataPoints(System.currentTimeMillis(), jvmGcBos, previousJvmGcBo);
+        SampledJvmGc sampledJvmGc = sampler.sampleDataPoints(0, System.currentTimeMillis(), jvmGcBos, previousJvmGcBo);
 
         // Then
         long gcCountsBeforeJvmRestart = secondGcCount_1 - previousGcCount;
@@ -188,7 +188,7 @@ public class JvmGcSamplerTest {
         List<JvmGcBo> jvmGcBos = Arrays.asList(secondJvmGcBo_2, firstJvmGcBo_2, secondJvmGcBo_1, firstJvmGcBo_1);
 
         // When
-        SampledJvmGc sampledJvmGc = sampler.sampleDataPoints(System.currentTimeMillis(), jvmGcBos, null);
+        SampledJvmGc sampledJvmGc = sampler.sampleDataPoints(0, System.currentTimeMillis(), jvmGcBos, null);
 
         // Then
         long gcCountsBeforeJvmRestart = secondGcCount_1 - firstGcCount_1;
@@ -224,7 +224,7 @@ public class JvmGcSamplerTest {
         List<JvmGcBo> jvmGcBos = Arrays.asList(secondJvmGcBo, uncollectedJvmGcBo3, uncollectedJvmGcBo2, firstJvmGcBo, uncollectedJvmGcBo1);
 
         // When
-        SampledJvmGc sampledJvmGc = sampler.sampleDataPoints(System.currentTimeMillis(), jvmGcBos, previousJvmGcBo);
+        SampledJvmGc sampledJvmGc = sampler.sampleDataPoints(0, System.currentTimeMillis(), jvmGcBos, previousJvmGcBo);
 
         // Then
         long expectedGcCount = secondGcCount - previousGcCount;
@@ -251,7 +251,7 @@ public class JvmGcSamplerTest {
         List<JvmGcBo> jvmGcBos = Arrays.asList(uncollectedJvmGcBo3, secondJvmGcBo, uncollectedJvmGcBo2, uncollectedJvmGcBo1, firstJvmGcBo);
 
         // When
-        SampledJvmGc sampledJvmGc = sampler.sampleDataPoints(System.currentTimeMillis(), jvmGcBos, null);
+        SampledJvmGc sampledJvmGc = sampler.sampleDataPoints(0, System.currentTimeMillis(), jvmGcBos, null);
 
         // Then
         long expectedGcCount = secondGcCount - firstGcCount;
@@ -281,7 +281,7 @@ public class JvmGcSamplerTest {
         List<JvmGcBo> jvmGcBos = Arrays.asList(secondJvmGcBo, uncollectedJvmGcBo2, firstJvmGcBo, uncollectedJvmGcBo1);
 
         // When
-        SampledJvmGc sampledJvmGc = sampler.sampleDataPoints(System.currentTimeMillis(), jvmGcBos, previousJvmGcBo);
+        SampledJvmGc sampledJvmGc = sampler.sampleDataPoints(0, System.currentTimeMillis(), jvmGcBos, previousJvmGcBo);
 
         // Then
         long expectedGcCount = secondGcCount - firstGcCount;
@@ -327,7 +327,7 @@ public class JvmGcSamplerTest {
         );
 
         // When
-        SampledJvmGc sampledJvmGc = sampler.sampleDataPoints(System.currentTimeMillis(), jvmGcBos, previousJvmGcBo);
+        SampledJvmGc sampledJvmGc = sampler.sampleDataPoints(0, System.currentTimeMillis(), jvmGcBos, previousJvmGcBo);
 
         // Then
         long gcCountsBeforeJvmRestart = firstGcCount_1 - previousGcCount;
@@ -373,7 +373,7 @@ public class JvmGcSamplerTest {
         );
 
         // When
-        SampledJvmGc sampledJvmGc = sampler.sampleDataPoints(System.currentTimeMillis(), jvmGcBos, null);
+        SampledJvmGc sampledJvmGc = sampler.sampleDataPoints(0, System.currentTimeMillis(), jvmGcBos, null);
 
         // Then
         long gcCountsBeforeJvmRestart = 0L;
@@ -424,7 +424,7 @@ public class JvmGcSamplerTest {
         );
 
         // When
-        SampledJvmGc sampledJvmGc = sampler.sampleDataPoints(System.currentTimeMillis(), jvmGcBos, previousJvmGcBo);
+        SampledJvmGc sampledJvmGc = sampler.sampleDataPoints(0, System.currentTimeMillis(), jvmGcBos, previousJvmGcBo);
 
         // Then
         long gcCountsBeforeJvmRestart = secondGcCount_1 - firstGcCount_1;

--- a/web/src/test/java/com/navercorp/pinpoint/web/mapper/stat/SampledAgentStatResultExtractorTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/mapper/stat/SampledAgentStatResultExtractorTest.java
@@ -178,7 +178,7 @@ public class SampledAgentStatResultExtractorTest {
     private static class TestAgentStatSampler extends AbstractAgentStatSampler<TestAgentStatDataPoint, TestSampledAgentStatDataPoint> {
 
         @Override
-        public TestSampledAgentStatDataPoint sampleDataPoints(long timestamp, List<TestAgentStatDataPoint> dataPoints, TestAgentStatDataPoint previousDataPoint) {
+        public TestSampledAgentStatDataPoint sampleDataPoints(int timeWindowIndex, long timestamp, List<TestAgentStatDataPoint> dataPoints, TestAgentStatDataPoint previousDataPoint) {
             return new TestSampledAgentStatDataPoint(timestamp, dataPoints);
         }
     }


### PR DESCRIPTION
Agent stat samplers need timeslot index to tell if a data point is the start of jvm life cycle or is the first timeslot when there is not previous data point.
related to #2345 