### PR TITLE
Allows specifying multiple source/destination applications when querying for node histograms

### DIFF
--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/appender/histogram/DefaultNodeHistogramFactory.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/appender/histogram/DefaultNodeHistogramFactory.java
@@ -83,9 +83,11 @@ public class DefaultNodeHistogramFactory implements NodeHistogramFactory {
 
         // for Terminal nodes, create AgentLevel histogram
         if (terminalApplication.getServiceType().isTerminal()) {
+            LinkCallDataMap mergeSource = new LinkCallDataMap();
             final Map<String, Histogram> agentHistogramMap = new HashMap<>();
             for (Link link : toLinkList) {
                 LinkCallDataMap sourceLinkCallDataMap = link.getSourceLinkCallDataMap();
+                mergeSource.addLinkDataMap(sourceLinkCallDataMap);
                 AgentHistogramList targetList = sourceLinkCallDataMap.getTargetList();
                 for (AgentHistogram histogram : targetList.getAgentHistogramList()) {
                     Histogram find = agentHistogramMap.get(histogram.getId());
@@ -97,17 +99,11 @@ public class DefaultNodeHistogramFactory implements NodeHistogramFactory {
                 }
                 nodeHistogram.setAgentHistogramMap(agentHistogramMap);
             }
-        }
 
-        LinkCallDataMap mergeSource = new LinkCallDataMap();
-        for (Link link : toLinkList) {
-            LinkCallDataMap sourceLinkCallDataMap = link.getSourceLinkCallDataMap();
-            mergeSource.addLinkDataMap(sourceLinkCallDataMap);
+            AgentTimeHistogramBuilder agentTimeBuilder = new AgentTimeHistogramBuilder(terminalApplication, range);
+            AgentTimeHistogram agentTimeHistogram = agentTimeBuilder.buildTarget(mergeSource);
+            nodeHistogram.setAgentTimeHistogram(agentTimeHistogram);
         }
-
-        AgentTimeHistogramBuilder agentTimeBuilder = new AgentTimeHistogramBuilder(terminalApplication, range);
-        AgentTimeHistogram agentTimeHistogram = agentTimeBuilder.buildTarget(mergeSource);
-        nodeHistogram.setAgentTimeHistogram(agentTimeHistogram);
 
         return nodeHistogram;
     }

--- a/web/src/main/java/com/navercorp/pinpoint/web/controller/MapController.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/controller/MapController.java
@@ -274,6 +274,43 @@ public class MapController {
         return responseTimeHistogramService.selectNodeHistogramData(application, range, fromApplications, toApplications);
     }
 
+    @RequestMapping(value = "/getResponseTimeHistogramDataV2", method = RequestMethod.GET)
+    @ResponseBody
+    public NodeHistogramSummary getResponseTimeHistogramDataV2(
+            @RequestParam("applicationName") String applicationName,
+            @RequestParam("serviceTypeCode") Short serviceTypeCode,
+            @RequestParam("from") long from,
+            @RequestParam("to") long to,
+            @RequestParam(value = "fromApplicationNames", defaultValue = "", required = false) List<String> fromApplicationNames,
+            @RequestParam(value = "fromServiceTypeCodes", defaultValue = "", required = false) List<Short> fromServiceTypeCodes,
+            @RequestParam(value = "toApplicationNames", defaultValue = "", required = false) List<String> toApplicationNames,
+            @RequestParam(value = "toServiceTypeCodes", defaultValue = "", required = false) List<Short> toServiceTypeCodes) {
+        final Range range = new Range(from, to);
+        dateLimit.limit(range);
+
+        if (fromApplicationNames.size() != fromServiceTypeCodes.size()) {
+            throw new IllegalArgumentException("fromApplicationNames and fromServiceTypeCodes must have the same number of elements");
+        }
+        if (toApplicationNames.size() != toServiceTypeCodes.size()) {
+            throw new IllegalArgumentException("toApplicationNames and toServiceTypeCodes must have the same number of elements");
+        }
+
+        Application application = applicationFactory.createApplication(applicationName, serviceTypeCode);
+
+        List<Application> fromApplications = new ArrayList<>(fromApplicationNames.size());
+        for (int i = 0; i < fromApplicationNames.size(); ++i) {
+            Application fromApplication = applicationFactory.createApplication(fromApplicationNames.get(i), fromServiceTypeCodes.get(i));
+            fromApplications.add(fromApplication);
+        }
+        List<Application> toApplications = new ArrayList<>(toApplicationNames.size());
+        for (int i = 0; i < toApplicationNames.size(); ++i) {
+            Application toApplication = applicationFactory.createApplication(toApplicationNames.get(i), toServiceTypeCodes.get(i));
+            toApplications.add(toApplication);
+        }
+
+        return responseTimeHistogramService.selectNodeHistogramData(application, range, fromApplications, toApplications);
+    }
+
     private List<Application> mapApplicationPairsToApplications(List<ApplicationPair> applicationPairs) {
         if (CollectionUtils.isEmpty(applicationPairs)) {
             return Collections.emptyList();

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/ResponseTimeHistogramService.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/ResponseTimeHistogramService.java
@@ -22,6 +22,8 @@ import com.navercorp.pinpoint.web.applicationmap.nodes.NodeHistogramSummary;
 import com.navercorp.pinpoint.web.vo.Application;
 import com.navercorp.pinpoint.web.vo.Range;
 
+import java.util.List;
+
 /**
  * @author HyunGil Jeong
  */
@@ -29,7 +31,7 @@ public interface ResponseTimeHistogramService {
 
     ApplicationTimeHistogramViewModel selectResponseTimeHistogramData(Application application, Range range);
 
-    NodeHistogramSummary selectNodeHistogramData(Application application, Range range, Application fromApplication, Application toApplication);
+    NodeHistogramSummary selectNodeHistogramData(Application application, Range range, List<Application> fromApplications, List<Application> toApplications);
 
     LinkHistogramSummary selectLinkHistogramData(Application fromApplication, Application toApplication, Range range);
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/vo/ApplicationPair.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/vo/ApplicationPair.java
@@ -16,55 +16,40 @@
 
 package com.navercorp.pinpoint.web.vo;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
 /**
  * @author HyunGil Jeong
  */
+@JsonFormat(shape = JsonFormat.Shape.ARRAY)
+@JsonPropertyOrder({"applicationName", "serviceTypeCode"})
 public class ApplicationPair {
 
-    private String fromApplicationName;
-    private short fromServiceTypeCode;
-    private String toApplicationName;
-    private short toServiceTypeCode;
+    private String applicationName;
+    private short serviceTypeCode;
 
-    public String getFromApplicationName() {
-        return fromApplicationName;
+    public String getApplicationName() {
+        return applicationName;
     }
 
-    public void setFromApplicationName(String fromApplicationName) {
-        this.fromApplicationName = fromApplicationName;
+    public void setApplicationName(String applicationName) {
+        this.applicationName = applicationName;
     }
 
-    public short getFromServiceTypeCode() {
-        return fromServiceTypeCode;
+    public short getServiceTypeCode() {
+        return serviceTypeCode;
     }
 
-    public void setFromServiceTypeCode(short fromServiceTypeCode) {
-        this.fromServiceTypeCode = fromServiceTypeCode;
-    }
-
-    public String getToApplicationName() {
-        return toApplicationName;
-    }
-
-    public void setToApplicationName(String toApplicationName) {
-        this.toApplicationName = toApplicationName;
-    }
-
-    public short getToServiceTypeCode() {
-        return toServiceTypeCode;
-    }
-
-    public void setToServiceTypeCode(short toServiceTypeCode) {
-        this.toServiceTypeCode = toServiceTypeCode;
+    public void setServiceTypeCode(short serviceTypeCode) {
+        this.serviceTypeCode = serviceTypeCode;
     }
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder("NodeKeysParam{");
-        sb.append("fromApplicationName='").append(fromApplicationName).append('\'');
-        sb.append(", fromServiceTypeCode=").append(fromServiceTypeCode);
-        sb.append(", toApplicationName='").append(toApplicationName).append('\'');
-        sb.append(", toServiceTypeCode=").append(toServiceTypeCode);
+        final StringBuilder sb = new StringBuilder("ApplicationPair{");
+        sb.append("applicationName='").append(applicationName).append('\'');
+        sb.append(", serviceTypeCode=").append(serviceTypeCode);
         sb.append('}');
         return sb.toString();
     }

--- a/web/src/main/java/com/navercorp/pinpoint/web/vo/ApplicationPairs.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/vo/ApplicationPairs.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2017 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.web.vo;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+/**
+ * @author HyunGil Jeong
+ */
+public class ApplicationPairs {
+
+    @JsonProperty("from")
+    private List<ApplicationPair> fromApplications;
+
+    @JsonProperty("to")
+    private List<ApplicationPair> toApplications;
+
+    public List<ApplicationPair> getFromApplications() {
+        return fromApplications;
+    }
+
+    public void setFromApplications(List<ApplicationPair> fromApplications) {
+        this.fromApplications = fromApplications;
+    }
+
+    public List<ApplicationPair> getToApplications() {
+        return toApplications;
+    }
+
+    public void setToApplications(List<ApplicationPair> toApplications) {
+        this.toApplications = toApplications;
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("ApplicationPairs{");
+        sb.append("fromApplications=").append(fromApplications);
+        sb.append(", toApplications=").append(toApplications);
+        sb.append('}');
+        return sb.toString();
+    }
+}


### PR DESCRIPTION
Some nodes may have inbound edges from multiple applications. This allows the node histogram API to receive multiple applications for these cases.