### PR TITLE
Removes JDK 7 API usage

### DIFF
--- a/commons-server/pom.xml
+++ b/commons-server/pom.xml
@@ -12,17 +12,12 @@
     <packaging>jar</packaging>
 
     <properties>
-        <jdk.version>1.7</jdk.version>
-        <jdk.home>${env.JAVA_7_HOME}</jdk.home>
-        <sniffer.artifactid>java17</sniffer.artifactid>
-
         <!-- jdk.version 1.6 : for profiler-test compatibility -->
         <!-- jdk.home 1.7 : for hbase compatibility -->
-        <!--
         <jdk.version>1.6</jdk.version>
         <jdk.home>${env.JAVA_7_HOME}</jdk.home>
+        <test.jdk.home>${jdk.home}</test.jdk.home>
         <sniffer.artifactid>java16</sniffer.artifactid>
-        -->
     </properties>
 
     <dependencies>

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/codec/stat/header/BitCountingHeaderDecoder.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/codec/stat/header/BitCountingHeaderDecoder.java
@@ -32,11 +32,23 @@ import java.util.BitSet;
  */
 public class BitCountingHeaderDecoder implements AgentStatHeaderDecoder {
 
+    private static final int NUM_BITS_PER_BYTE = 8;
+
     private final BitSet headerBitSet;
     private int position = 0;
 
     public BitCountingHeaderDecoder(byte[] header) {
-        this.headerBitSet = BitSet.valueOf(header);
+        headerBitSet = new BitSet();
+        // strictly follows JDK 7's BitSet.valueOf(byte[])
+        for (int i = 0; i < header.length * NUM_BITS_PER_BYTE; i++) {
+            byte currentBits = header[i / NUM_BITS_PER_BYTE];
+            int bitMask = 1 << (i % NUM_BITS_PER_BYTE);
+            if ((currentBits & bitMask) > 0) {
+                headerBitSet.set(i);
+            }
+        }
+        // use below when using JDK 7+
+//        this.headerBitSet = BitSet.valueOf(header);
     }
 
     @Override

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/codec/stat/header/BitCountingHeaderEncoder.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/codec/stat/header/BitCountingHeaderEncoder.java
@@ -34,7 +34,9 @@ import java.util.BitSet;
  */
 public class BitCountingHeaderEncoder implements AgentStatHeaderEncoder {
 
-    private BitSet headerBitSet = new BitSet();
+    private static final int NUM_BITS_PER_BYTE = 8;
+
+    private final BitSet headerBitSet = new BitSet();
     private int position = 0;
 
     @Override
@@ -50,6 +52,19 @@ public class BitCountingHeaderEncoder implements AgentStatHeaderEncoder {
 
     @Override
     public byte[] getHeader() {
-        return this.headerBitSet.toByteArray();
+        if (position == 0) {
+            return new byte[0];
+        }
+        // strictly follows JDK 7's BitSet.toByteArray()
+        int len = (headerBitSet.length() + (NUM_BITS_PER_BYTE - 1)) / NUM_BITS_PER_BYTE;
+        byte[] header = new byte[len];
+        for (int i = 0; i < len * NUM_BITS_PER_BYTE; ++i) {
+            int index = i / NUM_BITS_PER_BYTE;
+            int bitMask = (headerBitSet.get(i) ? 1 : 0) << (i % NUM_BITS_PER_BYTE);
+            header[index] |= bitMask;
+        }
+        return header;
+        // use below when using JDK 7+
+//        return this.headerBitSet.toByteArray();
     }
 }

--- a/commons-server/src/test/java/com/navercorp/pinpoint/common/server/bo/codec/stat/header/BitCountingHeaderEncoderTest.java
+++ b/commons-server/src/test/java/com/navercorp/pinpoint/common/server/bo/codec/stat/header/BitCountingHeaderEncoderTest.java
@@ -106,4 +106,38 @@ public class BitCountingHeaderEncoderTest {
         BitCountingHeaderDecoder decoder = new BitCountingHeaderDecoder(header);
         Assert.assertEquals(0, decoder.getCode());
     }
+
+    @Test
+    public void regression_against_jdk7() {
+        final int numRuns = 10000;
+        for (int numRun = 0; numRun < numRuns; ++numRun) {
+            final int numCodes = RANDOM.nextInt(20) + 1;
+            final List<Integer> givenCodes = new ArrayList<Integer>();
+            for (int i = 0; i < numCodes; ++i) {
+                givenCodes.add(RANDOM.nextInt(5));
+            }
+            BitCountingHeaderEncoder encoder = new BitCountingHeaderEncoder();
+            Jdk7BitCountingHeaderEncoder jdk7Encoder = new Jdk7BitCountingHeaderEncoder();
+            for (int givenCode : givenCodes) {
+                encoder.addCode(givenCode);
+                jdk7Encoder.addCode(givenCode);
+            }
+            final byte[] encodedHeader = encoder.getHeader();
+            final byte[] jdk7EncodedHeader = encoder.getHeader();
+            Assert.assertArrayEquals(jdk7EncodedHeader, encodedHeader);
+
+            BitCountingHeaderDecoder decoder = new BitCountingHeaderDecoder(encodedHeader);
+            Jdk7BitCountingHeaderDecoder jdk7Decoder = new Jdk7BitCountingHeaderDecoder(encodedHeader);
+            List<Integer> decodedCodes = new ArrayList<Integer>();
+            List<Integer> jdk7DecodedCodes = new ArrayList<Integer>();
+            for (int i = 0; i < numCodes; ++i) {
+                decodedCodes.add(decoder.getCode());
+                jdk7DecodedCodes.add(jdk7Decoder.getCode());
+            }
+            Assert.assertEquals(givenCodes, decodedCodes);
+            Assert.assertEquals(givenCodes, jdk7DecodedCodes);
+            Assert.assertEquals(0, decoder.getCode());
+            Assert.assertEquals(0, jdk7Decoder.getCode());
+        }
+    }
 }

--- a/commons-server/src/test/java/com/navercorp/pinpoint/common/server/bo/codec/stat/header/Jdk7BitCountingHeaderDecoder.java
+++ b/commons-server/src/test/java/com/navercorp/pinpoint/common/server/bo/codec/stat/header/Jdk7BitCountingHeaderDecoder.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.common.server.bo.codec.stat.header;
+
+import java.util.BitSet;
+
+/**
+ * JDK 7 implementation of {@link BitCountingHeaderDecoder}.
+ *
+ * @author HyunGil Jeong
+ */
+public class Jdk7BitCountingHeaderDecoder implements AgentStatHeaderDecoder {
+
+    private final BitSet headerBitSet;
+    private int position = 0;
+
+    public Jdk7BitCountingHeaderDecoder(byte[] header) {
+        headerBitSet = BitSet.valueOf(header);
+    }
+
+    @Override
+    public int getCode() {
+        int fromIndex = this.position;
+        int toIndex = this.headerBitSet.nextClearBit(this.position);
+        int numBitsSet = this.headerBitSet.get(fromIndex, toIndex).cardinality();
+        this.position = toIndex + 1;
+        return numBitsSet;
+    }
+}

--- a/commons-server/src/test/java/com/navercorp/pinpoint/common/server/bo/codec/stat/header/Jdk7BitCountingHeaderEncoder.java
+++ b/commons-server/src/test/java/com/navercorp/pinpoint/common/server/bo/codec/stat/header/Jdk7BitCountingHeaderEncoder.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.common.server.bo.codec.stat.header;
+
+import java.util.BitSet;
+
+/**
+ * JDK 7 implementation of {@link BitCountingHeaderEncoder}.
+ *
+ * @author HyunGil Jeong
+ */
+public class Jdk7BitCountingHeaderEncoder implements AgentStatHeaderEncoder {
+
+    private final BitSet headerBitSet = new BitSet();
+    private int position = 0;
+
+    @Override
+    public void addCode(int code) {
+        if (code < 0) {
+            throw new IllegalArgumentException("code must be positive");
+        }
+        int fromIndex = this.position;
+        int toIndex = this.position + code;
+        this.headerBitSet.set(fromIndex, toIndex);
+        this.position = toIndex + 1;
+    }
+
+    @Override
+    public byte[] getHeader() {
+        return headerBitSet.toByteArray();
+    }
+}


### PR DESCRIPTION
Remove `BitSet` JDK 7 API usages.
Related to #2415 