### PR TITLE
Makes test-compile libthrift independent from one used by the agent

### DIFF
--- a/agent/pom.xml
+++ b/agent/pom.xml
@@ -195,6 +195,13 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.thrift</groupId>
+            <artifactId>libthrift</artifactId>
+            <version>0.9.3</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.activemq</groupId>
             <artifactId>activemq-all</artifactId>
             <version>5.13.2</version>

--- a/agent/src/test/resources/thrift/Echo.thrift
+++ b/agent/src/test/resources/thrift/Echo.thrift
@@ -1,0 +1,6 @@
+namespace java com.navercorp.pinpoint.plugin.thrift.dto
+
+service EchoService
+{
+    string echo(1:string message)
+}


### PR DESCRIPTION
Previously, thrift integration tests were compiled by whatever libthrift version inherited from the parent pom.
So when pinpoint's internal thrift version was upgraded to 0.10.0, Thrift IT would be compiled using 0.10.0, but would run on 0.9.x and any changes in API signatures would cause errors at runtime (implementations of `AsyncProcessFunction` for example).

This PR makes it so that thrift ITs are compiled using libthrift version independent of the one used when compiling the agent.

resolves #2522 