### PR TITLE
[#2496] Add datasource metric collection

### DIFF
--- a/web/src/main/java/com/navercorp/pinpoint/web/mapper/stat/sampling/sampler/DataSourceSampler.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/mapper/stat/sampling/sampler/DataSourceSampler.java
@@ -93,7 +93,7 @@ public class DataSourceSampler implements AgentStatSampler<DataSourceBo, Sampled
                     timestamp,
                     INTEGER_DOWN_SAMPLER.sampleMin(values),
                     INTEGER_DOWN_SAMPLER.sampleMax(values),
-                    INTEGER_DOWN_SAMPLER.sampleAvg(values),
+                    INTEGER_DOWN_SAMPLER.sampleAvg(values, 3),
                     INTEGER_DOWN_SAMPLER.sampleSum(values));
         }
     }


### PR DESCRIPTION
1. Limits the number of decimal point for active avg and max avg