### PR TITLE
[#3369] Changes object type of the previous value in StringRepeatCoun…

### DIFF
--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/codec/strategy/impl/StringRepeatCountEncodingStrategy.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/codec/strategy/impl/StringRepeatCountEncodingStrategy.java
@@ -44,23 +44,23 @@ public class StringRepeatCountEncodingStrategy implements EncodingStrategy<Strin
 
     @Override
     public void encodeValues(Buffer buffer, List<String> values) {
-        String previousValue = null;
+        StringReference previousValueReference = null;
         int count = 0;
         for (String value : values) {
-            if (!StringUtils.equals(value, previousValue)) {
-                if (previousValue != null) {
+            if (previousValueReference == null || !StringUtils.equals(value, previousValueReference.get())) {
+                if (previousValueReference != null) {
                     buffer.putVInt(count);
-                    this.bufferHandler.put(buffer, previousValue);
+                    this.bufferHandler.put(buffer, previousValueReference.get());
                 }
-                previousValue = value;
+                previousValueReference = new StringReference(value);
                 count = 1;
             } else {
                 count++;
             }
         }
-        if (count > 0) {
+        if (count > 0 && previousValueReference != null) {
             buffer.putVInt(count);
-            this.bufferHandler.put(buffer, previousValue);
+            this.bufferHandler.put(buffer, previousValueReference.get());
         }
     }
 
@@ -77,6 +77,20 @@ public class StringRepeatCountEncodingStrategy implements EncodingStrategy<Strin
             }
         }
         return values;
+    }
+
+    private static class StringReference {
+
+        private final String value;
+
+        public StringReference(String value) {
+            this.value = value;
+        }
+
+        public String get() {
+            return value;
+        }
+
     }
 
 }


### PR DESCRIPTION
…tEncodingStrategy

 Current previous value is stored as a String, if input value is [null, null, "value", "value"], it is impossible to distinguish between the initial value and the previous value.
 To save the previous value, change it to AtomicReference.