### PR TITLE
Tcpconfigchanges

### DIFF
--- a/agent/pom.xml
+++ b/agent/pom.xml
@@ -330,7 +330,6 @@
                     </descriptors>
                     <outputDirectory>${project.build.directory}</outputDirectory>
                     <appendAssemblyId>false</appendAssemblyId>
-			<tarLongFileMode>posix</tarLongFileMode>
                 </configuration>
                 <executions>
                     <execution>

--- a/agent/pom.xml
+++ b/agent/pom.xml
@@ -330,6 +330,7 @@
                     </descriptors>
                     <outputDirectory>${project.build.directory}</outputDirectory>
                     <appendAssemblyId>false</appendAssemblyId>
+			<tarLongFileMode>posix</tarLongFileMode>
                 </configuration>
                 <executions>
                     <execution>

--- a/agent/src/main/resources-local/pinpoint.config
+++ b/agent/src/main/resources-local/pinpoint.config
@@ -3,9 +3,12 @@
 #
 
 ###########################################################
-# Collector server                                        # 
+# Collector server                                        #
 ###########################################################
 profiler.collector.ip=127.0.0.1
+
+# Set all connections to TCP
+profiler.all.tcp.enable=false
 
 # placeHolder support "${key}"
 profiler.collector.span.ip=${profiler.collector.ip}
@@ -20,7 +23,7 @@ profiler.collector.tcp.ip=${profiler.collector.ip}
 profiler.collector.tcp.port=9994
 
 ###########################################################
-# Profiler Global Configuration                           # 
+# Profiler Global Configuration                           #
 ###########################################################
 profiler.enable=true
 
@@ -96,20 +99,20 @@ bytecode.dump.verify=false
 bytecode.dump.asm=false
 
 ###########################################################
-# application type                                        # 
+# application type                                        #
 ###########################################################
 #profiler.applicationservertype=TOMCAT
 #profiler.applicationservertype=BLOC
 
 ###########################################################
-# application type detect order                           # 
+# application type detect order                           #
 ###########################################################
 profiler.type.detect.order=
 
 profiler.plugin.disable=
 
 ###########################################################
-# user defined classes                                    # 
+# user defined classes                                    #
 ###########################################################
 # Specify classes and methods you want to profile here.
 
@@ -238,7 +241,7 @@ profiler.springboot.bootstrap.main=org.springframework.boot.loader.JarLauncher, 
 
 
 ###########################################################
-# JDBC                                                    # 
+# JDBC                                                    #
 ###########################################################
 # Profile JDBC drivers.
 profiler.jdbc=true
@@ -425,7 +428,7 @@ profiler.apache.httpclient4.io=true
 profiler.jdk.http.param=true
 
 ###########################################################
-# Ning Async HTTP Client                                  # 
+# Ning Async HTTP Client                                  #
 ###########################################################
 # Profile Ning Async HTTP Client.
 profiler.ning.asynchttpclient=true
@@ -456,7 +459,7 @@ profiler.ning.asynchttpclient.param.sampling.rate=1
 
 
 ###########################################################
-# Arcus                                                   # 
+# Arcus                                                   #
 ###########################################################
 # Profile Arcus.
 profiler.arcus=true
@@ -464,7 +467,7 @@ profiler.arcus=true
 profiler.arcus.keytrace=true
 
 ###########################################################
-# Memcached                                               # 
+# Memcached                                               #
 ###########################################################
 # Profile Memecached.
 profiler.memcached=true
@@ -472,7 +475,7 @@ profiler.memcached=true
 profiler.memcached.keytrace=true
 
 ###########################################################
-# Thrift                                                  # 
+# Thrift                                                  #
 ###########################################################
 # Profile Thrift
 profiler.thrift.client=true
@@ -487,19 +490,19 @@ profiler.thrift.service.result=true
 
 
 ###########################################################
-# ibatis                                                  # 
+# ibatis                                                  #
 ###########################################################
 # Profile ibatis.
 profiler.orm.ibatis=true
 
 ###########################################################
-# mybatis                                                 # 
+# mybatis                                                 #
 ###########################################################
 # Profile mybatis
 profiler.orm.mybatis=true
 
 ###########################################################
-# spring-beans 
+# spring-beans
 ###########################################################
 # Profile spring-beans
 profiler.spring.beans=true
