### PR TITLE
Creates Inspector view agent status timeline server side

### DIFF
--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/util/AgentEventTypeCategory.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/util/AgentEventTypeCategory.java
@@ -20,7 +20,7 @@ package com.navercorp.pinpoint.common.server.util;
  * @author HyunGil Jeong
  */
 public enum AgentEventTypeCategory {
-    DURATIONAL,
+    @Deprecated DURATIONAL,
     AGENT_LIFECYCLE,
     USER_REQUEST,
     THREAD_DUMP,

--- a/web/src/main/java/com/navercorp/pinpoint/web/controller/AgentInfoController.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/controller/AgentInfoController.java
@@ -23,6 +23,7 @@ import com.navercorp.pinpoint.web.vo.AgentInfo;
 import com.navercorp.pinpoint.web.vo.AgentStatus;
 import com.navercorp.pinpoint.web.vo.ApplicationAgentList;
 import com.navercorp.pinpoint.web.vo.Range;
+import com.navercorp.pinpoint.web.vo.timeline.inspector.InspectorTimeline;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
@@ -128,5 +129,28 @@ public class AgentInfoController {
             @RequestParam(value = "exclude", defaultValue = "") int[] excludeEventTypeCodes) {
         Range range = new Range(from, to);
         return this.agentEventService.getAgentEvents(agentId, range, excludeEventTypeCodes);
+    }
+
+    @PreAuthorize("hasPermission(new com.navercorp.pinpoint.web.vo.AgentParam(#agentId, #to), 'agentParam', 'inspector')")
+    @RequestMapping(value = "/getAgentStatusTimeline", method = RequestMethod.GET)
+    @ResponseBody
+    public InspectorTimeline getAgentStatusTimeline(
+            @RequestParam("agentId") String agentId,
+            @RequestParam("from") long from,
+            @RequestParam("to") long to) {
+        Range range = new Range(from, to);
+        return agentInfoService.getAgentStatusTimeline(agentId, range, null);
+    }
+
+    @PreAuthorize("hasPermission(new com.navercorp.pinpoint.web.vo.AgentParam(#agentId, #to), 'agentParam', 'inspector')")
+    @RequestMapping(value = "/getAgentStatusTimeline", method = RequestMethod.GET, params = {"exclude"})
+    @ResponseBody
+    public InspectorTimeline getAgentStatusTimeline(
+            @RequestParam("agentId") String agentId,
+            @RequestParam("from") long from,
+            @RequestParam("to") long to,
+            @RequestParam(value = "exclude", defaultValue = "") int[] excludeEventTypeCodes) {
+        Range range = new Range(from, to);
+        return agentInfoService.getAgentStatusTimeline(agentId, range, excludeEventTypeCodes);
     }
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/filter/agent/AgentEventFilter.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/filter/agent/AgentEventFilter.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2017 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.web.filter.agent;
+
+import com.navercorp.pinpoint.common.server.util.AgentEventType;
+import com.navercorp.pinpoint.web.vo.AgentEvent;
+import org.apache.commons.lang3.ArrayUtils;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * @author HyunGil Jeong
+ */
+public interface AgentEventFilter {
+    boolean ACCEPT = true;
+    boolean REJECT = false;
+
+    boolean accept(AgentEvent agentEvent);
+
+    class ExcludeFilter implements AgentEventFilter {
+
+        private final Set<AgentEventType> excludedEventTypes;
+
+        public ExcludeFilter(AgentEventType... excludeEventTypes) {
+            if (ArrayUtils.isEmpty(excludeEventTypes)) {
+                this.excludedEventTypes = Collections.emptySet();
+            } else {
+                this.excludedEventTypes = new HashSet<>(Arrays.asList(excludeEventTypes));
+            }
+        }
+
+        public ExcludeFilter(int... excludeEventTypeCodes) {
+            if (ArrayUtils.isEmpty(excludeEventTypeCodes)) {
+                excludedEventTypes = Collections.emptySet();
+                return;
+            }
+            excludedEventTypes = new HashSet<>();
+            for (int excludeEventTypeCode : excludeEventTypeCodes) {
+                AgentEventType excludedEventType = AgentEventType.getTypeByCode(excludeEventTypeCode);
+                if (excludedEventType != null) {
+                    excludedEventTypes.add(excludedEventType);
+                }
+            }
+        }
+
+        @Override
+        public boolean accept(AgentEvent agentEvent) {
+            AgentEventType agentEventType = AgentEventType.getTypeByCode(agentEvent.getEventTypeCode());
+            if (excludedEventTypes.contains(agentEventType)) {
+                return REJECT;
+            }
+            return ACCEPT;
+        }
+    }
+}

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/AgentEventServiceImpl.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/AgentEventServiceImpl.java
@@ -131,6 +131,7 @@ public class AgentEventServiceImpl implements AgentEventService {
         return agentEvent;
     }
 
+    @Deprecated
     private DurationalAgentEvent createDurationalAgentEvent(AgentEventBo agentEventBo, boolean includeEventMessage) {
         DurationalAgentEvent durationalAgentEvent = new DurationalAgentEvent(agentEventBo);
         if (includeEventMessage) {

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/AgentInfoService.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/AgentInfoService.java
@@ -20,6 +20,8 @@ import com.navercorp.pinpoint.web.vo.AgentInfo;
 import com.navercorp.pinpoint.web.vo.AgentStatus;
 import com.navercorp.pinpoint.web.vo.ApplicationAgentHostList;
 import com.navercorp.pinpoint.web.vo.ApplicationAgentList;
+import com.navercorp.pinpoint.web.vo.Range;
+import com.navercorp.pinpoint.web.vo.timeline.inspector.InspectorTimeline;
 
 import java.util.Set;
 
@@ -48,4 +50,6 @@ public interface AgentInfoService {
     AgentInfo getAgentInfo(String agentId, long timestamp);
 
     AgentStatus getAgentStatus(String agentId, long timestamp);
+
+    InspectorTimeline getAgentStatusTimeline(String agentId, Range range, int... excludeAgentEventTypeCodes);
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/AgentInfoServiceImpl.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/AgentInfoServiceImpl.java
@@ -1,3 +1,4 @@
+
 /*
  * Copyright 2014 NAVER Corp.
  *
@@ -21,17 +22,26 @@ import com.navercorp.pinpoint.common.server.util.AgentLifeCycleState;
 import com.navercorp.pinpoint.web.dao.AgentInfoDao;
 import com.navercorp.pinpoint.web.dao.AgentLifeCycleDao;
 import com.navercorp.pinpoint.web.dao.ApplicationIndexDao;
+import com.navercorp.pinpoint.web.filter.agent.AgentEventFilter;
+import com.navercorp.pinpoint.web.vo.AgentEvent;
 import com.navercorp.pinpoint.web.vo.AgentInfo;
 import com.navercorp.pinpoint.web.vo.AgentStatus;
 import com.navercorp.pinpoint.web.vo.Application;
 import com.navercorp.pinpoint.web.vo.ApplicationAgentHostList;
 import com.navercorp.pinpoint.web.vo.ApplicationAgentList;
+import com.navercorp.pinpoint.web.vo.Range;
+import com.navercorp.pinpoint.web.vo.timeline.inspector.AgentEventTimeline;
+import com.navercorp.pinpoint.web.vo.timeline.inspector.AgentEventTimelineBuilder;
+import com.navercorp.pinpoint.web.vo.timeline.inspector.AgentStatusTimeline;
+import com.navercorp.pinpoint.web.vo.timeline.inspector.InspectorTimeline;
+import com.navercorp.pinpoint.web.vo.timeline.inspector.AgentStatusTimelineBuilder;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.PredicateUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.util.Assert;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -49,6 +59,9 @@ import java.util.TreeMap;
 public class AgentInfoServiceImpl implements AgentInfoService {
 
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
+
+    @Autowired
+    private AgentEventService agentEventService;
 
     @Autowired
     private ApplicationIndexDao applicationIndexDao;
@@ -233,5 +246,25 @@ public class AgentInfoServiceImpl implements AgentInfoService {
             throw new IllegalArgumentException("timestamp must not be less than 0");
         }
         return this.agentLifeCycleDao.getAgentStatus(agentId, timestamp);
+    }
+
+    @Override
+    public InspectorTimeline getAgentStatusTimeline(String agentId, Range range, int... excludeAgentEventTypeCodes) {
+        Assert.notNull(agentId, "agentId must not be null");
+        Assert.notNull(range, "range must not be null");
+
+        AgentStatus initialStatus = getAgentStatus(agentId, range.getFrom());
+        List<AgentEvent> agentEvents = agentEventService.getAgentEvents(agentId, range);
+
+        AgentStatusTimelineBuilder agentStatusTimelinebuilder = new AgentStatusTimelineBuilder(range, initialStatus);
+        agentStatusTimelinebuilder.from(agentEvents);
+        AgentStatusTimeline agentStatusTimeline = agentStatusTimelinebuilder.build();
+
+        AgentEventTimelineBuilder agentEventTimelineBuilder = new AgentEventTimelineBuilder(range);
+        agentEventTimelineBuilder.from(agentEvents);
+        agentEventTimelineBuilder.addFilter(new AgentEventFilter.ExcludeFilter(excludeAgentEventTypeCodes));
+        AgentEventTimeline agentEventTimeline = agentEventTimelineBuilder.build();
+
+        return new InspectorTimeline(agentStatusTimeline, agentEventTimeline);
     }
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/view/AgentEventMarkerSerializer.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/view/AgentEventMarkerSerializer.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.web.view;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.navercorp.pinpoint.common.server.util.AgentEventType;
+import com.navercorp.pinpoint.web.vo.timeline.inspector.AgentEventMarker;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * @author HyunGil Jeong
+ */
+public class AgentEventMarkerSerializer extends JsonSerializer<AgentEventMarker> {
+
+    @Override
+    public void serialize(AgentEventMarker agentEventMarker, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException, JsonProcessingException {
+        jsonGenerator.writeStartObject();
+        jsonGenerator.writeNumberField("totalCount", agentEventMarker.getTotalCount());
+        jsonGenerator.writeFieldName("typeCounts");
+        jsonGenerator.writeStartArray(agentEventMarker.getTypeCounts().size());
+        for (Map.Entry<AgentEventType, Integer> e : agentEventMarker.getTypeCounts().entrySet()) {
+            writeAgentEventTypeCount(jsonGenerator, e);
+        }
+        jsonGenerator.writeEndArray();
+        jsonGenerator.writeEndObject();
+    }
+
+    private void writeAgentEventTypeCount(JsonGenerator jsonGenerator, Map.Entry<AgentEventType, Integer> entry) throws IOException {
+        AgentEventType agentEventType = entry.getKey();
+        int count = entry.getValue();
+        jsonGenerator.writeStartObject();
+        jsonGenerator.writeNumberField("code", agentEventType.getCode());
+        jsonGenerator.writeStringField("desc", agentEventType.getDesc());
+        jsonGenerator.writeNumberField("count", count);
+        jsonGenerator.writeEndObject();
+    }
+}

--- a/web/src/main/java/com/navercorp/pinpoint/web/vo/DurationalAgentEvent.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/vo/DurationalAgentEvent.java
@@ -23,6 +23,7 @@ import com.navercorp.pinpoint.common.server.bo.AgentEventBo;
 /**
  * @author HyunGil Jeong
  */
+@Deprecated
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class DurationalAgentEvent extends AgentEvent {
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/vo/timeline/Timeline.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/vo/timeline/Timeline.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.web.vo.timeline;
+
+import java.util.List;
+
+/**
+ * @author HyunGil Jeong
+ */
+public interface Timeline<T> {
+
+    List<T> getTimelineSegments();
+
+}

--- a/web/src/main/java/com/navercorp/pinpoint/web/vo/timeline/TimelineSegment.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/vo/timeline/TimelineSegment.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.web.vo.timeline;
+
+/**
+ * @author HyunGil Jeong
+ */
+public interface TimelineSegment<T> {
+
+    long getStartTimestamp();
+
+    long getEndTimestamp();
+
+    T getValue();
+}

--- a/web/src/main/java/com/navercorp/pinpoint/web/vo/timeline/inspector/AgentEventMarker.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/vo/timeline/inspector/AgentEventMarker.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2017 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.web.vo.timeline.inspector;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.navercorp.pinpoint.common.server.util.AgentEventType;
+import com.navercorp.pinpoint.web.view.AgentEventMarkerSerializer;
+import com.navercorp.pinpoint.web.vo.AgentEvent;
+
+import java.util.EnumMap;
+import java.util.Map;
+
+/**
+ * @author HyunGil Jeong
+ */
+@JsonSerialize(using = AgentEventMarkerSerializer.class)
+public class AgentEventMarker {
+
+    private final Map<AgentEventType, MutableInt> typeCounts = new EnumMap<>(AgentEventType.class);
+
+    private int totalCount = 0;
+
+    public void addAgentEvent(AgentEvent agentEvent) {
+        AgentEventType agentEventType = AgentEventType.getTypeByCode(agentEvent.getEventTypeCode());
+        if (agentEventType != null) {
+            MutableInt typeCount = typeCounts.get(agentEventType);
+            if (typeCount == null) {
+                typeCount = new MutableInt();
+                typeCounts.put(agentEventType, typeCount);
+            }
+            typeCount.increment();
+            totalCount++;
+        }
+    }
+
+    public Map<AgentEventType, Integer> getTypeCounts() {
+        Map<AgentEventType, Integer> typeCounts = new EnumMap<>(AgentEventType.class);
+        for (Map.Entry<AgentEventType, MutableInt> e : this.typeCounts.entrySet()) {
+            typeCounts.put(e.getKey(), e.getValue().get());
+        }
+        return typeCounts;
+    }
+
+    public int getTotalCount() {
+        return totalCount;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        AgentEventMarker that = (AgentEventMarker) o;
+        if (totalCount != that.totalCount) return false;
+        return typeCounts.equals(that.typeCounts);
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = typeCounts.hashCode();
+        result = 31 * result + totalCount;
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("AgentEventMarker{");
+        sb.append("typeCounts=").append(typeCounts);
+        sb.append(", totalCount=").append(totalCount);
+        sb.append('}');
+        return sb.toString();
+    }
+
+    private static class MutableInt {
+
+        private int value;
+
+        private MutableInt() {
+            this(0);
+        }
+
+        private MutableInt(int initialValue) {
+            value = initialValue;
+        }
+
+        private void increment() {
+            value++;
+        }
+
+        private void decrement() {
+            value--;
+        }
+
+        private int get() {
+            return value;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            MutableInt that = (MutableInt) o;
+            return value == that.value;
+        }
+
+        @Override
+        public int hashCode() {
+            return value;
+        }
+
+        @Override
+        public String toString() {
+            final StringBuilder sb = new StringBuilder("MutableInt{");
+            sb.append("value=").append(value);
+            sb.append('}');
+            return sb.toString();
+        }
+    }
+}

--- a/web/src/main/java/com/navercorp/pinpoint/web/vo/timeline/inspector/AgentEventTimeline.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/vo/timeline/inspector/AgentEventTimeline.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2017 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.web.vo.timeline.inspector;
+
+import com.navercorp.pinpoint.web.vo.AgentEvent;
+import com.navercorp.pinpoint.web.vo.timeline.Timeline;
+import com.navercorp.pinpoint.web.vo.timeline.TimelineSegment;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author HyunGil Jeong
+ */
+public class AgentEventTimeline implements Timeline<AgentEventTimeline.Segment> {
+
+    private final List<AgentEventTimeline.Segment> timelineSegments;
+
+    AgentEventTimeline(List<AgentEventTimeline.Segment> timelineSegments) {
+        this.timelineSegments = timelineSegments;
+    }
+
+    @Override
+    public List<AgentEventTimeline.Segment> getTimelineSegments() {
+        return timelineSegments;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        AgentEventTimeline that = (AgentEventTimeline) o;
+
+        return timelineSegments != null ? timelineSegments.equals(that.timelineSegments) : that.timelineSegments == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return timelineSegments != null ? timelineSegments.hashCode() : 0;
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("AgentEventTimeline{");
+        sb.append("timelineSegments=").append(timelineSegments);
+        sb.append('}');
+        return sb.toString();
+    }
+
+    public static class Segment implements TimelineSegment<List<AgentEvent>> {
+        private long startTimestamp;
+        private long endTimestamp;
+        private List<AgentEvent> agentEvents = new ArrayList<>();
+
+        @Override
+        public long getStartTimestamp() {
+            return startTimestamp;
+        }
+
+        public void setStartTimestamp(long startTimestamp) {
+            this.startTimestamp = startTimestamp;
+        }
+
+        @Override
+        public long getEndTimestamp() {
+            return endTimestamp;
+        }
+
+        public void setEndTimestamp(long endTimestamp) {
+            this.endTimestamp = endTimestamp;
+        }
+
+        @Override
+        public List<AgentEvent> getValue() {
+            return agentEvents;
+        }
+
+        public void setValue(List<AgentEvent> agentEvents) {
+            this.agentEvents = agentEvents;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            Segment segment = (Segment) o;
+
+            if (startTimestamp != segment.startTimestamp) return false;
+            if (endTimestamp != segment.endTimestamp) return false;
+            return agentEvents != null ? agentEvents.equals(segment.agentEvents) : segment.agentEvents == null;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = (int) (startTimestamp ^ (startTimestamp >>> 32));
+            result = 31 * result + (int) (endTimestamp ^ (endTimestamp >>> 32));
+            result = 31 * result + (agentEvents != null ? agentEvents.hashCode() : 0);
+            return result;
+        }
+
+        @Override
+        public String toString() {
+            final StringBuilder sb = new StringBuilder("Segment{");
+            sb.append("startTimestamp=").append(startTimestamp);
+            sb.append(", endTimestamp=").append(endTimestamp);
+            sb.append(", agentEvents=").append(agentEvents);
+            sb.append('}');
+            return sb.toString();
+        }
+    }
+}

--- a/web/src/main/java/com/navercorp/pinpoint/web/vo/timeline/inspector/AgentEventTimeline.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/vo/timeline/inspector/AgentEventTimeline.java
@@ -16,26 +16,23 @@
 
 package com.navercorp.pinpoint.web.vo.timeline.inspector;
 
-import com.navercorp.pinpoint.web.vo.AgentEvent;
 import com.navercorp.pinpoint.web.vo.timeline.Timeline;
-import com.navercorp.pinpoint.web.vo.timeline.TimelineSegment;
 
-import java.util.ArrayList;
 import java.util.List;
 
 /**
  * @author HyunGil Jeong
  */
-public class AgentEventTimeline implements Timeline<AgentEventTimeline.Segment> {
+public class AgentEventTimeline implements Timeline<AgentEventTimelineSegment> {
 
-    private final List<AgentEventTimeline.Segment> timelineSegments;
+    private final List<AgentEventTimelineSegment> timelineSegments;
 
-    AgentEventTimeline(List<AgentEventTimeline.Segment> timelineSegments) {
+    public AgentEventTimeline(List<AgentEventTimelineSegment> timelineSegments) {
         this.timelineSegments = timelineSegments;
     }
 
     @Override
-    public List<AgentEventTimeline.Segment> getTimelineSegments() {
+    public List<AgentEventTimelineSegment> getTimelineSegments() {
         return timelineSegments;
     }
 
@@ -43,9 +40,7 @@ public class AgentEventTimeline implements Timeline<AgentEventTimeline.Segment> 
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-
         AgentEventTimeline that = (AgentEventTimeline) o;
-
         return timelineSegments != null ? timelineSegments.equals(that.timelineSegments) : that.timelineSegments == null;
     }
 
@@ -62,66 +57,4 @@ public class AgentEventTimeline implements Timeline<AgentEventTimeline.Segment> 
         return sb.toString();
     }
 
-    public static class Segment implements TimelineSegment<List<AgentEvent>> {
-        private long startTimestamp;
-        private long endTimestamp;
-        private List<AgentEvent> agentEvents = new ArrayList<>();
-
-        @Override
-        public long getStartTimestamp() {
-            return startTimestamp;
-        }
-
-        public void setStartTimestamp(long startTimestamp) {
-            this.startTimestamp = startTimestamp;
-        }
-
-        @Override
-        public long getEndTimestamp() {
-            return endTimestamp;
-        }
-
-        public void setEndTimestamp(long endTimestamp) {
-            this.endTimestamp = endTimestamp;
-        }
-
-        @Override
-        public List<AgentEvent> getValue() {
-            return agentEvents;
-        }
-
-        public void setValue(List<AgentEvent> agentEvents) {
-            this.agentEvents = agentEvents;
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-
-            Segment segment = (Segment) o;
-
-            if (startTimestamp != segment.startTimestamp) return false;
-            if (endTimestamp != segment.endTimestamp) return false;
-            return agentEvents != null ? agentEvents.equals(segment.agentEvents) : segment.agentEvents == null;
-        }
-
-        @Override
-        public int hashCode() {
-            int result = (int) (startTimestamp ^ (startTimestamp >>> 32));
-            result = 31 * result + (int) (endTimestamp ^ (endTimestamp >>> 32));
-            result = 31 * result + (agentEvents != null ? agentEvents.hashCode() : 0);
-            return result;
-        }
-
-        @Override
-        public String toString() {
-            final StringBuilder sb = new StringBuilder("Segment{");
-            sb.append("startTimestamp=").append(startTimestamp);
-            sb.append(", endTimestamp=").append(endTimestamp);
-            sb.append(", agentEvents=").append(agentEvents);
-            sb.append('}');
-            return sb.toString();
-        }
-    }
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/vo/timeline/inspector/AgentEventTimelineBuilder.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/vo/timeline/inspector/AgentEventTimelineBuilder.java
@@ -19,25 +19,45 @@ package com.navercorp.pinpoint.web.vo.timeline.inspector;
 import com.navercorp.pinpoint.web.filter.agent.AgentEventFilter;
 import com.navercorp.pinpoint.web.vo.AgentEvent;
 import com.navercorp.pinpoint.web.vo.Range;
+import org.springframework.util.Assert;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
 
 /**
  * @author HyunGil Jeong
  */
 public class AgentEventTimelineBuilder {
 
+    private static final int DEFAULT_NUM_TIMESLOTS = 100;
+
     private final long timelineStartTimestamp;
     private final long timelineEndTimestamp;
+    private final long timeslotSize;
+    private final int numTimeslots;
 
     private List<AgentEvent> agentEvents = Collections.emptyList();
     private List<AgentEventFilter> filters = new ArrayList<>();
 
     public AgentEventTimelineBuilder(Range range) {
+        this(range, DEFAULT_NUM_TIMESLOTS);
+    }
+
+    public AgentEventTimelineBuilder(Range range, int numTimeslots) {
+        Assert.notNull(range, "range must not be null");
+        Assert.isTrue(range.getRange() > 0, "timeline must have range greater than 0");
+        Assert.isTrue(numTimeslots > 0, "numTimeslots must be greater than 0");
         this.timelineStartTimestamp = range.getFrom();
         this.timelineEndTimestamp = range.getTo();
+        int adjustedNumTimeslots = numTimeslots;
+        if (range.getRange() < adjustedNumTimeslots) {
+            adjustedNumTimeslots = (int) range.getRange();
+        }
+        this.timeslotSize = (timelineEndTimestamp - timelineStartTimestamp) / adjustedNumTimeslots;
+        this.numTimeslots = adjustedNumTimeslots;
     }
 
     public AgentEventTimelineBuilder from(List<AgentEvent> agentEvents) {
@@ -73,11 +93,72 @@ public class AgentEventTimelineBuilder {
         return AgentEventFilter.ACCEPT;
     }
 
-    private List<AgentEventTimeline.Segment> createTimelineSegments(List<AgentEvent> agentEvents) {
-        AgentEventTimeline.Segment segment = new AgentEventTimeline.Segment();
-        segment.setStartTimestamp(timelineStartTimestamp);
-        segment.setEndTimestamp(timelineEndTimestamp);
-        segment.setValue(agentEvents);
-        return Collections.singletonList(segment);
+    private List<AgentEventTimelineSegment> createTimelineSegments(List<AgentEvent> agentEvents) {
+        if (agentEvents.isEmpty()) {
+            return Collections.emptyList();
+        }
+        Map<Long, List<AgentEvent>> timeWindowEventsMap = createTimeslotIndexMap(agentEvents);
+
+        List<AgentEventTimelineSegment> timelineSegments = new ArrayList<>();
+        for (Map.Entry<Long, List<AgentEvent>> e : timeWindowEventsMap.entrySet()) {
+            AgentEventTimelineSegment segment = createSegment(e.getKey(), e.getValue());
+            if (segment != null) {
+                timelineSegments.add(segment);
+            }
+        }
+        return timelineSegments;
+    }
+
+    private Map<Long, List<AgentEvent>> createTimeslotIndexMap(List<AgentEvent> agentEvents) {
+        Map<Long, List<AgentEvent>> timeslotIndexMap = new TreeMap<>();
+        for (AgentEvent agentEvent : agentEvents) {
+            long timeslotIndex = getTimeslotIndex(agentEvent.getEventTimestamp());
+            List<AgentEvent> timeslotAgentEvents = timeslotIndexMap.get(timeslotIndex);
+            if (timeslotAgentEvents == null) {
+                timeslotAgentEvents = new ArrayList<>();
+                timeslotIndexMap.put(timeslotIndex, timeslotAgentEvents);
+            }
+            timeslotAgentEvents.add(agentEvent);
+        }
+        return timeslotIndexMap;
+    }
+
+    private AgentEventTimelineSegment createSegment(long timeslotIndex, List<AgentEvent> agentEvents) {
+        // timeslotIndex guaranteed to be greater than 0 and less than numTimeslots
+        long segmentStartTimestamp = timelineStartTimestamp + (timeslotIndex * timeslotSize);
+        long segmentEndTimestamp = segmentStartTimestamp + timeslotSize;
+        if (timeslotIndex >= (numTimeslots - 1)) {
+            segmentEndTimestamp = timelineEndTimestamp;
+        }
+
+        AgentEventMarker agentEventMarker = createAgentEventMarker(agentEvents);
+        if (agentEventMarker.getTotalCount() == 0) {
+            return null;
+        }
+        AgentEventTimelineSegment segment = new AgentEventTimelineSegment();
+        segment.setStartTimestamp(segmentStartTimestamp);
+        segment.setEndTimestamp(segmentEndTimestamp);
+        segment.setValue(agentEventMarker);
+        return segment;
+    }
+
+    private long getTimeslotIndex(long timestamp) {
+        long diff = timestamp - timelineStartTimestamp;
+        long index = diff / timeslotSize;
+        if (index < 0) {
+            index = 0;
+        }
+        if (index >= numTimeslots) {
+            index = numTimeslots - 1;
+        }
+        return index;
+    }
+
+    private AgentEventMarker createAgentEventMarker(List<AgentEvent> agentEvents) {
+        AgentEventMarker agentEventMarker = new AgentEventMarker();
+        for (AgentEvent agentEvent : agentEvents) {
+            agentEventMarker.addAgentEvent(agentEvent);
+        }
+        return agentEventMarker;
     }
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/vo/timeline/inspector/AgentEventTimelineBuilder.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/vo/timeline/inspector/AgentEventTimelineBuilder.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2017 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.web.vo.timeline.inspector;
+
+import com.navercorp.pinpoint.web.filter.agent.AgentEventFilter;
+import com.navercorp.pinpoint.web.vo.AgentEvent;
+import com.navercorp.pinpoint.web.vo.Range;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * @author HyunGil Jeong
+ */
+public class AgentEventTimelineBuilder {
+
+    private final long timelineStartTimestamp;
+    private final long timelineEndTimestamp;
+
+    private List<AgentEvent> agentEvents = Collections.emptyList();
+    private List<AgentEventFilter> filters = new ArrayList<>();
+
+    public AgentEventTimelineBuilder(Range range) {
+        this.timelineStartTimestamp = range.getFrom();
+        this.timelineEndTimestamp = range.getTo();
+    }
+
+    public AgentEventTimelineBuilder from(List<AgentEvent> agentEvents) {
+        if (agentEvents != null) {
+            this.agentEvents = agentEvents;
+        }
+        return this;
+    }
+
+    public AgentEventTimelineBuilder addFilter(AgentEventFilter filter) {
+        if (filter != null) {
+            filters.add(filter);
+        }
+        return this;
+    }
+
+    public AgentEventTimeline build() {
+        List<AgentEvent> filteredAgentEvents = new ArrayList<>();
+        for (AgentEvent agentEvent : agentEvents) {
+            if (filterAgentEvent(agentEvent) == AgentEventFilter.ACCEPT) {
+                filteredAgentEvents.add(agentEvent);
+            }
+        }
+        return new AgentEventTimeline(createTimelineSegments(filteredAgentEvents));
+    }
+
+    private boolean filterAgentEvent(AgentEvent agentEvent) {
+        for (AgentEventFilter filter : filters) {
+            if (!filter.accept(agentEvent)) {
+                return AgentEventFilter.REJECT;
+            }
+        }
+        return AgentEventFilter.ACCEPT;
+    }
+
+    private List<AgentEventTimeline.Segment> createTimelineSegments(List<AgentEvent> agentEvents) {
+        AgentEventTimeline.Segment segment = new AgentEventTimeline.Segment();
+        segment.setStartTimestamp(timelineStartTimestamp);
+        segment.setEndTimestamp(timelineEndTimestamp);
+        segment.setValue(agentEvents);
+        return Collections.singletonList(segment);
+    }
+}

--- a/web/src/main/java/com/navercorp/pinpoint/web/vo/timeline/inspector/AgentEventTimelineSegment.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/vo/timeline/inspector/AgentEventTimelineSegment.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2017 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.web.vo.timeline.inspector;
+
+import com.navercorp.pinpoint.web.vo.timeline.TimelineSegment;
+
+/**
+ * @author HyunGil Jeong
+ */
+public class AgentEventTimelineSegment implements TimelineSegment<AgentEventMarker> {
+    private long startTimestamp;
+    private long endTimestamp;
+    private AgentEventMarker agentEventMarker;
+
+    @Override
+    public long getStartTimestamp() {
+        return startTimestamp;
+    }
+
+    public void setStartTimestamp(long startTimestamp) {
+        this.startTimestamp = startTimestamp;
+    }
+
+    @Override
+    public long getEndTimestamp() {
+        return endTimestamp;
+    }
+
+    public void setValue(AgentEventMarker agentEventMarker) {
+        this.agentEventMarker = agentEventMarker;
+    }
+
+    @Override
+    public AgentEventMarker getValue() {
+        return agentEventMarker;
+    }
+
+    public void setEndTimestamp(long endTimestamp) {
+        this.endTimestamp = endTimestamp;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        AgentEventTimelineSegment segment = (AgentEventTimelineSegment) o;
+        if (startTimestamp != segment.startTimestamp) return false;
+        if (endTimestamp != segment.endTimestamp) return false;
+        return agentEventMarker != null ? agentEventMarker.equals(segment.agentEventMarker) : segment.agentEventMarker == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = (int) (startTimestamp ^ (startTimestamp >>> 32));
+        result = 31 * result + (int) (endTimestamp ^ (endTimestamp >>> 32));
+        result = 31 * result + (agentEventMarker != null ? agentEventMarker.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("AgentEventTimelineSegment{");
+        sb.append("startTimestamp=").append(startTimestamp);
+        sb.append(", endTimestamp=").append(endTimestamp);
+        sb.append(", agentEventMarker=").append(agentEventMarker);
+        sb.append('}');
+        return sb.toString();
+    }
+}

--- a/web/src/main/java/com/navercorp/pinpoint/web/vo/timeline/inspector/AgentState.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/vo/timeline/inspector/AgentState.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2017 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.web.vo.timeline.inspector;
+
+import com.navercorp.pinpoint.common.server.util.AgentEventType;
+import com.navercorp.pinpoint.common.server.util.AgentEventTypeCategory;
+import com.navercorp.pinpoint.common.server.util.AgentLifeCycleState;
+import com.navercorp.pinpoint.web.vo.AgentEvent;
+
+import java.util.Set;
+
+/**
+ * @author HyunGil Jeong
+ */
+public enum AgentState {
+    RUNNING,
+    SHUTDOWN,
+    UNKNOWN;
+
+    private static final Set<AgentEventType> VALID_EVENT_TYPES = AgentEventType.getTypesByCatgory(AgentEventTypeCategory.AGENT_LIFECYCLE);
+
+    public static AgentState fromAgentLifeCycleState(AgentLifeCycleState state) {
+        switch (state) {
+            case RUNNING:
+                return RUNNING;
+            case SHUTDOWN:
+            case UNEXPECTED_SHUTDOWN:
+                return SHUTDOWN;
+            case DISCONNECTED:
+            case UNKNOWN:
+            default:
+                return UNKNOWN;
+        }
+    }
+
+    public static AgentState fromAgentEvent(AgentEvent agentEvent) {
+        AgentEventType eventType = AgentEventType.getTypeByCode(agentEvent.getEventTypeCode());
+        if (eventType != null && VALID_EVENT_TYPES.contains(eventType)) {
+            switch (eventType) {
+                case AGENT_CONNECTED:
+                case AGENT_PING:
+                    return RUNNING;
+                case AGENT_SHUTDOWN:
+                case AGENT_UNEXPECTED_SHUTDOWN:
+                    return SHUTDOWN;
+                case AGENT_CLOSED_BY_SERVER:
+                case AGENT_UNEXPECTED_CLOSE_BY_SERVER:
+                default:
+                    return UNKNOWN;
+            }
+        } else {
+            throw new IllegalArgumentException("agentEvent must be a life cycle event");
+        }
+    }
+}

--- a/web/src/main/java/com/navercorp/pinpoint/web/vo/timeline/inspector/AgentStatusTimeline.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/vo/timeline/inspector/AgentStatusTimeline.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2017 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.web.vo.timeline.inspector;
+
+import com.navercorp.pinpoint.web.vo.timeline.Timeline;
+
+import java.util.List;
+
+/**
+ * @author HyunGil Jeong
+ */
+public class AgentStatusTimeline implements Timeline<AgentStatusTimelineSegment> {
+
+    private final List<AgentStatusTimelineSegment> timelineSegments;
+    private final boolean includeWarning;
+
+    public AgentStatusTimeline(List<AgentStatusTimelineSegment> timelineSegments, boolean includeWarning) {
+        this.timelineSegments = timelineSegments;
+        this.includeWarning = includeWarning;
+    }
+
+    @Override
+    public List<AgentStatusTimelineSegment> getTimelineSegments() {
+        return timelineSegments;
+    }
+
+    public boolean isIncludeWarning() {
+        return includeWarning;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        AgentStatusTimeline that = (AgentStatusTimeline) o;
+
+        if (includeWarning != that.includeWarning) return false;
+        return timelineSegments != null ? timelineSegments.equals(that.timelineSegments) : that.timelineSegments == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = timelineSegments != null ? timelineSegments.hashCode() : 0;
+        result = 31 * result + (includeWarning ? 1 : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("AgentStatusTimeline{");
+        sb.append("timelineSegments=").append(timelineSegments);
+        sb.append(", includeWarning=").append(includeWarning);
+        sb.append('}');
+        return sb.toString();
+    }
+
+}

--- a/web/src/main/java/com/navercorp/pinpoint/web/vo/timeline/inspector/AgentStatusTimelineBuilder.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/vo/timeline/inspector/AgentStatusTimelineBuilder.java
@@ -1,0 +1,285 @@
+/*
+ * Copyright 2017 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.web.vo.timeline.inspector;
+
+import com.navercorp.pinpoint.common.server.util.AgentEventType;
+import com.navercorp.pinpoint.common.server.util.AgentEventTypeCategory;
+import com.navercorp.pinpoint.web.filter.agent.AgentEventFilter;
+import com.navercorp.pinpoint.web.vo.AgentEvent;
+import com.navercorp.pinpoint.web.vo.AgentStatus;
+import com.navercorp.pinpoint.web.vo.Range;
+import org.springframework.util.Assert;
+import org.springframework.util.CollectionUtils;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.PriorityQueue;
+import java.util.Queue;
+
+/**
+ * @author HyunGil Jeong
+ */
+public class AgentStatusTimelineBuilder {
+
+    private static final AgentEventFilter LIFECYCLE_EVENT_FILTER = new AgentEventFilter() {
+        @Override
+        public boolean accept(AgentEvent agentEvent) {
+            AgentEventType agentEventType = AgentEventType.getTypeByCode(agentEvent.getEventTypeCode());
+            if (agentEventType == null) {
+                return REJECT;
+            }
+            if (agentEventType.isCategorizedAs(AgentEventTypeCategory.AGENT_LIFECYCLE)) {
+                return ACCEPT;
+            }
+            return REJECT;
+        }
+    };
+
+    private final long timelineStartTimestamp;
+    private final long timelineEndTimestamp;
+    private final AgentState initialState;
+
+    private List<AgentEvent> agentEvents;
+    private boolean hasOverlap = false;
+
+    public AgentStatusTimelineBuilder(Range range, AgentStatus initialStatus) {
+        Assert.notNull(range, "range must not be null");
+        Assert.isTrue(range.getRange() > 0, "timeline must have range greater than 0");
+        timelineStartTimestamp = range.getFrom();
+        timelineEndTimestamp = range.getTo();
+        if (initialStatus == null) {
+            initialState = AgentState.UNKNOWN;
+        } else {
+            initialState = AgentState.fromAgentLifeCycleState(initialStatus.getState());
+        }
+    }
+
+    public AgentStatusTimelineBuilder from(List<AgentEvent> agentEvents) {
+        this.agentEvents = agentEvents;
+        return this;
+    }
+
+    public AgentStatusTimeline build() {
+        if (agentEvents == null) {
+            agentEvents = Collections.emptyList();
+        } else {
+            agentEvents = Collections.unmodifiableList(agentEvents);
+        }
+
+        List<AgentStatusTimelineSegment> timelineSegments = createTimelineSegments(agentEvents);
+
+        return new AgentStatusTimeline(timelineSegments, hasOverlap);
+    }
+
+    private List<AgentEvent> filterAgentEvents(AgentEventFilter agentEventFilter, List<AgentEvent> agentEvents) {
+        List<AgentEvent> filteredEvents = new ArrayList<>();
+        for (AgentEvent agentEvent : agentEvents) {
+            if (agentEventFilter.accept(agentEvent)) {
+                filteredEvents.add(agentEvent);
+            }
+        }
+        return filteredEvents;
+    }
+
+    private List<AgentStatusTimelineSegment> createTimelineSegments(List<AgentEvent> agentEvents) {
+        if (CollectionUtils.isEmpty(agentEvents)) {
+            AgentStatusTimelineSegment segment = createSegment(timelineStartTimestamp, timelineEndTimestamp, initialState);
+            return Collections.singletonList(segment);
+        } else {
+            List<AgentEvent> lifeCycleEvents = filterAgentEvents(LIFECYCLE_EVENT_FILTER, agentEvents);
+            List<AgentLifeCycle> agentLifeCycles = createAgentLifeCycles(lifeCycleEvents);
+            return convertToTimelineSegments(agentLifeCycles);
+        }
+    }
+
+    private List<AgentLifeCycle> createAgentLifeCycles(List<AgentEvent> agentEvents) {
+        Map<Long, List<AgentEvent>> partitions = partitionByStartTimestamp(agentEvents);
+        List<AgentLifeCycle> agentLifeCycles = new ArrayList<>(partitions.size());
+        for (Map.Entry<Long, List<AgentEvent>> e : partitions.entrySet()) {
+            Long agentStartTimestamp = e.getKey();
+            List<AgentEvent> agentLifeCycleEvents = e.getValue();
+            agentLifeCycles.add(createAgentLifeCycle(agentStartTimestamp, agentLifeCycleEvents));
+        }
+        return mergeOverlappingLifeCycles(agentLifeCycles);
+    }
+
+    private Map<Long, List<AgentEvent>> partitionByStartTimestamp(List<AgentEvent> agentEvents) {
+        Map<Long, List<AgentEvent>> partitions = new HashMap<>();
+        for (AgentEvent agentEvent : agentEvents) {
+            long startTimestamp = agentEvent.getStartTimestamp();
+            List<AgentEvent> partition = partitions.get(startTimestamp);
+            if (partition == null) {
+                partition = new ArrayList<>();
+                partitions.put(startTimestamp, partition);
+            }
+            partition.add(agentEvent);
+        }
+        return partitions;
+    }
+
+    private AgentLifeCycle createAgentLifeCycle(long agentStartTimestamp, List<AgentEvent> agentEvents) {
+        Collections.sort(agentEvents, AgentEvent.EVENT_TIMESTAMP_ASC_COMPARATOR);
+        AgentEvent first = agentEvents.get(0);
+        AgentEvent last = agentEvents.get(agentEvents.size() - 1);
+        AgentState endState = AgentState.fromAgentEvent(last);
+        long startTimestamp = first.getStartTimestamp();
+        if (agentStartTimestamp <= timelineStartTimestamp) {
+            startTimestamp = timelineStartTimestamp;
+        }
+        long endTimestamp = last.getEventTimestamp();
+        if (endState == AgentState.RUNNING) {
+            endTimestamp = timelineEndTimestamp;
+        }
+        return new AgentLifeCycle(startTimestamp, endTimestamp, endState);
+    }
+
+    private List<AgentLifeCycle> mergeOverlappingLifeCycles(List<AgentLifeCycle> agentLifeCycles) {
+        Collections.sort(agentLifeCycles, AgentLifeCycle.START_TIMESTAMP_ASC_COMPARATOR);
+        Queue<AgentLifeCycle> mergedAgentLifeCycles = new PriorityQueue<>(agentLifeCycles.size(), AgentLifeCycle.START_TIMESTAMP_ASC_COMPARATOR);
+        for (AgentLifeCycle agentLifeCycle : agentLifeCycles) {
+            Iterator<AgentLifeCycle> mergedAgentLifeCyclesIterator = mergedAgentLifeCycles.iterator();
+            while (mergedAgentLifeCyclesIterator.hasNext()) {
+                AgentLifeCycle mergedAgentLifeCycle = mergedAgentLifeCyclesIterator.next();
+                if (mergedAgentLifeCycle.isOverlapping(agentLifeCycle)) {
+                    mergedAgentLifeCyclesIterator.remove();
+                    agentLifeCycle = AgentLifeCycle.merge(agentLifeCycle, mergedAgentLifeCycle);
+                    hasOverlap = true;
+                }
+            }
+            mergedAgentLifeCycles.add(agentLifeCycle);
+        }
+        return new ArrayList<>(mergedAgentLifeCycles);
+    }
+
+    private List<AgentStatusTimelineSegment> convertToTimelineSegments(List<AgentLifeCycle> agentLifeCycles) {
+        List<AgentStatusTimelineSegment> segments = new ArrayList<>();
+        AgentStatusTimelineSegment fillerSegment = null;
+        for (AgentLifeCycle agentLifeCycle : agentLifeCycles) {
+            if (fillerSegment != null) {
+                fillerSegment.setEndTimestamp(agentLifeCycle.getStartTimestamp());
+                segments.add(fillerSegment);
+            } else if (agentLifeCycle.getStartTimestamp() > timelineStartTimestamp) {
+                if (initialState == AgentState.RUNNING) {
+                    hasOverlap = true;
+                }
+                fillerSegment = initializeFillerSegment(timelineStartTimestamp, initialState);
+                fillerSegment.setEndTimestamp(agentLifeCycle.getStartTimestamp());
+                segments.add(fillerSegment);
+            }
+            AgentStatusTimelineSegment lifeCycleSegment = agentLifeCycle.toTimelineSegment();
+            segments.add(lifeCycleSegment);
+            fillerSegment = initializeFillerSegment(agentLifeCycle.getEndTimestamp(), agentLifeCycle.getEndState());
+        }
+        if (fillerSegment != null && fillerSegment.getStartTimestamp() < timelineEndTimestamp) {
+            fillerSegment.setEndTimestamp(timelineEndTimestamp);
+            segments.add(fillerSegment);
+        }
+        return segments;
+    }
+
+    private AgentStatusTimelineSegment initializeFillerSegment(long startTimestamp, AgentState state) {
+        AgentStatusTimelineSegment fillerSegment = new AgentStatusTimelineSegment();
+        fillerSegment.setStartTimestamp(startTimestamp);
+        fillerSegment.setValue(state);
+        return fillerSegment;
+    }
+
+    private AgentStatusTimelineSegment createSegment(long startTimestamp, long endTimestamp, AgentState state) {
+        AgentStatusTimelineSegment segment = new AgentStatusTimelineSegment();
+        segment.setStartTimestamp(startTimestamp);
+        segment.setEndTimestamp(endTimestamp);
+        segment.setValue(state);
+        return segment;
+    }
+
+    private static class AgentLifeCycle {
+
+        private static final Comparator<AgentLifeCycle> START_TIMESTAMP_ASC_COMPARATOR = new Comparator<AgentLifeCycle>() {
+            @Override
+            public int compare(AgentLifeCycle o1, AgentLifeCycle o2) {
+                return Long.compare(o1.getStartTimestamp(), o2.getStartTimestamp());
+            }
+        };
+
+        private final long startTimestamp;
+        private final long endTimestamp;
+        private final AgentState endState;
+
+        private AgentLifeCycle(long startTimestamp, long endTimestamp, AgentState endState) {
+            if (startTimestamp >= endTimestamp) {
+                throw new IllegalArgumentException("startTimestamp must be less than endTimestamp");
+            }
+            this.startTimestamp = startTimestamp;
+            this.endTimestamp = endTimestamp;
+            this.endState = endState;
+        }
+
+        private long getStartTimestamp() {
+            return startTimestamp;
+        }
+
+        private long getEndTimestamp() {
+            return endTimestamp;
+        }
+
+        private AgentState getEndState() {
+            return endState;
+        }
+
+        private AgentStatusTimelineSegment toTimelineSegment() {
+            AgentStatusTimelineSegment timelineSegment = new AgentStatusTimelineSegment();
+            timelineSegment.setStartTimestamp(startTimestamp);
+            timelineSegment.setEndTimestamp(endTimestamp);
+            timelineSegment.setValue(AgentState.RUNNING);
+            return timelineSegment;
+        }
+
+        private boolean isOverlapping(AgentLifeCycle other) {
+            if (this.startTimestamp < other.getStartTimestamp()) {
+                return other.getStartTimestamp() <= this.endTimestamp;
+            } else if (this.startTimestamp > other.getStartTimestamp()) {
+                return this.startTimestamp <= other.getEndTimestamp();
+            } else {
+                return true;
+            }
+        }
+
+        @Override
+        public String toString() {
+            final StringBuilder sb = new StringBuilder("AgentLifeCycle{");
+            sb.append("startTimestamp=").append(startTimestamp);
+            sb.append(", endTimestamp=").append(endTimestamp);
+            sb.append(", endState=").append(endState);
+            sb.append('}');
+            return sb.toString();
+        }
+
+        private static AgentLifeCycle merge(AgentLifeCycle o1, AgentLifeCycle o2) {
+            long newStartTimestamp = Math.min(o1.getStartTimestamp(), o2.getStartTimestamp());
+            if (o1.getEndTimestamp() > o2.getEndTimestamp()) {
+                return new AgentLifeCycle(newStartTimestamp, o1.getEndTimestamp(), o1.getEndState());
+            } else {
+                return new AgentLifeCycle(newStartTimestamp, o2.getEndTimestamp(), o2.getEndState());
+            }
+        }
+    }
+}

--- a/web/src/main/java/com/navercorp/pinpoint/web/vo/timeline/inspector/AgentStatusTimelineSegment.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/vo/timeline/inspector/AgentStatusTimelineSegment.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2017 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.web.vo.timeline.inspector;
+
+import com.navercorp.pinpoint.web.vo.timeline.TimelineSegment;
+
+/**
+ * @author HyunGil Jeong
+ */
+public class AgentStatusTimelineSegment implements TimelineSegment<AgentState> {
+
+    private long startTimestamp;
+    private long endTimestamp;
+    private AgentState value;
+
+    @Override
+    public long getStartTimestamp() {
+        return startTimestamp;
+    }
+
+    public void setStartTimestamp(long startTimestamp) {
+        this.startTimestamp = startTimestamp;
+    }
+
+    @Override
+    public long getEndTimestamp() {
+        return endTimestamp;
+    }
+
+    public void setEndTimestamp(long endTimestamp) {
+        this.endTimestamp = endTimestamp;
+    }
+
+    @Override
+    public AgentState getValue() {
+        return value;
+    }
+
+    public void setValue(AgentState state) {
+        this.value = state;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        AgentStatusTimelineSegment that = (AgentStatusTimelineSegment) o;
+
+        if (startTimestamp != that.startTimestamp) return false;
+        if (endTimestamp != that.endTimestamp) return false;
+        return value == that.value;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = (int) (startTimestamp ^ (startTimestamp >>> 32));
+        result = 31 * result + (int) (endTimestamp ^ (endTimestamp >>> 32));
+        result = 31 * result + (value != null ? value.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("Segment{");
+        sb.append("startTimestamp=").append(startTimestamp);
+        sb.append(", endTimestamp=").append(endTimestamp);
+        sb.append(", value=").append(value);
+        sb.append('}');
+        return sb.toString();
+    }
+}

--- a/web/src/main/java/com/navercorp/pinpoint/web/vo/timeline/inspector/InspectorTimeline.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/vo/timeline/inspector/InspectorTimeline.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2017 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.web.vo.timeline.inspector;
+
+/**
+ * @author HyunGil Jeong
+ */
+public class InspectorTimeline {
+
+    private final AgentStatusTimeline agentStatusTimeline;
+    private final AgentEventTimeline agentEventTimeline;
+
+    public InspectorTimeline(AgentStatusTimeline agentStatusTimeline, AgentEventTimeline agentEventTimeline) {
+        this.agentStatusTimeline = agentStatusTimeline;
+        this.agentEventTimeline = agentEventTimeline;
+    }
+
+    public AgentStatusTimeline getAgentStatusTimeline() {
+        return agentStatusTimeline;
+    }
+
+    public AgentEventTimeline getAgentEventTimeline() {
+        return agentEventTimeline;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        InspectorTimeline that = (InspectorTimeline) o;
+
+        if (agentStatusTimeline != null ? !agentStatusTimeline.equals(that.agentStatusTimeline) : that.agentStatusTimeline != null)
+            return false;
+        return agentEventTimeline != null ? agentEventTimeline.equals(that.agentEventTimeline) : that.agentEventTimeline == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = agentStatusTimeline != null ? agentStatusTimeline.hashCode() : 0;
+        result = 31 * result + (agentEventTimeline != null ? agentEventTimeline.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("InspectorTimeline{");
+        sb.append("agentStatusTimeline=").append(agentStatusTimeline);
+        sb.append(", agentEventTimeline=").append(agentEventTimeline);
+        sb.append('}');
+        return sb.toString();
+    }
+}

--- a/web/src/test/java/com/navercorp/pinpoint/web/vo/timeline/inspector/AgentEventTimelineTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/vo/timeline/inspector/AgentEventTimelineTest.java
@@ -29,7 +29,9 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 /**
  * @author HyunGil Jeong
@@ -41,12 +43,12 @@ public class AgentEventTimelineTest {
         // Given
         Range timelineRange = new Range(100, 200);
         List<AgentEvent> agentEvents = Arrays.asList(
-                createAgentEvent(0, 140, AgentEventType.AGENT_PING),
-                createAgentEvent(0, 190, AgentEventType.AGENT_PING));
-        List<AgentEventTimeline.Segment> expectedTimelineSegments = Collections.singletonList(
+                createAgentEvent(140, AgentEventType.AGENT_PING),
+                createAgentEvent(190, AgentEventType.AGENT_PING));
+        List<AgentEventTimelineSegment> expectedTimelineSegments = Collections.singletonList(
                 createSegment(100, 200, agentEvents));
         // When
-        AgentEventTimeline timeline = new AgentEventTimelineBuilder(timelineRange)
+        AgentEventTimeline timeline = new AgentEventTimelineBuilder(timelineRange, 1)
                 .from(agentEvents)
                 .build();
         // Then
@@ -58,12 +60,12 @@ public class AgentEventTimelineTest {
         // Given
         Range timelineRange = new Range(100, 200);
         List<AgentEvent> agentEvents = Arrays.asList(
-                createAgentEvent(0, 140, AgentEventType.AGENT_PING),
-                createAgentEvent(0, 190, AgentEventType.AGENT_PING));
-        List<AgentEventTimeline.Segment> expectedTimelineSegments = Collections.singletonList(
+                createAgentEvent(140, AgentEventType.AGENT_PING),
+                createAgentEvent(190, AgentEventType.AGENT_PING));
+        List<AgentEventTimelineSegment> expectedTimelineSegments = Collections.singletonList(
                 createSegment(100, 200, agentEvents));
         // When
-        AgentEventTimeline timeline = new AgentEventTimelineBuilder(timelineRange)
+        AgentEventTimeline timeline = new AgentEventTimelineBuilder(timelineRange, 1)
                 .from(agentEvents)
                 .addFilter(null)
                 .build();
@@ -76,14 +78,14 @@ public class AgentEventTimelineTest {
         // Given
         Range timelineRange = new Range(100, 200);
         List<AgentEvent> agentEvents = Arrays.asList(
-                createAgentEvent(0, 110, AgentEventType.AGENT_PING),
-                createAgentEvent(0, 120, AgentEventType.AGENT_CONNECTED),
-                createAgentEvent(0, 130, AgentEventType.AGENT_SHUTDOWN),
-                createAgentEvent(0, 140, AgentEventType.AGENT_UNEXPECTED_SHUTDOWN),
-                createAgentEvent(0, 150, AgentEventType.AGENT_CLOSED_BY_SERVER),
-                createAgentEvent(0, 160, AgentEventType.AGENT_UNEXPECTED_CLOSE_BY_SERVER),
-                createAgentEvent(0, 170, AgentEventType.USER_THREAD_DUMP),
-                createAgentEvent(0, 180, AgentEventType.OTHER));
+                createAgentEvent(110, AgentEventType.AGENT_PING),
+                createAgentEvent(120, AgentEventType.AGENT_CONNECTED),
+                createAgentEvent(130, AgentEventType.AGENT_SHUTDOWN),
+                createAgentEvent(140, AgentEventType.AGENT_UNEXPECTED_SHUTDOWN),
+                createAgentEvent(150, AgentEventType.AGENT_CLOSED_BY_SERVER),
+                createAgentEvent(160, AgentEventType.AGENT_UNEXPECTED_CLOSE_BY_SERVER),
+                createAgentEvent(170, AgentEventType.USER_THREAD_DUMP),
+                createAgentEvent(180, AgentEventType.OTHER));
         Set<AgentEventType> includedAgentEventTypes = new HashSet<AgentEventType>() {{
             add(AgentEventType.AGENT_PING);
             add(AgentEventType.AGENT_CONNECTED);
@@ -95,37 +97,145 @@ public class AgentEventTimelineTest {
         AgentEventFilter excludeUserThreadDumpFilter = new AgentEventFilter.ExcludeFilter(AgentEventType.USER_THREAD_DUMP);
         AgentEventFilter excludeOtherFilter = new AgentEventFilter.ExcludeFilter(AgentEventType.OTHER);
         // When
-        AgentEventTimeline timeline = new AgentEventTimelineBuilder(timelineRange)
+        AgentEventTimeline timeline = new AgentEventTimelineBuilder(timelineRange, 1)
                 .from(agentEvents)
                 .addFilter(excludeUnexpectedEventsFilter)
                 .addFilter(excludeUserThreadDumpFilter)
                 .addFilter(excludeOtherFilter)
                 .build();
         // Then
-        List<AgentEvent> timelineEvents = new ArrayList<>();
-        List<AgentEventTimeline.Segment> segments = timeline.getTimelineSegments();
-        for (AgentEventTimeline.Segment segment : segments) {
-            timelineEvents.addAll(segment.getValue());
+        int allEventsTotalCount = 0;
+        for (AgentEventTimelineSegment segment : timeline.getTimelineSegments()) {
+            AgentEventMarker marker = segment.getValue();
+            allEventsTotalCount += marker.getTotalCount();
+            Map<AgentEventType, Integer> eventTypeCountMap = marker.getTypeCounts();
+            Assert.assertTrue(includedAgentEventTypes.containsAll(eventTypeCountMap.keySet()));
+            Assert.assertFalse(eventTypeCountMap.keySet().contains(AgentEventType.AGENT_UNEXPECTED_SHUTDOWN));
+            Assert.assertFalse(eventTypeCountMap.keySet().contains(AgentEventType.AGENT_UNEXPECTED_CLOSE_BY_SERVER));
+            Assert.assertFalse(eventTypeCountMap.keySet().contains(AgentEventType.USER_THREAD_DUMP));
+            Assert.assertFalse(eventTypeCountMap.keySet().contains(AgentEventType.OTHER));
         }
-        for (AgentEvent timelineEvent : timelineEvents) {
-            AgentEventType timelineEventType = AgentEventType.getTypeByCode(timelineEvent.getEventTypeCode());
-            Assert.assertTrue(includedAgentEventTypes.contains(timelineEventType));
-            Assert.assertTrue(timelineEventType != AgentEventType.AGENT_UNEXPECTED_SHUTDOWN);
-            Assert.assertTrue(timelineEventType != AgentEventType.AGENT_UNEXPECTED_CLOSE_BY_SERVER);
-            Assert.assertTrue(timelineEventType != AgentEventType.USER_THREAD_DUMP);
-            Assert.assertTrue(timelineEventType != AgentEventType.OTHER);
+        Assert.assertEquals(allEventsTotalCount, includedAgentEventTypes.size());
+    }
+
+    @Test
+    public void leftBiasedSpread() {
+        // Given
+        Range range = new Range(100, 200);
+        AgentEvent event1 = createAgentEvent(0, AgentEventType.AGENT_CONNECTED);
+        AgentEvent event2 = createAgentEvent(5, AgentEventType.AGENT_PING);
+        AgentEvent event3 = createAgentEvent(50, AgentEventType.AGENT_PING);
+        AgentEvent event4 = createAgentEvent(100, AgentEventType.AGENT_PING);
+        AgentEvent event5 = createAgentEvent(150, AgentEventType.AGENT_PING);
+        AgentEvent event6 = createAgentEvent(220, AgentEventType.AGENT_SHUTDOWN);
+        List<AgentEventTimelineSegment> expectedTimelineSegments = Arrays.asList(
+                createSegment(100, 101, Arrays.asList(event1, event2, event3, event4)),
+                createSegment(150, 151, Collections.singletonList(event5)),
+                createSegment(199, 200, Collections.singletonList(event6)));
+        // When
+        AgentEventTimeline timeline = new AgentEventTimelineBuilder(range, 100)
+                .from(Arrays.asList(event1, event2, event3, event4, event5, event6))
+                .build();
+        // Then
+        Assert.assertEquals(expectedTimelineSegments, timeline.getTimelineSegments());
+    }
+
+    @Test
+    public void rightBiasedSpread() {
+        // Given
+        Range range = new Range(0, 199);
+        AgentEvent event1 = createAgentEvent(0, AgentEventType.AGENT_CONNECTED);
+        AgentEvent event2 = createAgentEvent(5, AgentEventType.AGENT_PING);
+        AgentEvent event3 = createAgentEvent(100, AgentEventType.AGENT_PING);
+        AgentEvent event4 = createAgentEvent(110, AgentEventType.AGENT_PING);
+        AgentEvent event5 = createAgentEvent(199, AgentEventType.AGENT_PING);
+        AgentEvent event6 = createAgentEvent(200, AgentEventType.AGENT_SHUTDOWN);
+        List<AgentEventTimelineSegment> expectedTimelineSegments = Arrays.asList(
+                createSegment(0, 1, Collections.singletonList(event1)),
+                createSegment(5, 6, Collections.singletonList(event2)),
+                createSegment(99, 199, Arrays.asList(event3, event4, event5, event6)));
+        // When
+        AgentEventTimeline timeline = new AgentEventTimelineBuilder(range, 100)
+                .from(Arrays.asList(event1, event2, event3, event4, event5, event6))
+                .build();
+        // Then
+        Assert.assertEquals(expectedTimelineSegments, timeline.getTimelineSegments());
+    }
+
+    @Test
+    public void rangeLessThanNumTimeslots() {
+        // Given
+        Range range = new Range(10, 20);
+        AgentEvent event1 = createAgentEvent(10, AgentEventType.AGENT_PING);
+        AgentEvent event2 = createAgentEvent(11, AgentEventType.AGENT_PING);
+        AgentEvent event3 = createAgentEvent(12, AgentEventType.AGENT_PING);
+        AgentEvent event4 = createAgentEvent(13, AgentEventType.AGENT_PING);
+        AgentEvent event5 = createAgentEvent(14, AgentEventType.AGENT_PING);
+        AgentEvent event6 = createAgentEvent(15, AgentEventType.AGENT_PING);
+        AgentEvent event7 = createAgentEvent(16, AgentEventType.AGENT_PING);
+        AgentEvent event8 = createAgentEvent(17, AgentEventType.AGENT_PING);
+        AgentEvent event9 = createAgentEvent(18, AgentEventType.AGENT_PING);
+        AgentEvent event10 = createAgentEvent(19, AgentEventType.AGENT_PING);
+        List<AgentEventTimelineSegment> expectedTimelineSegments = Arrays.asList(
+                createSegment(10, 11, Collections.singletonList(event1)),
+                createSegment(11, 12, Collections.singletonList(event2)),
+                createSegment(12, 13, Collections.singletonList(event3)),
+                createSegment(13, 14, Collections.singletonList(event4)),
+                createSegment(14, 15, Collections.singletonList(event5)),
+                createSegment(15, 16, Collections.singletonList(event6)),
+                createSegment(16, 17, Collections.singletonList(event7)),
+                createSegment(17, 18, Collections.singletonList(event8)),
+                createSegment(18, 19, Collections.singletonList(event9)),
+                createSegment(19, 20, Collections.singletonList(event10)));
+        // When
+        AgentEventTimeline timeline = new AgentEventTimelineBuilder(range, 100)
+                .from(Arrays.asList(event1, event2, event3, event4, event5, event6, event7, event8, event9, event10))
+                .build();
+        // Then
+        Assert.assertEquals(expectedTimelineSegments, timeline.getTimelineSegments());
+    }
+
+    @Test
+    public void fullTimeslots_multipleEvents() {
+        // Given
+        long timeRangeMs = TimeUnit.DAYS.toMillis(7);
+        long from = System.currentTimeMillis();
+        long to = from + timeRangeMs;
+        Range range = new Range(from, to);
+        int numTimeslots = 100;
+        int expectedEventCountPerSegment = 20;
+        List<AgentEvent> agentEvents = new ArrayList<>();
+        for (int i = 0 ; i < timeRangeMs; i += (timeRangeMs / (numTimeslots * expectedEventCountPerSegment))) {
+            agentEvents.add(createAgentEvent(from + i, AgentEventType.AGENT_PING));
+        }
+        // When
+        AgentEventTimeline timeline = new AgentEventTimelineBuilder(range, numTimeslots)
+                .from(agentEvents)
+                .build();
+        // Then
+        List<AgentEventTimelineSegment> timelineSegments = timeline.getTimelineSegments();
+        Assert.assertEquals(numTimeslots, timelineSegments.size());
+        for (AgentEventTimelineSegment timelineSegment : timelineSegments) {
+            AgentEventMarker eventMarker = timelineSegment.getValue();
+            Assert.assertEquals(expectedEventCountPerSegment, eventMarker.getTotalCount());
+            int pingEventCount = eventMarker.getTypeCounts().get(AgentEventType.AGENT_PING);
+            Assert.assertEquals(expectedEventCountPerSegment, pingEventCount);
         }
     }
 
-    private AgentEventTimeline.Segment createSegment(long startTimestamp, long endTimestamp, List<AgentEvent> agentEvents) {
-        AgentEventTimeline.Segment segment = new AgentEventTimeline.Segment();
+    private AgentEventTimelineSegment createSegment(long startTimestamp, long endTimestamp, List<AgentEvent> agentEvents) {
+        AgentEventTimelineSegment segment = new AgentEventTimelineSegment();
         segment.setStartTimestamp(startTimestamp);
         segment.setEndTimestamp(endTimestamp);
-        segment.setValue(agentEvents);
+        AgentEventMarker agentEventMarker = new AgentEventMarker();
+        for (AgentEvent agentEvent : agentEvents) {
+            agentEventMarker.addAgentEvent(agentEvent);
+        }
+        segment.setValue(agentEventMarker);
         return segment;
     }
 
-    private AgentEvent createAgentEvent(long agentStartTimestamp, long timestamp, AgentEventType agentEventType) {
-        return new AgentEvent(new AgentEventBo("testAgentId", agentStartTimestamp, timestamp, agentEventType));
+    private AgentEvent createAgentEvent(long eventTimestamp, AgentEventType agentEventType) {
+        return new AgentEvent(new AgentEventBo("testAgentId", 0, eventTimestamp, agentEventType));
     }
 }

--- a/web/src/test/java/com/navercorp/pinpoint/web/vo/timeline/inspector/AgentEventTimelineTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/vo/timeline/inspector/AgentEventTimelineTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2017 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.web.vo.timeline.inspector;
+
+import com.navercorp.pinpoint.common.server.bo.AgentEventBo;
+import com.navercorp.pinpoint.common.server.util.AgentEventType;
+import com.navercorp.pinpoint.web.filter.agent.AgentEventFilter;
+import com.navercorp.pinpoint.web.vo.AgentEvent;
+import com.navercorp.pinpoint.web.vo.Range;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * @author HyunGil Jeong
+ */
+public class AgentEventTimelineTest {
+
+    @Test
+    public void noFilter() {
+        // Given
+        Range timelineRange = new Range(100, 200);
+        List<AgentEvent> agentEvents = Arrays.asList(
+                createAgentEvent(0, 140, AgentEventType.AGENT_PING),
+                createAgentEvent(0, 190, AgentEventType.AGENT_PING));
+        List<AgentEventTimeline.Segment> expectedTimelineSegments = Collections.singletonList(
+                createSegment(100, 200, agentEvents));
+        // When
+        AgentEventTimeline timeline = new AgentEventTimelineBuilder(timelineRange)
+                .from(agentEvents)
+                .build();
+        // Then
+        Assert.assertEquals(expectedTimelineSegments, timeline.getTimelineSegments());
+    }
+
+    @Test
+    public void nullFilter() {
+        // Given
+        Range timelineRange = new Range(100, 200);
+        List<AgentEvent> agentEvents = Arrays.asList(
+                createAgentEvent(0, 140, AgentEventType.AGENT_PING),
+                createAgentEvent(0, 190, AgentEventType.AGENT_PING));
+        List<AgentEventTimeline.Segment> expectedTimelineSegments = Collections.singletonList(
+                createSegment(100, 200, agentEvents));
+        // When
+        AgentEventTimeline timeline = new AgentEventTimelineBuilder(timelineRange)
+                .from(agentEvents)
+                .addFilter(null)
+                .build();
+        // Then
+        Assert.assertEquals(expectedTimelineSegments, timeline.getTimelineSegments());
+    }
+
+    @Test
+    public void multipleFilters() {
+        // Given
+        Range timelineRange = new Range(100, 200);
+        List<AgentEvent> agentEvents = Arrays.asList(
+                createAgentEvent(0, 110, AgentEventType.AGENT_PING),
+                createAgentEvent(0, 120, AgentEventType.AGENT_CONNECTED),
+                createAgentEvent(0, 130, AgentEventType.AGENT_SHUTDOWN),
+                createAgentEvent(0, 140, AgentEventType.AGENT_UNEXPECTED_SHUTDOWN),
+                createAgentEvent(0, 150, AgentEventType.AGENT_CLOSED_BY_SERVER),
+                createAgentEvent(0, 160, AgentEventType.AGENT_UNEXPECTED_CLOSE_BY_SERVER),
+                createAgentEvent(0, 170, AgentEventType.USER_THREAD_DUMP),
+                createAgentEvent(0, 180, AgentEventType.OTHER));
+        Set<AgentEventType> includedAgentEventTypes = new HashSet<AgentEventType>() {{
+            add(AgentEventType.AGENT_PING);
+            add(AgentEventType.AGENT_CONNECTED);
+            add(AgentEventType.AGENT_SHUTDOWN);
+            add(AgentEventType.AGENT_CLOSED_BY_SERVER);
+        }};
+        AgentEventFilter excludeUnexpectedEventsFilter = new AgentEventFilter.ExcludeFilter(
+                AgentEventType.AGENT_UNEXPECTED_SHUTDOWN, AgentEventType.AGENT_UNEXPECTED_CLOSE_BY_SERVER);
+        AgentEventFilter excludeUserThreadDumpFilter = new AgentEventFilter.ExcludeFilter(AgentEventType.USER_THREAD_DUMP);
+        AgentEventFilter excludeOtherFilter = new AgentEventFilter.ExcludeFilter(AgentEventType.OTHER);
+        // When
+        AgentEventTimeline timeline = new AgentEventTimelineBuilder(timelineRange)
+                .from(agentEvents)
+                .addFilter(excludeUnexpectedEventsFilter)
+                .addFilter(excludeUserThreadDumpFilter)
+                .addFilter(excludeOtherFilter)
+                .build();
+        // Then
+        List<AgentEvent> timelineEvents = new ArrayList<>();
+        List<AgentEventTimeline.Segment> segments = timeline.getTimelineSegments();
+        for (AgentEventTimeline.Segment segment : segments) {
+            timelineEvents.addAll(segment.getValue());
+        }
+        for (AgentEvent timelineEvent : timelineEvents) {
+            AgentEventType timelineEventType = AgentEventType.getTypeByCode(timelineEvent.getEventTypeCode());
+            Assert.assertTrue(includedAgentEventTypes.contains(timelineEventType));
+            Assert.assertTrue(timelineEventType != AgentEventType.AGENT_UNEXPECTED_SHUTDOWN);
+            Assert.assertTrue(timelineEventType != AgentEventType.AGENT_UNEXPECTED_CLOSE_BY_SERVER);
+            Assert.assertTrue(timelineEventType != AgentEventType.USER_THREAD_DUMP);
+            Assert.assertTrue(timelineEventType != AgentEventType.OTHER);
+        }
+    }
+
+    private AgentEventTimeline.Segment createSegment(long startTimestamp, long endTimestamp, List<AgentEvent> agentEvents) {
+        AgentEventTimeline.Segment segment = new AgentEventTimeline.Segment();
+        segment.setStartTimestamp(startTimestamp);
+        segment.setEndTimestamp(endTimestamp);
+        segment.setValue(agentEvents);
+        return segment;
+    }
+
+    private AgentEvent createAgentEvent(long agentStartTimestamp, long timestamp, AgentEventType agentEventType) {
+        return new AgentEvent(new AgentEventBo("testAgentId", agentStartTimestamp, timestamp, agentEventType));
+    }
+}

--- a/web/src/test/java/com/navercorp/pinpoint/web/vo/timeline/inspector/AgentStatusTimelineTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/vo/timeline/inspector/AgentStatusTimelineTest.java
@@ -1,0 +1,437 @@
+/*
+ * Copyright 2017 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.web.vo.timeline.inspector;
+
+import com.navercorp.pinpoint.common.server.bo.AgentEventBo;
+import com.navercorp.pinpoint.common.server.util.AgentEventType;
+import com.navercorp.pinpoint.common.server.util.AgentLifeCycleState;
+import com.navercorp.pinpoint.web.vo.AgentEvent;
+import com.navercorp.pinpoint.web.vo.AgentStatus;
+import com.navercorp.pinpoint.web.vo.Range;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * @author HyunGil Jeong
+ */
+public class AgentStatusTimelineTest {
+
+    @Test
+    public void nullAgentStatus() {
+        // Given
+        Range timelineRange = new Range(0, 100);
+        List<AgentStatusTimelineSegment> expectedTimelineSegments = Collections.singletonList(
+                createSegment(0, 100, AgentState.UNKNOWN));
+        // When
+        AgentStatusTimeline timeline = new AgentStatusTimelineBuilder(timelineRange, null).build();
+        // Then
+        Assert.assertEquals(expectedTimelineSegments, timeline.getTimelineSegments());
+        Assert.assertFalse(timeline.isIncludeWarning());
+    }
+
+    @Test
+    public void nullAgentStatus_nullAgentEvents() {
+        // Given
+        Range timelineRange = new Range(0, 100);
+        List<AgentStatusTimelineSegment> expectedTimelineSegments = Collections.singletonList(
+                createSegment(0, 100, AgentState.UNKNOWN));
+        // When
+        AgentStatusTimeline timeline = new AgentStatusTimelineBuilder(timelineRange, null).from(null).build();
+        // Then
+        Assert.assertEquals(expectedTimelineSegments, timeline.getTimelineSegments());
+        Assert.assertFalse(timeline.isIncludeWarning());
+    }
+
+    @Test
+    public void agentStatus() {
+        // Given
+        Range timelineRange = new Range(100, 200);
+        AgentLifeCycleState expectedState = AgentLifeCycleState.RUNNING;
+        List<AgentStatusTimelineSegment> expectedTimelineSegments = Collections.singletonList(
+                createSegment(100, 200, AgentState.fromAgentLifeCycleState(expectedState)));
+        // When
+        AgentStatus initialStatus = createAgentStatus(50, expectedState);
+        AgentStatusTimeline timeline = new AgentStatusTimelineBuilder(timelineRange, initialStatus).build();
+        // Then
+        Assert.assertEquals(expectedTimelineSegments, timeline.getTimelineSegments());
+        Assert.assertFalse(timeline.isIncludeWarning());
+    }
+
+    @Test
+    public void agentStatus_nullAgentEvents() {
+        // Given
+        Range timelineRange = new Range(100, 200);
+        AgentLifeCycleState expectedState = AgentLifeCycleState.RUNNING;
+        List<AgentStatusTimelineSegment> expectedTimelineSegments = Collections.singletonList(
+                createSegment(100, 200, AgentState.fromAgentLifeCycleState(expectedState)));
+        // When
+        AgentStatus initialStatus = createAgentStatus(50, expectedState);
+        AgentStatusTimeline timeline = new AgentStatusTimelineBuilder(timelineRange, initialStatus).from(null).build();
+        // Then
+        Assert.assertEquals(expectedTimelineSegments, timeline.getTimelineSegments());
+        Assert.assertFalse(timeline.isIncludeWarning());
+    }
+
+    @Test
+    public void singleLifeCycle_startedBeforeTimelineStartTimestamp() {
+        // Given
+        Range timelineRange = new Range(100, 200);
+        List<AgentStatusTimelineSegment> expectedTimelineSegments = Collections.singletonList(
+                createSegment(100, 200, AgentState.RUNNING));
+        // When
+        long agentA = 0;
+        AgentStatus initialStatus = createAgentStatus(90, AgentLifeCycleState.RUNNING);
+        AgentStatusTimeline timeline = new AgentStatusTimelineBuilder(timelineRange, initialStatus)
+                .from(Arrays.asList(
+                        createAgentEvent(agentA, 140, AgentEventType.AGENT_PING),
+                        createAgentEvent(agentA, 190, AgentEventType.AGENT_PING)
+                )).build();
+        // Then
+        Assert.assertEquals(expectedTimelineSegments, timeline.getTimelineSegments());
+        Assert.assertFalse(timeline.isIncludeWarning());
+    }
+
+    @Test
+    public void singleLifeCycle_startedAfterTimelineStartTimestamp_initialStateRunning() {
+        // Given
+        Range timelineRange = new Range(100, 200);
+        List<AgentStatusTimelineSegment> expectedTimelineSegments = Arrays.asList(
+                createSegment(100, 150, AgentState.RUNNING),
+                createSegment(150, 200, AgentState.RUNNING));
+        // When
+        long agentA = 150;
+        AgentStatus initialStatus = createAgentStatus(50, AgentLifeCycleState.RUNNING);
+        AgentStatusTimeline timeline = new AgentStatusTimelineBuilder(timelineRange, initialStatus)
+                .from(Arrays.asList(
+                        createAgentEvent(agentA, 150, AgentEventType.AGENT_CONNECTED),
+                        createAgentEvent(agentA, 180, AgentEventType.AGENT_PING)
+                )).build();
+        // Then
+        Assert.assertEquals(expectedTimelineSegments, timeline.getTimelineSegments());
+        Assert.assertTrue(timeline.isIncludeWarning());
+    }
+
+    @Test
+    public void singleLifeCycle_startedAfterTimelineStartTimestamp_initialStateShutdown() {
+        // Given
+        Range timelineRange = new Range(100, 200);
+        List<AgentStatusTimelineSegment> expectedTimelineSegments = Arrays.asList(
+                createSegment(100, 150, AgentState.SHUTDOWN),
+                createSegment(150, 200, AgentState.RUNNING));
+        // When
+        long agentA = 150;
+        AgentStatus initialStatus = createAgentStatus(50, AgentLifeCycleState.SHUTDOWN);
+        AgentStatusTimeline timeline = new AgentStatusTimelineBuilder(timelineRange, initialStatus)
+                .from(Arrays.asList(
+                        createAgentEvent(agentA, 150, AgentEventType.AGENT_CONNECTED),
+                        createAgentEvent(agentA, 180, AgentEventType.AGENT_PING)
+                )).build();
+        // Then
+        Assert.assertEquals(expectedTimelineSegments, timeline.getTimelineSegments());
+        Assert.assertFalse(timeline.isIncludeWarning());
+    }
+
+    @Test
+    public void singleLifeCycle_endedBeforeTimelineEndTimestamp() {
+        // Given
+        Range timelineRange = new Range(100, 200);
+        List<AgentStatusTimelineSegment> expectedTimelineSegments = Arrays.asList(
+                createSegment(100, 180, AgentState.RUNNING),
+                createSegment(180, 200, AgentState.SHUTDOWN));
+        // When
+        long agentA = 0;
+        AgentStatus initialStatus = createAgentStatus(90, AgentLifeCycleState.RUNNING);
+        AgentStatusTimeline timeline = new AgentStatusTimelineBuilder(timelineRange, initialStatus)
+                .from(Arrays.asList(
+                        createAgentEvent(agentA, 120, AgentEventType.AGENT_PING),
+                        createAgentEvent(agentA, 150, AgentEventType.AGENT_PING),
+                        createAgentEvent(agentA, 180, AgentEventType.AGENT_SHUTDOWN)
+                )).build();
+        // Then
+        Assert.assertEquals(expectedTimelineSegments, timeline.getTimelineSegments());
+        Assert.assertFalse(timeline.isIncludeWarning());
+    }
+
+    @Test
+    public void singleLifeCycle_disconnected() {
+        // Given
+        Range timelineRange = new Range(100, 200);
+        List<AgentStatusTimelineSegment> expectedTimelineSegments = Collections.singletonList(
+                createSegment(100, 200, AgentState.RUNNING));
+        // When
+        long agentA = 0;
+        AgentStatus initialStatus = createAgentStatus(90, AgentLifeCycleState.RUNNING);
+        AgentStatusTimeline timeline = new AgentStatusTimelineBuilder(timelineRange, initialStatus)
+                .from(Arrays.asList(
+                        createAgentEvent(agentA, 150, AgentEventType.AGENT_CLOSED_BY_SERVER),
+                        createAgentEvent(agentA, 160, AgentEventType.AGENT_CONNECTED),
+                        createAgentEvent(agentA, 180, AgentEventType.AGENT_PING)
+                )).build();
+        // Then
+        Assert.assertEquals(expectedTimelineSegments, timeline.getTimelineSegments());
+        Assert.assertFalse(timeline.isIncludeWarning());
+    }
+
+    @Test
+    public void multipleLifeCycles_disconnected() {
+        // Given
+        Range timelineRange = new Range(100, 200);
+        List<AgentStatusTimelineSegment> expectedTimelineSegments = Arrays.asList(
+                createSegment(100, 150, AgentState.RUNNING),
+                createSegment(150, 160, AgentState.UNKNOWN),
+                createSegment(160, 200, AgentState.RUNNING));
+        // When
+        long agentA = 0;
+        long agentB = 160;
+        AgentStatus initialStatus = createAgentStatus(90, AgentLifeCycleState.RUNNING);
+        AgentStatusTimeline timeline = new AgentStatusTimelineBuilder(timelineRange, initialStatus)
+                .from(Arrays.asList(
+                        createAgentEvent(agentA, 150, AgentEventType.AGENT_CLOSED_BY_SERVER),
+                        createAgentEvent(agentB, 160, AgentEventType.AGENT_CONNECTED),
+                        createAgentEvent(agentB, 180, AgentEventType.AGENT_PING)
+                )).build();
+        // Then
+        Assert.assertEquals(expectedTimelineSegments, timeline.getTimelineSegments());
+        Assert.assertFalse(timeline.isIncludeWarning());
+    }
+
+    @Test
+    public void multipleLifeCycles_noOverlap() {
+        // Given
+        Range timelineRange = new Range(100, 200);
+        List<AgentStatusTimelineSegment> expectedTimelineSegments = Arrays.asList(
+                createSegment(100, 140, AgentState.RUNNING),
+                createSegment(140, 160, AgentState.SHUTDOWN),
+                createSegment(160, 200, AgentState.RUNNING));
+        // When
+        long agentA = 0;
+        long agentB = 160;
+        AgentStatus initialStatus = createAgentStatus(90, AgentLifeCycleState.RUNNING);
+        AgentStatusTimeline timeline = new AgentStatusTimelineBuilder(timelineRange, initialStatus)
+                .from(Arrays.asList(
+                        createAgentEvent(agentA, 140, AgentEventType.AGENT_UNEXPECTED_SHUTDOWN),
+                        createAgentEvent(agentB, 160, AgentEventType.AGENT_CONNECTED),
+                        createAgentEvent(agentB, 180, AgentEventType.AGENT_PING)
+                )).build();
+        // Then
+        Assert.assertEquals(expectedTimelineSegments, timeline.getTimelineSegments());
+        Assert.assertFalse(timeline.isIncludeWarning());
+    }
+
+    @Test
+    public void multipleLifeCycles_noOverlap2() {
+        // Given
+        Range timelineRange = new Range(100, 200);
+        List<AgentStatusTimelineSegment> expectedTimelineSegments = Arrays.asList(
+                createSegment(100, 159, AgentState.RUNNING),
+                createSegment(159, 160, AgentState.SHUTDOWN),
+                createSegment(160, 200, AgentState.RUNNING));
+        // When
+        long agentA = 0;
+        long agentB = 160;
+        AgentStatus initialStatus = createAgentStatus(90, AgentLifeCycleState.RUNNING);
+        AgentStatusTimeline timeline = new AgentStatusTimelineBuilder(timelineRange, initialStatus)
+                .from(Arrays.asList(
+                        createAgentEvent(agentA, 159, AgentEventType.AGENT_UNEXPECTED_SHUTDOWN),
+                        createAgentEvent(agentB, 160, AgentEventType.AGENT_CONNECTED),
+                        createAgentEvent(agentB, 180, AgentEventType.AGENT_PING)
+                )).build();
+        // Then
+        Assert.assertEquals(expectedTimelineSegments, timeline.getTimelineSegments());
+        Assert.assertFalse(timeline.isIncludeWarning());
+    }
+
+    @Test
+    public void multipleLifeCycles_noOverlap3() {
+        // Given
+        Range timelineRange = new Range(100, 200);
+        List<AgentStatusTimelineSegment> expectedTimelineSegments = Arrays.asList(
+                createSegment(100, 120, AgentState.SHUTDOWN),
+                createSegment(120, 140, AgentState.RUNNING),
+                createSegment(140, 160, AgentState.SHUTDOWN),
+                createSegment(160, 180, AgentState.RUNNING),
+                createSegment(180, 200, AgentState.SHUTDOWN));
+        // When
+        long agentA = 120;
+        long agentB = 160;
+        AgentStatus initialStatus = createAgentStatus(90, AgentLifeCycleState.SHUTDOWN);
+        AgentStatusTimeline timeline = new AgentStatusTimelineBuilder(timelineRange, initialStatus)
+                .from(Arrays.asList(
+                        createAgentEvent(agentA, 120, AgentEventType.AGENT_CONNECTED),
+                        createAgentEvent(agentA, 140, AgentEventType.AGENT_UNEXPECTED_SHUTDOWN),
+                        createAgentEvent(agentB, 160, AgentEventType.AGENT_CONNECTED),
+                        createAgentEvent(agentB, 180, AgentEventType.AGENT_SHUTDOWN)
+                )).build();
+        // Then
+        Assert.assertEquals(expectedTimelineSegments, timeline.getTimelineSegments());
+        Assert.assertFalse(timeline.isIncludeWarning());
+    }
+
+    @Test
+    public void multipleLifeCycles_overlap() {
+        // Given
+        Range timelineRange = new Range(100, 200);
+        List<AgentStatusTimelineSegment> expectedTimelineSegments = Arrays.asList(
+                createSegment(100, 180, AgentState.RUNNING),
+                createSegment(180, 200, AgentState.SHUTDOWN));
+        // When
+        long agentA = 0;
+        long agentB = 120;
+        AgentStatus initialStatus = createAgentStatus(90, AgentLifeCycleState.RUNNING);
+        AgentStatusTimeline timeline = new AgentStatusTimelineBuilder(timelineRange, initialStatus)
+                .from(Arrays.asList(
+                        createAgentEvent(agentB, 120, AgentEventType.AGENT_CONNECTED),
+                        createAgentEvent(agentA, 140, AgentEventType.AGENT_PING),
+                        createAgentEvent(agentB, 160, AgentEventType.AGENT_UNEXPECTED_SHUTDOWN),
+                        createAgentEvent(agentA, 180, AgentEventType.AGENT_SHUTDOWN)
+                )).build();
+        // Then
+        Assert.assertEquals(expectedTimelineSegments, timeline.getTimelineSegments());
+        Assert.assertTrue(timeline.isIncludeWarning());
+    }
+
+    @Test
+    public void multipleLifeCycles_overlap2() {
+        // Given
+        Range timelineRange = new Range(100, 200);
+        List<AgentStatusTimelineSegment> expectedTimelineSegments = Collections.singletonList(
+                createSegment(100, 200, AgentState.RUNNING));
+        // When
+        long agentA = 0;
+        long agentB = 160;
+        AgentStatus initialStatus = createAgentStatus(90, AgentLifeCycleState.RUNNING);
+        AgentStatusTimeline timeline = new AgentStatusTimelineBuilder(timelineRange, initialStatus)
+                .from(Arrays.asList(
+                        createAgentEvent(agentA, 160, AgentEventType.AGENT_UNEXPECTED_SHUTDOWN),
+                        createAgentEvent(agentB, 160, AgentEventType.AGENT_CONNECTED),
+                        createAgentEvent(agentB, 180, AgentEventType.AGENT_PING)
+                )).build();
+        // Then
+        Assert.assertEquals(expectedTimelineSegments, timeline.getTimelineSegments());
+        Assert.assertTrue(timeline.isIncludeWarning());
+    }
+
+    @Test
+    public void multipleLifeCycles_overlap3() {
+        // Given
+        Range timelineRange = new Range(100, 200);
+        List<AgentStatusTimelineSegment> expectedTimelineSegments = Collections.singletonList(
+                createSegment(100, 200, AgentState.RUNNING));
+        // When
+        long agentA = 80;
+        long agentB = 90;
+        long agentC = 110;
+        AgentStatus initialStatus = createAgentStatus(90, AgentLifeCycleState.RUNNING);
+        AgentStatusTimeline timeline = new AgentStatusTimelineBuilder(timelineRange, initialStatus)
+                .from(Arrays.asList(
+                        createAgentEvent(agentA, 120, AgentEventType.AGENT_PING),
+                        createAgentEvent(agentB, 130, AgentEventType.AGENT_PING),
+                        createAgentEvent(agentC, 140, AgentEventType.AGENT_PING),
+                        createAgentEvent(agentA, 150, AgentEventType.AGENT_PING),
+                        createAgentEvent(agentB, 170, AgentEventType.AGENT_SHUTDOWN),
+                        createAgentEvent(agentA, 180, AgentEventType.AGENT_PING),
+                        createAgentEvent(agentC, 190, AgentEventType.AGENT_SHUTDOWN)
+                )).build();
+        // Then
+        Assert.assertEquals(expectedTimelineSegments, timeline.getTimelineSegments());
+        Assert.assertTrue(timeline.isIncludeWarning());
+    }
+
+    @Test
+    public void multipleLifeCycles_overlap4() {
+        // Given
+        Range timelineRange = new Range(100, 200);
+        List<AgentStatusTimelineSegment> expectedTimelineSegments = Collections.singletonList(
+                createSegment(100, 200, AgentState.RUNNING));
+        // When
+        long agentA = 90;
+        long agentB = 130;
+        long agentC = 160;
+        long agentD = 180;
+        AgentStatus initialStatus = createAgentStatus(90, AgentLifeCycleState.RUNNING);
+        AgentStatusTimeline timeline = new AgentStatusTimelineBuilder(timelineRange, initialStatus)
+                .from(Arrays.asList(
+                        createAgentEvent(agentA, 120, AgentEventType.AGENT_PING),
+                        createAgentEvent(agentB, 130, AgentEventType.AGENT_CONNECTED),
+                        createAgentEvent(agentA, 150, AgentEventType.AGENT_SHUTDOWN),
+                        createAgentEvent(agentC, 160, AgentEventType.AGENT_CONNECTED),
+                        createAgentEvent(agentB, 170, AgentEventType.AGENT_SHUTDOWN),
+                        createAgentEvent(agentD, 180, AgentEventType.AGENT_CONNECTED),
+                        createAgentEvent(agentC, 190, AgentEventType.AGENT_SHUTDOWN)
+                )).build();
+        // Then
+        Assert.assertEquals(expectedTimelineSegments, timeline.getTimelineSegments());
+        Assert.assertTrue(timeline.isIncludeWarning());
+    }
+
+    @Test
+    public void multipleLifeCycles_mixed() {
+        // Given
+        Range timelineRange = new Range(100, 300);
+        List<AgentStatusTimelineSegment> expectedTimelineSegments = Arrays.asList(
+                createSegment(100, 150, AgentState.RUNNING),
+                createSegment(150, 160, AgentState.UNKNOWN),
+                createSegment(160, 250, AgentState.RUNNING),
+                createSegment(250, 260, AgentState.SHUTDOWN),
+                createSegment(260, 290, AgentState.RUNNING),
+                createSegment(290, 300, AgentState.UNKNOWN));
+        // When
+        long agentA = 90;
+        long agentB = 160;
+        long agentC = 220;
+        long agentD = 260;
+        AgentStatus initialStatus = createAgentStatus(90, AgentLifeCycleState.RUNNING);
+        AgentStatusTimeline timeline = new AgentStatusTimelineBuilder(timelineRange, initialStatus)
+                .from(Arrays.asList(
+                        createAgentEvent(agentA, 120, AgentEventType.AGENT_PING),
+                        createAgentEvent(agentA, 150, AgentEventType.AGENT_UNEXPECTED_CLOSE_BY_SERVER),
+                        createAgentEvent(agentB, 160, AgentEventType.AGENT_CONNECTED),
+                        createAgentEvent(agentB, 200, AgentEventType.AGENT_PING),
+                        createAgentEvent(agentC, 220, AgentEventType.AGENT_CONNECTED),
+                        createAgentEvent(agentB, 220, AgentEventType.AGENT_CLOSED_BY_SERVER),
+                        createAgentEvent(agentC, 250, AgentEventType.AGENT_SHUTDOWN),
+                        createAgentEvent(agentD, 260, AgentEventType.AGENT_CONNECTED),
+                        createAgentEvent(agentD, 290, AgentEventType.AGENT_CLOSED_BY_SERVER)
+                )).build();
+        // Then
+        Assert.assertEquals(expectedTimelineSegments, timeline.getTimelineSegments());
+        Assert.assertTrue(timeline.isIncludeWarning());
+    }
+
+    private AgentStatus createAgentStatus(long timestamp, AgentLifeCycleState state) {
+        AgentStatus agentStatus = new AgentStatus("testAgent");
+        agentStatus.setEventTimestamp(timestamp);
+        agentStatus.setState(state);
+        return agentStatus;
+    }
+
+    private AgentEvent createAgentEvent(long agentStartTimestamp, long timestamp, AgentEventType agentEventType) {
+        return new AgentEvent(new AgentEventBo("testAgentId", agentStartTimestamp, timestamp, agentEventType));
+    }
+
+    private AgentStatusTimelineSegment createSegment(long startTimestamp, long endTimestamp, AgentState state) {
+        AgentStatusTimelineSegment segment = new AgentStatusTimelineSegment();
+        segment.setStartTimestamp(startTimestamp);
+        segment.setEndTimestamp(endTimestamp);
+        segment.setValue(state);
+        return segment;
+    }
+}


### PR DESCRIPTION
Inspector view's agent status timeline should render life cycle states correctly on the timeline even if there are multiple agents sharing the same agent id.
To do this, each life cycle is calculated separately using agent's lifecycle event data (such as connected, disconnected, ping, etc) and their respective agent's start timestamp.
These life cycles are then laid on top of a single dimension to form the complete timeline.

Also divides up the timeline into segments to group up agent events that happened in a single segment to
a) prevent rendering too many agent event markers that might crash browsers, and
b) provide an easier way to view events that happened too close to each other that clicking on them proved impossible.
