### PR TITLE
Disables integration tests for thrift 0.10.0

### DIFF
--- a/agent/src/test/java/com/navercorp/pinpoint/plugin/thrift/it/asynchronous/ThriftHalfSyncHalfAsyncServerAsyncIT.java
+++ b/agent/src/test/java/com/navercorp/pinpoint/plugin/thrift/it/asynchronous/ThriftHalfSyncHalfAsyncServerAsyncIT.java
@@ -41,7 +41,7 @@ import com.navercorp.pinpoint.test.plugin.PinpointPluginTestSuite;
  */
 @RunWith(PinpointPluginTestSuite.class)
 @PinpointAgent("agent/target/pinpoint-agent-" + Version.VERSION)
-@Dependency({ "org.apache.thrift:libthrift:[0.9.2,)", "log4j:log4j:1.2.16", "org.slf4j:slf4j-log4j12:1.5.8" })
+@Dependency({ "org.apache.thrift:libthrift:[0.9.2,0.9.3]", "log4j:log4j:1.2.16", "org.slf4j:slf4j-log4j12:1.5.8" })
 public class ThriftHalfSyncHalfAsyncServerAsyncIT extends EchoTestRunner<THsHaServer> {
 
     @Override

--- a/agent/src/test/java/com/navercorp/pinpoint/plugin/thrift/it/asynchronous/ThriftNonblockingServerAsyncIT.java
+++ b/agent/src/test/java/com/navercorp/pinpoint/plugin/thrift/it/asynchronous/ThriftNonblockingServerAsyncIT.java
@@ -41,7 +41,7 @@ import com.navercorp.pinpoint.test.plugin.PinpointPluginTestSuite;
  */
 @RunWith(PinpointPluginTestSuite.class)
 @PinpointAgent("agent/target/pinpoint-agent-" + Version.VERSION)
-@Dependency({ "org.apache.thrift:libthrift:[0.9.2,)", "log4j:log4j:1.2.16", "org.slf4j:slf4j-log4j12:1.5.8" })
+@Dependency({ "org.apache.thrift:libthrift:[0.9.2,0.9.3]", "log4j:log4j:1.2.16", "org.slf4j:slf4j-log4j12:1.5.8" })
 public class ThriftNonblockingServerAsyncIT extends EchoTestRunner<TNonblockingServer> {
 
     @Override

--- a/agent/src/test/java/com/navercorp/pinpoint/plugin/thrift/it/asynchronous/ThriftThreadedSelectorServerAsyncIT.java
+++ b/agent/src/test/java/com/navercorp/pinpoint/plugin/thrift/it/asynchronous/ThriftThreadedSelectorServerAsyncIT.java
@@ -41,7 +41,7 @@ import com.navercorp.pinpoint.test.plugin.PinpointPluginTestSuite;
  */
 @RunWith(PinpointPluginTestSuite.class)
 @PinpointAgent("agent/target/pinpoint-agent-" + Version.VERSION)
-@Dependency({ "org.apache.thrift:libthrift:[0.9.2,)", "log4j:log4j:1.2.16", "org.slf4j:slf4j-log4j12:1.5.8" })
+@Dependency({ "org.apache.thrift:libthrift:[0.9.2,0.9.3]", "log4j:log4j:1.2.16", "org.slf4j:slf4j-log4j12:1.5.8" })
 public class ThriftThreadedSelectorServerAsyncIT extends EchoTestRunner<TThreadedSelectorServer> {
 
     @Override

--- a/agent/src/test/java/com/navercorp/pinpoint/plugin/thrift/it/synchronous/ThriftHalfSyncHalfAsyncServerIT.java
+++ b/agent/src/test/java/com/navercorp/pinpoint/plugin/thrift/it/synchronous/ThriftHalfSyncHalfAsyncServerIT.java
@@ -41,7 +41,7 @@ import com.navercorp.pinpoint.test.plugin.PinpointPluginTestSuite;
  */
 @RunWith(PinpointPluginTestSuite.class)
 @PinpointAgent("agent/target/pinpoint-agent-" + Version.VERSION)
-@Dependency({ "org.apache.thrift:libthrift:[0.9.2,)", "log4j:log4j:1.2.16", "org.slf4j:slf4j-log4j12:1.5.8" })
+@Dependency({ "org.apache.thrift:libthrift:[0.9.2,0.9.3]", "log4j:log4j:1.2.16", "org.slf4j:slf4j-log4j12:1.5.8" })
 public class ThriftHalfSyncHalfAsyncServerIT extends EchoTestRunner<THsHaServer> {
 
     @Override

--- a/agent/src/test/java/com/navercorp/pinpoint/plugin/thrift/it/synchronous/ThriftNonblockingServerIT.java
+++ b/agent/src/test/java/com/navercorp/pinpoint/plugin/thrift/it/synchronous/ThriftNonblockingServerIT.java
@@ -41,7 +41,7 @@ import com.navercorp.pinpoint.test.plugin.PinpointPluginTestSuite;
  */
 @RunWith(PinpointPluginTestSuite.class)
 @PinpointAgent("agent/target/pinpoint-agent-" + Version.VERSION)
-@Dependency({ "org.apache.thrift:libthrift:[0.9.2,)", "log4j:log4j:1.2.16", "org.slf4j:slf4j-log4j12:1.5.8" })
+@Dependency({ "org.apache.thrift:libthrift:[0.9.2,0.9.3]", "log4j:log4j:1.2.16", "org.slf4j:slf4j-log4j12:1.5.8" })
 public class ThriftNonblockingServerIT extends EchoTestRunner<TNonblockingServer> {
 
     @Override

--- a/agent/src/test/java/com/navercorp/pinpoint/plugin/thrift/it/synchronous/ThriftSimpleServerIT.java
+++ b/agent/src/test/java/com/navercorp/pinpoint/plugin/thrift/it/synchronous/ThriftSimpleServerIT.java
@@ -41,7 +41,7 @@ import com.navercorp.pinpoint.test.plugin.PinpointPluginTestSuite;
  */
 @RunWith(PinpointPluginTestSuite.class)
 @PinpointAgent("agent/target/pinpoint-agent-" + Version.VERSION)
-@Dependency({ "org.apache.thrift:libthrift:[0.9.1,)", "log4j:log4j:1.2.16", "org.slf4j:slf4j-log4j12:1.5.8" })
+@Dependency({ "org.apache.thrift:libthrift:[0.9.1,0.9.3]", "log4j:log4j:1.2.16", "org.slf4j:slf4j-log4j12:1.5.8" })
 public class ThriftSimpleServerIT extends EchoTestRunner<TSimpleServer> {
 
     @Override

--- a/agent/src/test/java/com/navercorp/pinpoint/plugin/thrift/it/synchronous/ThriftThreadPoolServerIT.java
+++ b/agent/src/test/java/com/navercorp/pinpoint/plugin/thrift/it/synchronous/ThriftThreadPoolServerIT.java
@@ -41,7 +41,7 @@ import com.navercorp.pinpoint.test.plugin.PinpointPluginTestSuite;
  */
 @RunWith(PinpointPluginTestSuite.class)
 @PinpointAgent("agent/target/pinpoint-agent-" + Version.VERSION)
-@Dependency({ "org.apache.thrift:libthrift:[0.9.1,)", "log4j:log4j:1.2.16", "org.slf4j:slf4j-log4j12:1.5.8" })
+@Dependency({ "org.apache.thrift:libthrift:[0.9.1,0.9.3]", "log4j:log4j:1.2.16", "org.slf4j:slf4j-log4j12:1.5.8" })
 public class ThriftThreadPoolServerIT extends EchoTestRunner<TThreadPoolServer> {
 
     @Override

--- a/agent/src/test/java/com/navercorp/pinpoint/plugin/thrift/it/synchronous/ThriftThreadedSelectorServerIT.java
+++ b/agent/src/test/java/com/navercorp/pinpoint/plugin/thrift/it/synchronous/ThriftThreadedSelectorServerIT.java
@@ -41,7 +41,7 @@ import com.navercorp.pinpoint.test.plugin.PinpointPluginTestSuite;
  */
 @RunWith(PinpointPluginTestSuite.class)
 @PinpointAgent("agent/target/pinpoint-agent-" + Version.VERSION)
-@Dependency({ "org.apache.thrift:libthrift:[0.9.2,)", "log4j:log4j:1.2.16", "org.slf4j:slf4j-log4j12:1.5.8" })
+@Dependency({ "org.apache.thrift:libthrift:[0.9.2,0.9.3]", "log4j:log4j:1.2.16", "org.slf4j:slf4j-log4j12:1.5.8" })
 public class ThriftThreadedSelectorServerIT extends EchoTestRunner<TThreadedSelectorServer> {
 
     @Override


### PR DESCRIPTION
Disable thrift integration tests for 0.10.0+ until Pinpoint thrift plugin is updated to support libthrift v0.10.0.