@@ -560,13 +563,13 @@ profiler.log4j.logging.transactioninfo=false
 profiler.logback.logging.transactioninfo=false
 
 ###########################################################
-# google httpclient 
+# google httpclient
 ###########################################################
 # Profile async.
 profiler.google.httpclient.async=true
 
 ###########################################################
-# redis 
+# redis
 ###########################################################
 profiler.redis.pipeline
 profiler.redis=true

--- a/agent/src/main/resources-local/pinpoint.config
+++ b/agent/src/main/resources-local/pinpoint.config
@@ -7,8 +7,9 @@
 ###########################################################
 profiler.collector.ip=127.0.0.1
 
-# Set all connections to TCP
-profiler.all.tcp.enable=false
+# Set connection tyoes for span and stat data.accepts UDP or TCP
+profiler.collector.span.transport.type=UDP
+profiler.collector.stat.transport.type=UDP
 
 # placeHolder support "${key}"
 profiler.collector.span.ip=${profiler.collector.ip}

--- a/agent/src/main/resources-release/pinpoint.config
+++ b/agent/src/main/resources-release/pinpoint.config
@@ -7,6 +7,9 @@
 ###########################################################
 profiler.collector.ip=127.0.0.1
 
+# Set all connections to TCP
+profiler.all.tcp.enable=false
+
 # placeHolder support "${key}"
 profiler.collector.span.ip=${profiler.collector.ip}
 profiler.collector.span.port=9996

--- a/agent/src/main/resources-release/pinpoint.config
+++ b/agent/src/main/resources-release/pinpoint.config
@@ -7,8 +7,9 @@
 ###########################################################
 profiler.collector.ip=127.0.0.1
 
-# Set all connections to TCP
-profiler.all.tcp.enable=false
+# Set connection tyoes for span and stat data.accepts UDP or TCP
+profiler.collector.span.transport.type=UDP
+profiler.collector.stat.transport.type=UDP
 
 # placeHolder support "${key}"
 profiler.collector.span.ip=${profiler.collector.ip}

--- a/agent/src/main/resources/pinpoint-real-env-lowoverhead-sample.config
+++ b/agent/src/main/resources/pinpoint-real-env-lowoverhead-sample.config
@@ -3,9 +3,13 @@
 #
 
 ###########################################################
-# Collector server                                        # 
+# Collector server                                        #
 ###########################################################
 profiler.collector.ip=127.0.0.1
+
+# Set connection tyoes for span and stat data.accepts UDP or TCP
+profiler.collector.span.transport.type=UDP
+profiler.collector.stat.transport.type=UDP
 
 # placeHolder support "${key}"
 profiler.collector.span.ip=${profiler.collector.ip}
@@ -20,7 +24,7 @@ profiler.collector.tcp.ip=${profiler.collector.ip}
 profiler.collector.tcp.port=9994
 
 ###########################################################
-# Profiler Global Configuration                           # 
+# Profiler Global Configuration                           #
 ###########################################################
 profiler.enable=true
 
@@ -80,20 +84,20 @@ bytecode.dump.verify=false
 bytecode.dump.asm=false
 
 ###########################################################
-# application type                                        # 
+# application type                                        #
 ###########################################################
 #profiler.applicationservertype=TOMCAT
 #profiler.applicationservertype=BLOC
 
 ###########################################################
-# application type detect order                           # 
+# application type detect order                           #
 ###########################################################
 profiler.type.detect.order=
 
 profiler.plugin.disable=
 
 ###########################################################
-# user defined classes                                    # 
+# user defined classes                                    #
 ###########################################################
 # Specify classes and methods you want to profile here.
 
@@ -219,7 +223,7 @@ profiler.springboot.enable=true
 profiler.springboot.bootstrap.main=org.springframework.boot.loader.JarLauncher, org.springframework.boot.loader.WarLauncher, org.springframework.boot.loader.PropertiesLauncher
 
 ###########################################################
-# JDBC                                                    # 
+# JDBC                                                    #
 ###########################################################
 # Profile JDBC drivers.
 profiler.jdbc=true
@@ -378,7 +382,7 @@ profiler.apache.httpclient4.entity.sampling.rate=10
 #profiler.apache.nio.httpclient4=true
 
 ###########################################################
