### PR TITLE
tomcat profiler fail response codes

### DIFF
--- a/agent/src/main/resources-local/pinpoint.config
+++ b/agent/src/main/resources-local/pinpoint.config
@@ -140,6 +140,12 @@ profiler.tomcat.excludeurl=/aa/test.html, /bb/exclude.html
 #profiler.tomcat.excludemethod=
 profiler.tomcat.tracerequestparam=true
 
+#enables http failure codes
+profiler.tomcat.enablefailurecodes=false
+#sets success ports for tomcat http codes
+#any other codes not mentioned below will show as fail transactions
+profiler.tomcat.successcodes=200,201,202,203,204,205,206,207,208,226
+
 # original IP address header
 # https://en.wikipedia.org/wiki/X-Forwarded-For
 #profiler.tomcat.realipheader=X-Forwarded-For

--- a/agent/src/main/resources/pinpoint-real-env-lowoverhead-sample.config
+++ b/agent/src/main/resources/pinpoint-real-env-lowoverhead-sample.config
@@ -3,7 +3,7 @@
 #
 
 ###########################################################
-# Collector server                                        # 
+# Collector server                                        #
 ###########################################################
 profiler.collector.ip=127.0.0.1
 
@@ -20,7 +20,7 @@ profiler.collector.tcp.ip=${profiler.collector.ip}
 profiler.collector.tcp.port=9994
 
 ###########################################################
-# Profiler Global Configuration                           # 
+# Profiler Global Configuration                           #
 ###########################################################
 profiler.enable=true
 
@@ -80,20 +80,20 @@ bytecode.dump.verify=false
 bytecode.dump.asm=false
 
 ###########################################################
-# application type                                        # 
+# application type                                        #
 ###########################################################
 #profiler.applicationservertype=TOMCAT
 #profiler.applicationservertype=BLOC
 
 ###########################################################
-# application type detect order                           # 
+# application type detect order                           #
 ###########################################################
 profiler.type.detect.order=
 
 profiler.plugin.disable=
 
 ###########################################################
-# user defined classes                                    # 
+# user defined classes                                    #
 ###########################################################
 # Specify classes and methods you want to profile here.
 
@@ -121,6 +121,12 @@ profiler.tomcat.hidepinpointheader=true
 # URLs to exclude from tracing
 profiler.tomcat.excludeurl=/aa/test.html, /bb/exclude.html
 profiler.tomcat.tracerequestparam=true
+
+#enables http failure codes
+profiler.tomcat.enablefailurecodes=false
+#sets success ports for tomcat http codes
+#any other codes not mentioned below will show as fail transactions
+profiler.tomcat.successcodes=200,201,202,203,204,205,206,207,208,226
 
 # original IP address header
 # https://en.wikipedia.org/wiki/X-Forwarded-For
@@ -219,7 +225,7 @@ profiler.springboot.enable=true
 profiler.springboot.bootstrap.main=org.springframework.boot.loader.JarLauncher, org.springframework.boot.loader.WarLauncher, org.springframework.boot.loader.PropertiesLauncher
 
 ###########################################################
-# JDBC                                                    # 
+# JDBC                                                    #
 ###########################################################
 # Profile JDBC drivers.
 profiler.jdbc=true
@@ -378,7 +384,7 @@ profiler.apache.httpclient4.entity.sampling.rate=10
 #profiler.apache.nio.httpclient4=true
 
 ###########################################################
-# Ning Async HTTP Client                                  # 
+# Ning Async HTTP Client                                  #
 ###########################################################
 # Profile Ning Async HTTP Client.
 profiler.ning.asynchttpclient=true
@@ -408,7 +414,7 @@ profiler.ning.asynchttpclient.param.dumpsize=1024
 profiler.ning.asynchttpclient.param.sampling.rate=10
 
 ###########################################################
-# Arcus                                                   # 
+# Arcus                                                   #
 ###########################################################
 # Profile Arcus.
 profiler.arcus=true
@@ -416,7 +422,7 @@ profiler.arcus=true
 profiler.arcus.keytrace=false
 
 ###########################################################
-# Memcached                                               # 
+# Memcached                                               #
 ###########################################################
 # Profile Memecached.
 profiler.memcached=true
@@ -424,7 +430,7 @@ profiler.memcached=true
 profiler.memcached.keytrace=false
 
 ###########################################################
-# Thrift                                                  # 
+# Thrift                                                  #
 ###########################################################
 # Profile Thrift
 profiler.thrift.client=true
@@ -436,19 +442,19 @@ profiler.thrift.service.args=false
 profiler.thrift.service.result=false
 
 ###########################################################
-# ibatis                                                  # 
+# ibatis                                                  #
 ###########################################################
 # Profile ibatis.
 profiler.orm.ibatis=true
 
 ###########################################################
-# mybatis                                                 # 
+# mybatis                                                 #
 ###########################################################
 # Profile mybatis
 profiler.orm.mybatis=true
 
 ###########################################################
-# spring-beans 
+# spring-beans
 ###########################################################
 # Profile spring-beans
 profiler.spring.beans=true
@@ -509,7 +515,7 @@ profiler.log4j.logging.transactioninfo=false
 profiler.logback.logging.transactioninfo=false
 
 ###########################################################
-# google httpclient 
+# google httpclient
 ###########################################################
 # Profile google httpclient.
 profiler.google.httpclient.enable=true

