### PR TITLE
Adds a parameter to filter out terminal and unknown nodes when querying server map

### DIFF
--- a/web/src/main/java/com/navercorp/pinpoint/web/controller/MapController.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/controller/MapController.java
@@ -80,11 +80,12 @@ public class MapController {
                                     @RequestParam(value = "callerRange", defaultValue = DEFAULT_SEARCH_DEPTH) int callerRange,
                                     @RequestParam(value = "calleeRange", defaultValue = DEFAULT_SEARCH_DEPTH) int calleeRange,
                                     @RequestParam(value = "bidirectional", defaultValue = "true", required = false) boolean bidirectional,
+                                    @RequestParam(value = "wasOnly", defaultValue="false", required = false) boolean wasOnly,
                                     @RequestParam(value = "includeHistograms", defaultValue = "true", required = false) boolean includeHistograms) {
         final Range range = new Range(from, to);
         this.dateLimit.limit(range);
 
-        SearchOption searchOption = new SearchOption(callerRange, calleeRange, bidirectional);
+        SearchOption searchOption = new SearchOption(callerRange, calleeRange, bidirectional, wasOnly);
         assertSearchOption(searchOption);
 
         Application application = applicationFactory.createApplication(applicationName, serviceTypeCode);
@@ -113,11 +114,12 @@ public class MapController {
                                     @RequestParam(value = "callerRange", defaultValue = DEFAULT_SEARCH_DEPTH) int callerRange,
                                     @RequestParam(value = "calleeRange", defaultValue = DEFAULT_SEARCH_DEPTH) int calleeRange,
                                     @RequestParam(value = "bidirectional", defaultValue = "true", required = false) boolean bidirectional,
+                                    @RequestParam(value = "wasOnly", defaultValue="false", required = false) boolean wasOnly,
                                     @RequestParam(value = "includeHistograms", defaultValue = "true", required = false) boolean includeHistograms) {
         final Range range = new Range(from, to);
         this.dateLimit.limit(range);
 
-        SearchOption searchOption = new SearchOption(callerRange, calleeRange, bidirectional);
+        SearchOption searchOption = new SearchOption(callerRange, calleeRange, bidirectional, wasOnly);
         assertSearchOption(searchOption);
 
         Application application = applicationFactory.createApplicationByTypeName(applicationName, serviceTypeName);
@@ -177,6 +179,7 @@ public class MapController {
                                         @RequestParam(value = "callerRange", defaultValue = DEFAULT_SEARCH_DEPTH) int callerRange,
                                         @RequestParam(value = "calleeRange", defaultValue = DEFAULT_SEARCH_DEPTH) int calleeRange,
                                         @RequestParam(value = "bidirectional", defaultValue = "true", required = false) boolean bidirectional,
+                                        @RequestParam(value = "wasOnly", defaultValue="false", required = false) boolean wasOnly,
                                         @RequestParam(value = "includeHistograms", defaultValue = "true", required = false) boolean includeHistograms) {
 
         long to = TimeUtils.getDelayLastTime();
@@ -185,7 +188,7 @@ public class MapController {
         final Range range = new Range(from, to);
         this.dateLimit.limit(range);
 
-        SearchOption searchOption = new SearchOption(callerRange, calleeRange, bidirectional);
+        SearchOption searchOption = new SearchOption(callerRange, calleeRange, bidirectional, wasOnly);
         assertSearchOption(searchOption);
 
         Application application = applicationFactory.createApplication(applicationName, serviceTypeCode);
@@ -210,6 +213,7 @@ public class MapController {
                                         @RequestParam(value = "callerRange", defaultValue = DEFAULT_SEARCH_DEPTH) int callerRange,
                                         @RequestParam(value = "calleeRange", defaultValue = DEFAULT_SEARCH_DEPTH) int calleeRange,
                                         @RequestParam(value = "bidirectional", defaultValue = "true", required = false) boolean bidirectional,
+                                        @RequestParam(value = "wasOnly", defaultValue="false", required = false) boolean wasOnly,
                                         @RequestParam(value = "includeHistograms", defaultValue = "true", required = false) boolean includeHistograms) {
 
         long to = TimeUtils.getDelayLastTime();
@@ -218,7 +222,7 @@ public class MapController {
         final Range range = new Range(from, to);
         this.dateLimit.limit(range);
 
-        SearchOption searchOption = new SearchOption(callerRange, calleeRange, bidirectional);
+        SearchOption searchOption = new SearchOption(callerRange, calleeRange, bidirectional, wasOnly);
         assertSearchOption(searchOption);
 
         Application application = applicationFactory.createApplicationByTypeName(applicationName, serviceTypeName);

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/MapServiceImpl.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/MapServiceImpl.java
@@ -91,7 +91,7 @@ public class MapServiceImpl implements MapService {
         StopWatch watch = new StopWatch("ApplicationMap");
         watch.start("ApplicationMap Hbase Io Fetch(Caller,Callee) Time");
 
-        LinkSelector linkSelector = linkSelectorFactory.create(searchOption.getLinkSelectorType());
+        LinkSelector linkSelector = linkSelectorFactory.create(searchOption);
         LinkDataDuplexMap linkDataDuplexMap = linkSelector.select(sourceApplication, range, searchOption);
         watch.stop();
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/map/LinkDataMapProcessor.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/map/LinkDataMapProcessor.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.web.service.map;
+
+import com.navercorp.pinpoint.web.applicationmap.rawdata.LinkDataMap;
+import com.navercorp.pinpoint.web.vo.Range;
+
+/**
+ * @author HyunGil Jeong
+ */
+public interface LinkDataMapProcessor {
+
+    LinkDataMap processLinkDataMap(LinkDataMap linkDataMap, Range range);
+
+    LinkDataMapProcessor NO_OP = new LinkDataMapProcessor() {
+        @Override
+        public LinkDataMap processLinkDataMap(LinkDataMap linkDataMap, Range range) {
+            return linkDataMap;
+        }
+    };
+}

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/map/LinkDataMapProcessors.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/map/LinkDataMapProcessors.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.web.service.map;
+
+import com.navercorp.pinpoint.web.applicationmap.rawdata.LinkDataMap;
+import com.navercorp.pinpoint.web.vo.Range;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author HyunGil Jeong
+ */
+public class LinkDataMapProcessors implements LinkDataMapProcessor {
+
+    List<LinkDataMapProcessor> linkDataMapProcessors = new ArrayList<>();
+
+    void addLinkDataMapProcessor(LinkDataMapProcessor linkDataMapProcessor) {
+        if (linkDataMapProcessor == null) {
+            return;
+        }
+        linkDataMapProcessors.add(linkDataMapProcessor);
+    }
+
+    @Override
+    public LinkDataMap processLinkDataMap(LinkDataMap linkDataMap, Range range) {
+        LinkDataMap processedLinkDataMap = linkDataMap;
+        for (LinkDataMapProcessor linkDataMapProcessor : linkDataMapProcessors) {
+            processedLinkDataMap = linkDataMapProcessor.processLinkDataMap(processedLinkDataMap, range);
+        }
+        return processedLinkDataMap;
+    }
+}

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/map/LinkSelectorFactory.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/map/LinkSelectorFactory.java
@@ -18,6 +18,7 @@ package com.navercorp.pinpoint.web.service.map;
 
 import com.navercorp.pinpoint.web.security.ServerMapDataFilter;
 import com.navercorp.pinpoint.web.service.LinkDataMapService;
+import com.navercorp.pinpoint.web.vo.SearchOption;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -50,10 +51,12 @@ public class LinkSelectorFactory {
         this.serverMapDataFilter = serverMapDataFilter;
     }
 
-    public LinkSelector create(LinkSelectorType linkSelectorType) {
+    public LinkSelector create(SearchOption searchOption) {
+        LinkSelectorType linkSelectorType = searchOption.getLinkSelectorType();
+
         VirtualLinkMarker virtualLinkMarker = new VirtualLinkMarker();
         VirtualLinkProcessor virtualLinkProcessor = new VirtualLinkProcessor(linkDataMapService, virtualLinkMarker);
-        ApplicationsMapCreator applicationsMapCreator = applicationsMapCreatorFactory.create(virtualLinkMarker);
+        ApplicationsMapCreator applicationsMapCreator = applicationsMapCreatorFactory.create(searchOption, virtualLinkMarker);
         if (linkSelectorType == LinkSelectorType.UNIDIRECTIONAL) {
             return new UnidirectionalLinkSelector(applicationsMapCreator, virtualLinkProcessor, serverMapDataFilter);
         } else {

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/map/WasOnlyProcessor.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/map/WasOnlyProcessor.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.web.service.map;
+
+import com.navercorp.pinpoint.web.applicationmap.rawdata.LinkData;
+import com.navercorp.pinpoint.web.applicationmap.rawdata.LinkDataMap;
+import com.navercorp.pinpoint.web.vo.Application;
+import com.navercorp.pinpoint.web.vo.Range;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Filters out link data pointing to terminal and unknown nodes.
+ *
+ * @author HyunGil Jeong
+ */
+public class WasOnlyProcessor implements LinkDataMapProcessor {
+
+    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+
+    @Override
+    public LinkDataMap processLinkDataMap(LinkDataMap linkDataMap, Range range) {
+        final LinkDataMap filteredLinkDataMap = new LinkDataMap();
+        for (LinkData linkData : linkDataMap.getLinkDataList()) {
+            if (accept(linkData)) {
+                filteredLinkDataMap.addLinkData(linkData);
+            }
+        }
+        return filteredLinkDataMap;
+    }
+
+    private boolean accept(LinkData linkData) {
+        final Application toApplication = linkData.getToApplication();
+        boolean isDestinationTerminal = toApplication.getServiceType().isTerminal();
+        boolean isDestinationUnknown = toApplication.getServiceType().isUnknown();
+        if (isDestinationTerminal || isDestinationUnknown) {
+            logger.debug("Filtering linkData : {}", linkData);
+            return false;
+        }
+        return true;
+    }
+}

--- a/web/src/main/java/com/navercorp/pinpoint/web/vo/SearchOption.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/vo/SearchOption.java
@@ -26,21 +26,23 @@ public class SearchOption {
     private final int callerSearchDepth;
     private final int calleeSearchDepth;
     private final LinkSelectorType linkSelectorType;
+    private final boolean wasOnly;
 
     public SearchOption(int callerSearchDepth, int calleeSearchDepth) {
-        this(callerSearchDepth, calleeSearchDepth, false);
+        this(callerSearchDepth, calleeSearchDepth, false, false);
     }
 
-    public SearchOption(int callerSearchDepth, int calleeSearchDepth, boolean bidirectional) {
+    public SearchOption(int callerSearchDepth, int calleeSearchDepth, boolean bidirectional, boolean wasOnly) {
+        this(callerSearchDepth, calleeSearchDepth, bidirectional ? LinkSelectorType.BIDIRECTIONAL : LinkSelectorType.UNIDIRECTIONAL, wasOnly);
+    }
+
+    public SearchOption(int callerSearchDepth, int calleeSearchDepth, LinkSelectorType linkSelectorType, boolean wasOnly) {
         Assert.isTrue(callerSearchDepth >= 0, "negative callerSearchDepth");
         Assert.isTrue(calleeSearchDepth >= 0, "negative calleeSearchDepth");
         this.callerSearchDepth = callerSearchDepth;
         this.calleeSearchDepth = calleeSearchDepth;
-        if (bidirectional) {
-            this.linkSelectorType = LinkSelectorType.BIDIRECTIONAL;
-        } else {
-            this.linkSelectorType = LinkSelectorType.UNIDIRECTIONAL;
-        }
+        this.linkSelectorType = linkSelectorType;
+        this.wasOnly = wasOnly;
     }
 
     public int getCallerSearchDepth() {
@@ -55,12 +57,17 @@ public class SearchOption {
         return linkSelectorType;
     }
 
+    public boolean isWasOnly() {
+        return wasOnly;
+    }
+
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder("SearchOption{");
         sb.append("callerSearchDepth=").append(callerSearchDepth);
         sb.append(", calleeSearchDepth=").append(calleeSearchDepth);
         sb.append(", linkSelectorType=").append(linkSelectorType);
+        sb.append(", wasOnly=").append(wasOnly);
         sb.append('}');
         return sb.toString();
     }

--- a/web/src/test/java/com/navercorp/pinpoint/web/service/map/BidirectionalLinkSelectorTestBase.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/service/map/BidirectionalLinkSelectorTestBase.java
@@ -23,6 +23,7 @@ import com.navercorp.pinpoint.web.applicationmap.rawdata.LinkDataMap;
 import com.navercorp.pinpoint.web.vo.Application;
 import com.navercorp.pinpoint.web.vo.LinkKey;
 import com.navercorp.pinpoint.web.vo.Range;
+import com.navercorp.pinpoint.web.vo.SearchOption;
 import org.apache.hadoop.hbase.shaded.org.junit.Assert;
 import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
@@ -117,8 +118,9 @@ public abstract class BidirectionalLinkSelectorTestBase extends LinkSelectorTest
         });
         when(hostApplicationMapDao.findAcceptApplicationName(any(Application.class), any(Range.class))).thenReturn(new HashSet<>());
 
-        LinkSelector linkSelector = linkSelectorFactory.create(getLinkSelectorType());
-        LinkDataDuplexMap linkDataDuplexMap = linkSelector.select(APP_A, range, twoDepth);
+        SearchOption searchOption = new SearchOption(2, 2, getLinkSelectorType(), false);
+        LinkSelector linkSelector = linkSelectorFactory.create(searchOption);
+        LinkDataDuplexMap linkDataDuplexMap = linkSelector.select(APP_A, range, searchOption);
 
         // APP_IN_IN -> APP_IN (callee)
         LinkKey linkKey_IN_IN_to_IN = new LinkKey(APP_IN_IN, APP_IN);

--- a/web/src/test/java/com/navercorp/pinpoint/web/service/map/LinkSelectorTestBase.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/service/map/LinkSelectorTestBase.java
@@ -57,9 +57,6 @@ public abstract class LinkSelectorTestBase {
 
     protected final Range range = new Range(0, 100);
 
-    protected final SearchOption oneDepth = new SearchOption(1, 1);
-    protected final SearchOption twoDepth = new SearchOption(2, 2);
-
     protected LinkDataMapService linkDataMapService;
     protected HostApplicationMapDao hostApplicationMapDao;
     protected LinkSelectorFactory linkSelectorFactory;
@@ -87,8 +84,9 @@ public abstract class LinkSelectorTestBase {
         when(linkDataMapService.selectCalleeLinkDataMap(any(Application.class), any(Range.class))).thenReturn(newEmptyLinkDataMap());
         when(hostApplicationMapDao.findAcceptApplicationName(any(Application.class), any(Range.class))).thenReturn(new HashSet<>());
 
-        LinkSelector linkSelector = linkSelectorFactory.create(getLinkSelectorType());
-        LinkDataDuplexMap select = linkSelector.select(APP_A, range, oneDepth);
+        SearchOption searchOption = new SearchOption(1, 1, getLinkSelectorType(), false);
+        LinkSelector linkSelector = linkSelectorFactory.create(searchOption);
+        LinkDataDuplexMap select = linkSelector.select(APP_A, range, searchOption);
 
         Assert.assertEquals(select.size(), 0);
         Assert.assertEquals(select.getTotalCount(), 0);
@@ -110,8 +108,9 @@ public abstract class LinkSelectorTestBase {
         when(linkDataMapService.selectCalleeLinkDataMap(any(Application.class), any(Range.class))).thenReturn(newEmptyLinkDataMap());
         when(hostApplicationMapDao.findAcceptApplicationName(any(Application.class), any(Range.class))).thenReturn(new HashSet<>());
 
-        LinkSelector linkSelector = linkSelectorFactory.create(getLinkSelectorType());
-        LinkDataDuplexMap linkData = linkSelector.select(APP_A, range, oneDepth);
+        SearchOption searchOption = new SearchOption(1, 1, getLinkSelectorType(), false);
+        LinkSelector linkSelector = linkSelectorFactory.create(searchOption);
+        LinkDataDuplexMap linkData = linkSelector.select(APP_A, range, searchOption);
 
         Assert.assertEquals(linkData.size(), 1);
         Assert.assertEquals(linkData.getTotalCount(), callCount_A_B);
@@ -142,8 +141,9 @@ public abstract class LinkSelectorTestBase {
         when(linkDataMapService.selectCalleeLinkDataMap(any(Application.class), any(Range.class))).thenReturn(newEmptyLinkDataMap());
         when(hostApplicationMapDao.findAcceptApplicationName(any(Application.class), any(Range.class))).thenReturn(new HashSet<>());
 
-        LinkSelector linkSelector = linkSelectorFactory.create(getLinkSelectorType());
-        LinkDataDuplexMap linkData = linkSelector.select(APP_A, range, oneDepth);
+        SearchOption searchOption = new SearchOption(1, 1, getLinkSelectorType(), false);
+        LinkSelector linkSelector = linkSelectorFactory.create(searchOption);
+        LinkDataDuplexMap linkData = linkSelector.select(APP_A, range, searchOption);
 
         Assert.assertEquals(linkData.size(), numTargets);
         Assert.assertEquals(linkData.getTotalCount(), numTargets * callCount_A_APP);
@@ -180,8 +180,9 @@ public abstract class LinkSelectorTestBase {
         when(hostApplicationMapDao.findAcceptApplicationName(any(Application.class), any(Range.class))).thenReturn(new HashSet<>());
 
         // depth 1
-        LinkSelector linkSelector = linkSelectorFactory.create(getLinkSelectorType());
-        LinkDataDuplexMap linkData = linkSelector.select(APP_A, range, oneDepth);
+        SearchOption searchOption = new SearchOption(1, 1, getLinkSelectorType(), false);
+        LinkSelector linkSelector = linkSelectorFactory.create(searchOption);
+        LinkDataDuplexMap linkData = linkSelector.select(APP_A, range, searchOption);
 
         Assert.assertEquals(linkData.size(), 1);
         Assert.assertEquals(linkData.getTotalCount(), callCount_A_B);
@@ -193,8 +194,9 @@ public abstract class LinkSelectorTestBase {
         Assert.assertEquals(linkData.getTargetLinkDataList().size(), 0);
 
         // depth 2
-        LinkSelector linkSelector2 = linkSelectorFactory.create(getLinkSelectorType());
-        LinkDataDuplexMap linkData_depth2 = linkSelector2.select(APP_A, range, twoDepth);
+        SearchOption searchOption2 = new SearchOption(2, 2, getLinkSelectorType(), false);
+        LinkSelector linkSelector2 = linkSelectorFactory.create(searchOption2);
+        LinkDataDuplexMap linkData_depth2 = linkSelector2.select(APP_A, range, searchOption2);
         Assert.assertEquals(linkData_depth2.size(), 2);
         Assert.assertEquals(linkData_depth2.getTotalCount(), callCount_A_B + callCount_B_C);
 
@@ -228,8 +230,9 @@ public abstract class LinkSelectorTestBase {
         when(hostApplicationMapDao.findAcceptApplicationName(eq(APP_A), any(Range.class))).thenReturn(acceptApplications);
 
         // When
-        LinkSelector linkSelector = linkSelectorFactory.create(getLinkSelectorType());
-        LinkDataDuplexMap linkData = linkSelector.select(APP_A, range, oneDepth);
+        SearchOption searchOption = new SearchOption(1, 1, getLinkSelectorType(), false);
+        LinkSelector linkSelector = linkSelectorFactory.create(searchOption);
+        LinkDataDuplexMap linkData = linkSelector.select(APP_A, range, searchOption);
 
         // Then
         Assert.assertEquals(1, linkData.size());
@@ -264,10 +267,11 @@ public abstract class LinkSelectorTestBase {
 
         when(linkDataMapService.selectCallerLinkDataMap(any(Application.class), any(Range.class))).thenReturn(newEmptyLinkDataMap());
         when(linkDataMapService.selectCalleeLinkDataMap(eq(APP_B), any(Range.class))).thenReturn(linkDataMap);
-        when(hostApplicationMapDao.findAcceptApplicationName(any(Application.class), any(Range.class))).thenReturn(new HashSet<AcceptApplication>());
+        when(hostApplicationMapDao.findAcceptApplicationName(any(Application.class), any(Range.class))).thenReturn(new HashSet<>());
 
-        LinkSelector linkSelector = linkSelectorFactory.create(getLinkSelectorType());
-        LinkDataDuplexMap linkData = linkSelector.select(APP_B, range, oneDepth);
+        SearchOption searchOption = new SearchOption(1, 1, getLinkSelectorType(), false);
+        LinkSelector linkSelector = linkSelectorFactory.create(searchOption);
+        LinkDataDuplexMap linkData = linkSelector.select(APP_B, range, searchOption);
 
         Assert.assertEquals(linkData.size(), 1);
         Assert.assertEquals(linkData.getTotalCount(), callCount_A_B);
@@ -303,10 +307,11 @@ public abstract class LinkSelectorTestBase {
         when(linkDataMapService.selectCalleeLinkDataMap(eq(APP_C), any(Range.class))).thenReturn(linkDataMap_B_C);
 
         when(linkDataMapService.selectCallerLinkDataMap(any(Application.class), any(Range.class))).thenReturn(newEmptyLinkDataMap());
-        when(hostApplicationMapDao.findAcceptApplicationName(any(Application.class), any(Range.class))).thenReturn(new HashSet<AcceptApplication>());
+        when(hostApplicationMapDao.findAcceptApplicationName(any(Application.class), any(Range.class))).thenReturn(new HashSet<>());
 
-        LinkSelector linkSelector = linkSelectorFactory.create(getLinkSelectorType());
-        LinkDataDuplexMap linkData = linkSelector.select(APP_C, range, oneDepth);
+        SearchOption searchOption = new SearchOption(1, 1, getLinkSelectorType(), false);
+        LinkSelector linkSelector = linkSelectorFactory.create(searchOption);
+        LinkDataDuplexMap linkData = linkSelector.select(APP_C, range, searchOption);
 
         Assert.assertEquals(linkData.size(), 1);
         Assert.assertEquals(linkData.getTotalCount(), callCount_B_C);
@@ -317,8 +322,9 @@ public abstract class LinkSelectorTestBase {
         Assert.assertEquals(linkData.getTotalCount(), callCount_B_C);
 
         // depth 2
-        LinkSelector linkSelector2 = linkSelectorFactory.create(getLinkSelectorType());
-        LinkDataDuplexMap linkData_depth2 = linkSelector2.select(APP_C, range, twoDepth);
+        SearchOption searchOption2 = new SearchOption(2, 2, getLinkSelectorType(), false);
+        LinkSelector linkSelector2 = linkSelectorFactory.create(searchOption2);
+        LinkDataDuplexMap linkData_depth2 = linkSelector2.select(APP_C, range, searchOption2);
         Assert.assertEquals(linkData_depth2.size(), 2);
 
         LinkKey linkKey_A_B = new LinkKey(APP_A, APP_B);
@@ -368,8 +374,9 @@ public abstract class LinkSelectorTestBase {
         when(hostApplicationMapDao.findAcceptApplicationName(eq(APP_A), any(Range.class))).thenReturn(acceptApplications);
 
         // When
-        LinkSelector linkSelector = linkSelectorFactory.create(getLinkSelectorType());
-        LinkDataDuplexMap linkData = linkSelector.select(APP_A, range, oneDepth);
+        SearchOption searchOption = new SearchOption(1, 1, getLinkSelectorType(), false);
+        LinkSelector linkSelector = linkSelectorFactory.create(searchOption);
+        LinkDataDuplexMap linkData = linkSelector.select(APP_A, range, searchOption);
 
         // Then
         LinkData linkData_A_B = linkData.getSourceLinkData(new LinkKey(APP_A, APP_B));
@@ -448,8 +455,9 @@ public abstract class LinkSelectorTestBase {
         when(hostApplicationMapDao.findAcceptApplicationName(eq(APP_A), any(Range.class))).thenReturn(acceptApplications);
 
         // When
-        LinkSelector linkSelector = linkSelectorFactory.create(getLinkSelectorType());
-        LinkDataDuplexMap linkData = linkSelector.select(APP_A, range, oneDepth);
+        SearchOption searchOption = new SearchOption(1, 1, getLinkSelectorType(), false);
+        LinkSelector linkSelector = linkSelectorFactory.create(searchOption);
+        LinkDataDuplexMap linkData = linkSelector.select(APP_A, range, searchOption);
 
         // Then
         assertSource_Target_TotalCount("APP_A -> APP_B", linkData, new LinkKey(APP_A, APP_B), callCount_proxy_B + callCount_B);
@@ -529,9 +537,9 @@ public abstract class LinkSelectorTestBase {
         when(hostApplicationMapDao.findAcceptApplicationName(eq(APP_C), any(Range.class))).thenReturn(apiAcceptApplications);
 
         // When
-        LinkSelector linkSelector = linkSelectorFactory.create(getLinkSelectorType());
-        SearchOption in1_out2_options = new SearchOption(2, 1);
-        LinkDataDuplexMap linkData = linkSelector.select(APP_A, range, in1_out2_options);
+        SearchOption searchOption = new SearchOption(2, 1, getLinkSelectorType(), false);
+        LinkSelector linkSelector = linkSelectorFactory.create(searchOption);
+        LinkDataDuplexMap linkData = linkSelector.select(APP_A, range, searchOption);
 
         // Then
         LinkData linkData_A_B = linkData.getSourceLinkData(new LinkKey(APP_A, APP_B));

--- a/web/src/test/java/com/navercorp/pinpoint/web/service/map/RpcCallProcessorTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/service/map/RpcCallProcessorTest.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright 2017 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.web.service.map;
+
+import com.google.common.collect.Sets;
+import com.navercorp.pinpoint.common.trace.ServiceType;
+import com.navercorp.pinpoint.web.applicationmap.rawdata.LinkData;
+import com.navercorp.pinpoint.web.applicationmap.rawdata.LinkDataMap;
+import com.navercorp.pinpoint.web.dao.HostApplicationMapDao;
+import com.navercorp.pinpoint.web.vo.Application;
+import com.navercorp.pinpoint.web.vo.LinkKey;
+import com.navercorp.pinpoint.web.vo.Range;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.Collections;
+import java.util.Set;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author HyunGil Jeong
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class RpcCallProcessorTest {
+
+    private final Range testRange = new Range(System.currentTimeMillis(), System.currentTimeMillis());
+
+    @Mock
+    private HostApplicationMapDao hostApplicationMapDao;
+
+    @Test
+    public void nonRpcClientOrQueueCallsShouldNotBeReplaced() {
+        // Given
+        ServiceType nonRpcClientOrQueueServiceType = mock(ServiceType.class);
+        when(nonRpcClientOrQueueServiceType.isRpcClient()).thenReturn(false);
+        when(nonRpcClientOrQueueServiceType.isQueue()).thenReturn(false);
+
+        Application fromApplication = new Application("WAS", ServiceType.TEST_STAND_ALONE);
+        Application toApplication = new Application("NON_RPC_OR_QUEUE", nonRpcClientOrQueueServiceType);
+
+        LinkDataMap linkDataMap = new LinkDataMap();
+        linkDataMap.addLinkData(new LinkData(fromApplication, toApplication));
+
+        // When
+        VirtualLinkMarker virtualLinkMarker = new VirtualLinkMarker();
+        RpcCallProcessor rpcCallProcessor = new RpcCallProcessor(hostApplicationMapDao, virtualLinkMarker);
+        LinkDataMap replacedLinkDataMap = rpcCallProcessor.processLinkDataMap(linkDataMap, testRange);
+
+        // Then
+        LinkKey linkKey = new LinkKey(fromApplication, toApplication);
+        Assert.assertNotNull(replacedLinkDataMap.getLinkData(linkKey));
+        Assert.assertEquals(linkDataMap.size(), replacedLinkDataMap.size());
+
+        Assert.assertTrue(virtualLinkMarker.getVirtualLinkData().isEmpty());
+    }
+
+    @Test
+    public void oneAcceptApplication() {
+        // Given
+        ServiceType rpcClientServiceType = mock(ServiceType.class);
+        when(rpcClientServiceType.isRpcClient()).thenReturn(true);
+        String rpcUri = "accept.host/foo";
+
+        Application fromApplication = new Application("WAS", ServiceType.TEST_STAND_ALONE);
+        Application toApplication = new Application(rpcUri, rpcClientServiceType);
+
+        LinkDataMap linkDataMap = new LinkDataMap();
+        linkDataMap.addLinkData(new LinkData(fromApplication, toApplication));
+
+        Application expectedToApplication = new Application("ACCEPT_WAS", ServiceType.TEST_STAND_ALONE);
+        when(hostApplicationMapDao.findAcceptApplicationName(fromApplication, testRange))
+                .thenReturn(Sets.newHashSet(new AcceptApplication(rpcUri, expectedToApplication)));
+
+        // When
+        VirtualLinkMarker virtualLinkMarker = new VirtualLinkMarker();
+        RpcCallProcessor rpcCallProcessor = new RpcCallProcessor(hostApplicationMapDao, virtualLinkMarker);
+        LinkDataMap replacedLinkDataMap = rpcCallProcessor.processLinkDataMap(linkDataMap, testRange);
+
+        // Then
+        LinkKey originalLinkKey = new LinkKey(fromApplication, toApplication);
+        Assert.assertNull(replacedLinkDataMap.getLinkData(originalLinkKey));
+
+        LinkKey replacedLinkKey = new LinkKey(fromApplication, expectedToApplication);
+        LinkData replacedLinkData = replacedLinkDataMap.getLinkData(replacedLinkKey);
+        Assert.assertNotNull(replacedLinkData);
+        Assert.assertEquals(fromApplication, replacedLinkData.getFromApplication());
+        Assert.assertEquals(expectedToApplication, replacedLinkData.getToApplication());
+
+        Assert.assertTrue(virtualLinkMarker.getVirtualLinkData().isEmpty());
+    }
+
+    @Test
+    public void multipleAcceptApplications() {
+        // Given
+        ServiceType rpcClientServiceType = mock(ServiceType.class);
+        when(rpcClientServiceType.isRpcClient()).thenReturn(true);
+        String rpcUri = "accept.host/foo";
+
+        Application fromApplication = new Application("WAS", ServiceType.TEST_STAND_ALONE);
+        Application toApplication = new Application(rpcUri, rpcClientServiceType);
+
+        LinkDataMap linkDataMap = new LinkDataMap();
+        linkDataMap.addLinkData(new LinkData(fromApplication, toApplication));
+
+        Application expectedToApplication1 = new Application("ACCEPT_WAS1", ServiceType.TEST_STAND_ALONE);
+        Application expectedToApplication2 = new Application("ACCEPT_WAS2", ServiceType.TEST_STAND_ALONE);
+        when(hostApplicationMapDao.findAcceptApplicationName(fromApplication, testRange))
+                .thenReturn(Sets.newHashSet(
+                        new AcceptApplication(rpcUri, expectedToApplication1),
+                        new AcceptApplication(rpcUri, expectedToApplication2)));
+
+        // When
+        VirtualLinkMarker virtualLinkMarker = new VirtualLinkMarker();
+        RpcCallProcessor rpcCallProcessor = new RpcCallProcessor(hostApplicationMapDao, virtualLinkMarker);
+        LinkDataMap replacedLinkDataMap = rpcCallProcessor.processLinkDataMap(linkDataMap, testRange);
+
+        // Then
+        LinkKey originalLinkKey = new LinkKey(fromApplication, toApplication);
+        Assert.assertNull(replacedLinkDataMap.getLinkData(originalLinkKey));
+
+        LinkKey replacedLinkKey1 = new LinkKey(fromApplication, expectedToApplication1);
+        LinkData replacedLinkData1 = replacedLinkDataMap.getLinkData(replacedLinkKey1);
+        Assert.assertNotNull(replacedLinkData1);
+        Assert.assertEquals(fromApplication, replacedLinkData1.getFromApplication());
+        Assert.assertEquals(expectedToApplication1, replacedLinkData1.getToApplication());
+
+        LinkKey replacedLinkKey2 = new LinkKey(fromApplication, expectedToApplication2);
+        LinkData replacedLinkData2 = replacedLinkDataMap.getLinkData(replacedLinkKey2);
+        Assert.assertNotNull(replacedLinkData2);
+        Assert.assertEquals(fromApplication, replacedLinkData2.getFromApplication());
+        Assert.assertEquals(expectedToApplication2, replacedLinkData2.getToApplication());
+
+        Set<LinkData> virtualLinkDatas = virtualLinkMarker.getVirtualLinkData();
+        Assert.assertTrue(virtualLinkDatas.contains(replacedLinkData1));
+        Assert.assertTrue(virtualLinkDatas.contains(replacedLinkData2));
+    }
+
+    @Test
+    public void rpcWithoutAcceptApplication_shouldBeReplacedToUnknown() {
+        // Given
+        ServiceType rpcClientServiceType = mock(ServiceType.class);
+        when(rpcClientServiceType.isRpcClient()).thenReturn(true);
+        String rpcUri = "accept.host/foo";
+
+        Application fromApplication = new Application("WAS", ServiceType.TEST_STAND_ALONE);
+        Application toApplication = new Application(rpcUri, rpcClientServiceType);
+        Application expectedToApplication = new Application(rpcUri, ServiceType.UNKNOWN);
+
+        LinkDataMap linkDataMap = new LinkDataMap();
+        linkDataMap.addLinkData(new LinkData(fromApplication, toApplication));
+
+        when(hostApplicationMapDao.findAcceptApplicationName(fromApplication, testRange)).thenReturn(Collections.emptySet());
+
+        // When
+        VirtualLinkMarker virtualLinkMarker = new VirtualLinkMarker();
+        RpcCallProcessor rpcCallProcessor = new RpcCallProcessor(hostApplicationMapDao, virtualLinkMarker);
+        LinkDataMap replacedLinkDataMap = rpcCallProcessor.processLinkDataMap(linkDataMap, testRange);
+
+        // Then
+        LinkKey originalLinkKey = new LinkKey(fromApplication, toApplication);
+        Assert.assertNull(replacedLinkDataMap.getLinkData(originalLinkKey));
+
+        LinkKey replacedLinkKey = new LinkKey(fromApplication, expectedToApplication);
+        LinkData replacedLinkData = replacedLinkDataMap.getLinkData(replacedLinkKey);
+        Assert.assertEquals(fromApplication, replacedLinkData.getFromApplication());
+        Assert.assertEquals(expectedToApplication, replacedLinkData.getToApplication());
+
+        Assert.assertTrue(virtualLinkMarker.getVirtualLinkData().isEmpty());
+    }
+
+    @Test
+    public void queueWithoutAcceptApplication_shouldNotReplace() {
+        // Given
+        ServiceType queueServiceType = mock(ServiceType.class);
+        when(queueServiceType.isRpcClient()).thenReturn(false);
+        when(queueServiceType.isQueue()).thenReturn(true);
+        String queueName = "TestQueue";
+
+        Application fromApplication = new Application("WAS", ServiceType.TEST_STAND_ALONE);
+        Application toApplication = new Application(queueName, queueServiceType);
+
+        LinkDataMap linkDataMap = new LinkDataMap();
+        linkDataMap.addLinkData(new LinkData(fromApplication, toApplication));
+
+        when(hostApplicationMapDao.findAcceptApplicationName(fromApplication, testRange)).thenReturn(Collections.emptySet());
+
+        // When
+        VirtualLinkMarker virtualLinkMarker = new VirtualLinkMarker();
+        RpcCallProcessor rpcCallProcessor = new RpcCallProcessor(hostApplicationMapDao, virtualLinkMarker);
+        LinkDataMap replacedLinkDataMap = rpcCallProcessor.processLinkDataMap(linkDataMap, testRange);
+
+        // Then
+        LinkKey linkKey = new LinkKey(fromApplication, toApplication);
+        LinkData linkData = replacedLinkDataMap.getLinkData(linkKey);
+        Assert.assertEquals(fromApplication, linkData.getFromApplication());
+        Assert.assertEquals(toApplication, linkData.getToApplication());
+
+        Assert.assertTrue(virtualLinkMarker.getVirtualLinkData().isEmpty());
+    }
+}

--- a/web/src/test/java/com/navercorp/pinpoint/web/service/map/UnidirectionalLinkSelectorTestBase.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/service/map/UnidirectionalLinkSelectorTestBase.java
@@ -23,6 +23,7 @@ import com.navercorp.pinpoint.web.applicationmap.rawdata.LinkDataMap;
 import com.navercorp.pinpoint.web.vo.Application;
 import com.navercorp.pinpoint.web.vo.LinkKey;
 import com.navercorp.pinpoint.web.vo.Range;
+import com.navercorp.pinpoint.web.vo.SearchOption;
 import org.apache.hadoop.hbase.shaded.org.junit.Assert;
 import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
@@ -117,8 +118,9 @@ public abstract class UnidirectionalLinkSelectorTestBase extends LinkSelectorTes
         });
         when(hostApplicationMapDao.findAcceptApplicationName(any(Application.class), any(Range.class))).thenReturn(new HashSet<>());
 
-        LinkSelector linkSelector = linkSelectorFactory.create(getLinkSelectorType());
-        LinkDataDuplexMap linkDataDuplexMap = linkSelector.select(APP_A, range, twoDepth);
+        SearchOption searchOption = new SearchOption(2, 2, getLinkSelectorType(), false);
+        LinkSelector linkSelector = linkSelectorFactory.create(searchOption);
+        LinkDataDuplexMap linkDataDuplexMap = linkSelector.select(APP_A, range, searchOption);
 
         // APP_IN_IN -> APP_IN -> APP_A(selected) -> APP_OUT -> APP_OUT_OUT
         //                 |-> APP_IN_OUT   APP_OUT_IN -^

--- a/web/src/test/java/com/navercorp/pinpoint/web/service/map/WasOnlyProcessorTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/service/map/WasOnlyProcessorTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2017 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.web.service.map;
+
+import com.navercorp.pinpoint.common.trace.ServiceType;
+import com.navercorp.pinpoint.common.trace.ServiceTypeFactory;
+import com.navercorp.pinpoint.common.trace.ServiceTypeProperty;
+import com.navercorp.pinpoint.web.applicationmap.rawdata.LinkData;
+import com.navercorp.pinpoint.web.applicationmap.rawdata.LinkDataMap;
+import com.navercorp.pinpoint.web.vo.Application;
+import com.navercorp.pinpoint.web.vo.Range;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author HyunGil Jeong
+ */
+public class WasOnlyProcessorTest {
+
+    private final Range testRange = new Range(System.currentTimeMillis(), System.currentTimeMillis());
+
+    @Test
+    public void shouldFilterLinksToTerminalNodes() {
+        // Given
+        Application fromApplication = new Application("WAS", ServiceType.TEST_STAND_ALONE);
+        ServiceType terminalServiceType = ServiceTypeFactory.of(2222, "TERMINAL", ServiceTypeProperty.TERMINAL);
+        Application toApplication = new Application("TERMINAL", terminalServiceType);
+        LinkData wasToTerminalLinkData = new LinkData(fromApplication, toApplication);
+        LinkDataMap linkDataMap = new LinkDataMap();
+        linkDataMap.addLinkData(wasToTerminalLinkData);
+
+        // When
+        WasOnlyProcessor wasOnlyProcessor = new WasOnlyProcessor();
+        LinkDataMap filteredLinkDataMap = wasOnlyProcessor.processLinkDataMap(linkDataMap, testRange);
+
+        // Then
+        Assert.assertTrue(filteredLinkDataMap.getLinkDataList().isEmpty());
+    }
+
+    @Test
+    public void shouldFilterLinksToUnknownNodes() {
+        // Given
+        Application fromApplication = new Application("WAS", ServiceType.TEST_STAND_ALONE);
+        Application toApplication = new Application("UNKNOWN", ServiceType.UNKNOWN);
+        LinkData wasToUnknownLinkData = new LinkData(fromApplication, toApplication);
+        LinkDataMap linkDataMap = new LinkDataMap();
+        linkDataMap.addLinkData(wasToUnknownLinkData);
+
+        // When
+        WasOnlyProcessor wasOnlyProcessor = new WasOnlyProcessor();
+        LinkDataMap filteredLinkDataMap = wasOnlyProcessor.processLinkDataMap(linkDataMap, testRange);
+
+        // Then
+        Assert.assertTrue(filteredLinkDataMap.getLinkDataList().isEmpty());
+    }
+
+    @Test
+    public void shouldNotFilterLinksToWasNodes() {
+        // Given
+        Application fromApplication = new Application("WAS_FROM", ServiceType.TEST_STAND_ALONE);
+        Application toApplication = new Application("WAS_TO", ServiceType.TEST_STAND_ALONE);
+        LinkData wasToWasLinkData = new LinkData(fromApplication, toApplication);
+        LinkDataMap linkDataMap = new LinkDataMap();
+        linkDataMap.addLinkData(wasToWasLinkData);
+
+        // When
+        WasOnlyProcessor wasOnlyProcessor = new WasOnlyProcessor();
+        LinkDataMap filteredLinkDataMap = wasOnlyProcessor.processLinkDataMap(linkDataMap, testRange);
+
+        // Then
+        Assert.assertFalse(filteredLinkDataMap.getLinkDataList().isEmpty());
+    }
+
+    @Test
+    public void shouldNotFilterLinksToQueueNodes() {
+        // Given
+        Application fromApplication = new Application("WAS", ServiceType.TEST_STAND_ALONE);
+        Application toApplication = new Application("QUEUE", ServiceTypeFactory.of(8888, "QUEUE", ServiceTypeProperty.QUEUE));
+        LinkData wasToQueueLinkData = new LinkData(fromApplication, toApplication);
+        LinkDataMap linkDataMap = new LinkDataMap();
+        linkDataMap.addLinkData(wasToQueueLinkData);
+
+        // When
+        WasOnlyProcessor wasOnlyProcessor = new WasOnlyProcessor();
+        LinkDataMap filteredLinkDataMap = wasOnlyProcessor.processLinkDataMap(linkDataMap, testRange);
+
+        // Then
+        Assert.assertFalse(filteredLinkDataMap.getLinkDataList().isEmpty());
+    }
+}


### PR DESCRIPTION
This adds a query parameter *wasOnly* to main server map queries.
If the parameter is true, `LinkData` to applications with `TERMINAL` service types (calls made to terminal nodes such as database and cache), or `UNKNOWN` service types (rpc calls made to destinations without an agent) are filtered out and the destination nodes will subsequently not be rendered in the server map.

Default value is false to maintain the same query behavior as the current API.