### PR TITLE
Limits MariaDB integration test to exclude 1.6.x and 2.x

### DIFF
--- a/agent/src/test/java/com/navercorp/pinpoint/plugin/jdbc/mariadb/MariaDB_1_4_x_to_1_6_0_IT.java
+++ b/agent/src/test/java/com/navercorp/pinpoint/plugin/jdbc/mariadb/MariaDB_1_4_x_to_1_6_0_IT.java
@@ -35,8 +35,8 @@ import static com.navercorp.pinpoint.bootstrap.plugin.test.Expectations.*;
 
 @RunWith(PinpointPluginTestSuite.class)
 @JvmVersion(7)
-@Dependency({ "org.mariadb.jdbc:mariadb-java-client:[1.4.min,2.0.min)", "ch.vorburger.mariaDB4j:mariaDB4j:2.2.2" })
-public class MariaDB_1_4_x_to_2_0_0_IT extends MariaDB_IT_Base {
+@Dependency({ "org.mariadb.jdbc:mariadb-java-client:[1.4.min,1.6.min)", "ch.vorburger.mariaDB4j:mariaDB4j:2.2.2" })
+public class MariaDB_1_4_x_to_1_6_0_IT extends MariaDB_IT_Base {
 
     // see CallableParameterMetaData#queryMetaInfos
     private  static final String CALLABLE_QUERY_META_INFOS_QUERY = "select param_list, returns, db, type from mysql.proc where db=DATABASE() and name=?";


### PR DESCRIPTION
Integration tests for 1.6.x and 2.x should be added once they are supported by mariadb plugin.