--- a/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/context/SpanEventRecorder.java
+++ b/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/context/SpanEventRecorder.java
@@ -50,4 +50,6 @@ public interface SpanEventRecorder extends FrameAttachment {
     void recordNextAsyncId(int asyncId);
     
     void recordAsyncSequence(short sequence);
+    
+    void recordError(boolean markError, String errorMessage);
 }

--- a/plugins/tomcat/src/main/java/com/navercorp/pinpoint/plugin/tomcat/TomcatConfig.java
+++ b/plugins/tomcat/src/main/java/com/navercorp/pinpoint/plugin/tomcat/TomcatConfig.java
@@ -34,6 +34,8 @@ public class TomcatConfig {
     private final List<String> tomcatBootstrapMains;
     private final boolean tomcatConditionalTransformEnable;
     private final boolean tomcatHidePinpointHeader;
+    private final String successCodes;
+    private final boolean enablefailurecodes;
 
     private final boolean tomcatTraceRequestParam;
     private final Filter<String> tomcatExcludeUrlFilter;
@@ -54,7 +56,8 @@ public class TomcatConfig {
         this.tomcatBootstrapMains = config.readList("profiler.tomcat.bootstrap.main");
         this.tomcatConditionalTransformEnable = config.readBoolean("profiler.tomcat.conditional.transform", true);
         this.tomcatHidePinpointHeader = config.readBoolean("profiler.tomcat.hidepinpointheader", true);
-
+        this.successCodes = config.readString("profiler.tomcat.successcodes", "200,201,202,203,204,205,206,207,208,226");
+        this.enablefailurecodes =  config.readBoolean("profiler.tomcat.enablefailurecodes", true);
         // runtime
         this.tomcatTraceRequestParam = config.readBoolean("profiler.tomcat.tracerequestparam", true);
         final String tomcatExcludeURL = config.readString("profiler.tomcat.excludeurl", "");
@@ -92,6 +95,14 @@ public class TomcatConfig {
         return tomcatHidePinpointHeader;
     }
 
+	public boolean isTomcatEnablefailureCodes() {
+		return enablefailurecodes;
+	}
+
+	public String getSuccessCodes() {
+		return successCodes;
+	}
+    	
     public boolean isTomcatTraceRequestParam() {
         return tomcatTraceRequestParam;
     }

--- a/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/SpanEvent.java
+++ b/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/SpanEvent.java
@@ -61,7 +61,7 @@ public class SpanEvent extends TSpanEvent implements FrameAttachment {
         }
     }
 
-    void setExceptionInfo(int exceptionClassId, String exceptionMessage) {
+    public void setExceptionInfo(int exceptionClassId, String exceptionMessage) {
         final TIntStringValue exceptionInfo = new TIntStringValue(exceptionClassId);
         if (StringUtils.isNotEmpty(exceptionMessage)) {
             exceptionInfo.setStringValue(exceptionMessage);

--- a/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/recorder/WrappedSpanEventRecorder.java
+++ b/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/recorder/WrappedSpanEventRecorder.java
@@ -194,7 +194,7 @@ public class WrappedSpanEventRecorder extends AbstractRecorder implements SpanEv
 	@Override
 	public void recordError(boolean markError, String errorMessage) {
 		if (markError) {
-			spanEvent.setExceptionInfo(404, errorMessage);
+			spanEvent.setExceptionInfo(5001, errorMessage);
 			final Span span = spanEvent.getSpan();
 			if (!span.isSetErrCode()) {
 				span.setErrCode(1);

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/SpanServiceImpl.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/SpanServiceImpl.java
@@ -355,6 +355,11 @@ public class SpanServiceImpl implements SpanService {
 
     private StringMetaDataBo selectStringMetaData(String agentId, int cacheId, long agentStartTime) {
         final List<StringMetaDataBo> metaDataList = stringMetaDataDao.getStringMetaData(agentId, agentStartTime, cacheId);
+		if (cacheId == 404) {
+			StringMetaDataBo stringMetaDataBo = new StringMetaDataBo(agentId, agentStartTime, cacheId);
+			stringMetaDataBo.setStringValue("HTTP Failed response code");
+			return stringMetaDataBo;
+		}
         if (CollectionUtils.isEmpty(metaDataList)) {
             logger.warn("StringMetaData not Found agent:{}, cacheId{}, agentStartTime:{}", agentId, cacheId, agentStartTime);
             StringMetaDataBo stringMetaDataBo = new StringMetaDataBo(agentId, agentStartTime, cacheId);

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/SpanServiceImpl.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/SpanServiceImpl.java
@@ -355,7 +355,7 @@ public class SpanServiceImpl implements SpanService {
 
     private StringMetaDataBo selectStringMetaData(String agentId, int cacheId, long agentStartTime) {
         final List<StringMetaDataBo> metaDataList = stringMetaDataDao.getStringMetaData(agentId, agentStartTime, cacheId);
-		if (cacheId == 404) {
+		if (cacheId == 5001) {
 			StringMetaDataBo stringMetaDataBo = new StringMetaDataBo(agentId, agentStartTime, cacheId);
 			stringMetaDataBo.setStringValue("HTTP Failed response code");
 			return stringMetaDataBo;


### PR DESCRIPTION
resolves issue #2654 
this adds capability to tomcat plugin to read the HTTP response codes like 4xx/5xx and distinguish between pass/fail requests, also makes scatter chart to display in red for all the failed requests
and call stack shows the response code in red.
this option can be enabled or disabled and also success codes can be specified in pinpoint.config