-# Ning Async HTTP Client                                  # 
+# Ning Async HTTP Client                                  #
 ###########################################################
 # Profile Ning Async HTTP Client.
 profiler.ning.asynchttpclient=true
@@ -408,7 +412,7 @@ profiler.ning.asynchttpclient.param.dumpsize=1024
 profiler.ning.asynchttpclient.param.sampling.rate=10
 
 ###########################################################
-# Arcus                                                   # 
+# Arcus                                                   #
 ###########################################################
 # Profile Arcus.
 profiler.arcus=true
@@ -416,7 +420,7 @@ profiler.arcus=true
 profiler.arcus.keytrace=false
 
 ###########################################################
-# Memcached                                               # 
+# Memcached                                               #
 ###########################################################
 # Profile Memecached.
 profiler.memcached=true
@@ -424,7 +428,7 @@ profiler.memcached=true
 profiler.memcached.keytrace=false
 
 ###########################################################
-# Thrift                                                  # 
+# Thrift                                                  #
 ###########################################################
 # Profile Thrift
 profiler.thrift.client=true
@@ -436,19 +440,19 @@ profiler.thrift.service.args=false
 profiler.thrift.service.result=false
 
 ###########################################################
-# ibatis                                                  # 
+# ibatis                                                  #
 ###########################################################
 # Profile ibatis.
 profiler.orm.ibatis=true
 
 ###########################################################
-# mybatis                                                 # 
+# mybatis                                                 #
 ###########################################################
 # Profile mybatis
 profiler.orm.mybatis=true
 
 ###########################################################
-# spring-beans 
+# spring-beans
 ###########################################################
 # Profile spring-beans
 profiler.spring.beans=true
@@ -509,7 +513,7 @@ profiler.log4j.logging.transactioninfo=false
 profiler.logback.logging.transactioninfo=false
 
 ###########################################################
-# google httpclient 
+# google httpclient
 ###########################################################
 # Profile google httpclient.
 profiler.google.httpclient.enable=true

--- a/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/config/DefaultProfilerConfig.java
+++ b/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/config/DefaultProfilerConfig.java
@@ -87,6 +87,8 @@ public class DefaultProfilerConfig implements ProfilerConfig {
         }
     }
 
+    private boolean allTcpEnable = false;
+
     private boolean profileEnable = false;
 
     private String profileInstrumentEngine = INSTRUMENT_ENGINE_ASM;
@@ -166,6 +168,10 @@ public class DefaultProfilerConfig implements ProfilerConfig {
         readPropertyValues();
     }
 
+    @Override
+    public boolean isAllTcpEnable() { 
+    	return allTcpEnable; }
+    
     @Override
     public int getInterceptorRegistrySize() {
         return interceptorRegistrySize;
@@ -402,7 +408,7 @@ public class DefaultProfilerConfig implements ProfilerConfig {
     void readPropertyValues() {
         // TODO : use Properties' default value instead of using a temp variable.
         final ValueResolver placeHolderResolver = new PlaceHolderResolver();
-
+        this.allTcpEnable = readBoolean("profiler.all.tcp.enable", true);
         this.profileEnable = readBoolean("profiler.enable", true);
         this.profileInstrumentEngine = readString("profiler.instrument.engine", INSTRUMENT_ENGINE_ASM);
 
@@ -594,6 +600,8 @@ public class DefaultProfilerConfig implements ProfilerConfig {
         StringBuilder builder = new StringBuilder(1024);
         builder.append("DefaultProfilerConfig{properties=");
         builder.append(properties);
+        builder.append(", allTcpEnable=");
+        builder.append(allTcpEnable);
         builder.append(", interceptorRegistrySize=");
         builder.append(interceptorRegistrySize);
         builder.append(", propertyPlaceholderHelper=");

--- a/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/config/DefaultProfilerConfig.java
+++ b/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/config/DefaultProfilerConfig.java
@@ -46,6 +46,10 @@ public class DefaultProfilerConfig implements ProfilerConfig {
     @Deprecated
     public static final String INSTRUMENT_ENGINE_JAVASSIST = "JAVASSIST";
     public static final String INSTRUMENT_ENGINE_ASM = "ASM";
+    public static final String TCP_TRANSPORT = "TCP";
+    
+    private static final String DEFAULT_TRANSPORT = "UDP";
+    
 
     public interface ValueResolver {
         String resolve(String value, Properties properties);
@@ -87,7 +91,9 @@ public class DefaultProfilerConfig implements ProfilerConfig {
         }
     }
 
-    private boolean allTcpEnable = false;
+    private String spanTransportType = DEFAULT_TRANSPORT;
+    
+    private String statTransportType = DEFAULT_TRANSPORT;
 
     private boolean profileEnable = false;
 
@@ -168,10 +174,6 @@ public class DefaultProfilerConfig implements ProfilerConfig {
         readPropertyValues();
     }
 
-    @Override
-    public boolean isAllTcpEnable() { 
-    	return allTcpEnable; }
-    
     @Override
     public int getInterceptorRegistrySize() {
         return interceptorRegistrySize;
@@ -408,7 +410,8 @@ public class DefaultProfilerConfig implements ProfilerConfig {
     void readPropertyValues() {
         // TODO : use Properties' default value instead of using a temp variable.
         final ValueResolver placeHolderResolver = new PlaceHolderResolver();
-        this.allTcpEnable = readBoolean("profiler.all.tcp.enable", true);
+        this.spanTransportType = readString("profiler.collector.span.transport.type", DEFAULT_TRANSPORT);
+        this.statTransportType = readString("profiler.collector.stat.transport.type", DEFAULT_TRANSPORT);
         this.profileEnable = readBoolean("profiler.enable", true);
         this.profileInstrumentEngine = readString("profiler.instrument.engine", INSTRUMENT_ENGINE_ASM);
 
@@ -600,8 +603,10 @@ public class DefaultProfilerConfig implements ProfilerConfig {
         StringBuilder builder = new StringBuilder(1024);
         builder.append("DefaultProfilerConfig{properties=");
         builder.append(properties);
-        builder.append(", allTcpEnable=");
-        builder.append(allTcpEnable);
+        builder.append(", statTransportType=");
+        builder.append(statTransportType);
+        builder.append(", spanTransportType=");
+        builder.append(spanTransportType);
         builder.append(", interceptorRegistrySize=");
         builder.append(interceptorRegistrySize);
         builder.append(", propertyPlaceholderHelper=");
@@ -689,5 +694,17 @@ public class DefaultProfilerConfig implements ProfilerConfig {
         builder.append("}");
         return builder.toString();
     }
+
+	@Override
+	public String getSpanTransportType() {
+		
+		return spanTransportType;
+	}
+
+	@Override
+	public String getStatTransportType() {
+		
+		return statTransportType;
+	}
 
 }

--- a/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/config/ProfilerConfig.java
+++ b/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/config/ProfilerConfig.java
@@ -127,4 +127,6 @@ public interface ProfilerConfig {
 
     Map<String, String> readPattern(String propertyNamePatternRegex);
 
+	boolean isAllTcpEnable();
+
 }

--- a/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/config/ProfilerConfig.java
+++ b/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/config/ProfilerConfig.java
@@ -127,6 +127,8 @@ public interface ProfilerConfig {
 
     Map<String, String> readPattern(String propertyNamePatternRegex);
 
-	boolean isAllTcpEnable();
+	String getSpanTransportType();
+	
+	String getStatTransportType();
 
 }

--- a/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/config/TransportType.java
+++ b/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/config/TransportType.java
@@ -1,0 +1,15 @@
+package com.navercorp.pinpoint.bootstrap.config;
+
+public enum TransportType {
+	UDP("UDP"), TCP("TCP");
+
+	private String type;
+
+	TransportType(String type) {
+		this.type = type;
+	}
+
+	public String type() {
+		return type;
+	}
+}

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/receiver/TcpDispatchHandler.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/receiver/TcpDispatchHandler.java
@@ -84,16 +84,6 @@ public class TcpDispatchHandler extends AbstractDispatchHandler {
     }
     
     @Override
-    Handler getHandler(TBase<?, ?> tBase) {
-    // To change below code to switch table make it a little bit faster.
-    // FIXME (2014.08) Legacy - TAgentStats should not be sent over the wire.
-		if (tBase instanceof TAgentStat || tBase instanceof TAgentStatBatch) {
-			return agentStatHandler;
-		}
-		return null;
-	}
-    
-    @Override
     SimpleHandler getSimpleHandler(TBase<?, ?> tBase) {
 
 		if (tBase instanceof TAgentInfo) {

--- a/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/module/ApplicationContextModule.java
+++ b/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/module/ApplicationContextModule.java
@@ -22,6 +22,7 @@ import com.google.inject.TypeLiteral;
 import com.google.inject.name.Names;
 import com.navercorp.pinpoint.bootstrap.AgentOption;
 import com.navercorp.pinpoint.bootstrap.config.ProfilerConfig;
+import com.navercorp.pinpoint.bootstrap.config.TransportType;
 import com.navercorp.pinpoint.bootstrap.context.ServerMetaDataHolder;
 import com.navercorp.pinpoint.bootstrap.context.TraceContext;
 import com.navercorp.pinpoint.bootstrap.instrument.DynamicTransformTrigger;
@@ -234,14 +235,17 @@ public class ApplicationContextModule extends AbstractModule {
         bind(PinpointClient.class).toProvider(PinpointClientProvider.class).in(Scopes.SINGLETON);
 
 		bind(CommandDispatcher.class).toProvider(CommandDispatcherProvider.class).in(Scopes.SINGLETON);
-		if (this.profilerConfig.isAllTcpEnable()) {
+		if (this.profilerConfig.getSpanTransportType().equals(TransportType.TCP.type())) {
 			bind(DataSender.class).annotatedWith(SpanDataSender.class).toProvider(TcpDataSenderProvider.class)
-					.in(Scopes.SINGLETON);
-			bind(DataSender.class).annotatedWith(StatDataSender.class).toProvider(TcpDataSenderProvider.class)
 					.in(Scopes.SINGLETON);
 		} else {
 			bind(DataSender.class).annotatedWith(SpanDataSender.class).toProvider(UdpSpanDataSenderProvider.class)
 					.in(Scopes.SINGLETON);
+		}
+		if (this.profilerConfig.getStatTransportType().equals(TransportType.TCP.type())) {
+			bind(DataSender.class).annotatedWith(StatDataSender.class).toProvider(TcpDataSenderProvider.class)
+					.in(Scopes.SINGLETON);
+		} else {
 			bind(DataSender.class).annotatedWith(StatDataSender.class).toProvider(UdpStatDataSenderProvider.class)
 					.in(Scopes.SINGLETON);
 		}

--- a/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/module/ApplicationContextModule.java
+++ b/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/module/ApplicationContextModule.java
@@ -233,12 +233,19 @@ public class ApplicationContextModule extends AbstractModule {
         bind(EnhancedDataSender.class).toProvider(TcpDataSenderProvider.class).in(Scopes.SINGLETON);
         bind(PinpointClient.class).toProvider(PinpointClientProvider.class).in(Scopes.SINGLETON);
 
-        bind(CommandDispatcher.class).toProvider(CommandDispatcherProvider.class).in(Scopes.SINGLETON);
-
-        bind(DataSender.class).annotatedWith(SpanDataSender.class)
-                .toProvider(UdpSpanDataSenderProvider.class).in(Scopes.SINGLETON);
-        bind(DataSender.class).annotatedWith(StatDataSender.class)
-                .toProvider(UdpStatDataSenderProvider.class).in(Scopes.SINGLETON);
+		bind(CommandDispatcher.class).toProvider(CommandDispatcherProvider.class).in(Scopes.SINGLETON);
+		if (this.profilerConfig.isAllTcpEnable()) {
+			bind(DataSender.class).annotatedWith(SpanDataSender.class).toProvider(TcpDataSenderProvider.class)
+					.in(Scopes.SINGLETON);
+			bind(DataSender.class).annotatedWith(StatDataSender.class).toProvider(TcpDataSenderProvider.class)
+					.in(Scopes.SINGLETON);
+		} else {
+			bind(DataSender.class).annotatedWith(SpanDataSender.class).toProvider(UdpSpanDataSenderProvider.class)
+					.in(Scopes.SINGLETON);
+			bind(DataSender.class).annotatedWith(StatDataSender.class).toProvider(UdpStatDataSenderProvider.class)
+					.in(Scopes.SINGLETON);
+		}
+        
     }
 
     private void bindServiceComponent() {


### PR DESCRIPTION
resolve #2666
use the options in pinpoint.config to set transport type of span and stat 
default is UDP
# Set connection types for span and stat data. accepts UDP or TCP
profiler.collector.span.transport.type=UDP
profiler.collector.stat.transport.type=UDP
