### PR TITLE
[#noissue] cleanup rpc

### DIFF
--- a/rpc/src/main/java/com/navercorp/pinpoint/rpc/client/DefaultPinpointClientFactory.java
+++ b/rpc/src/main/java/com/navercorp/pinpoint/rpc/client/DefaultPinpointClientFactory.java
@@ -224,16 +224,6 @@ public class DefaultPinpointClientFactory implements PinpointClientFactory {
         return pinpointClient;
     }
 
-    public PinpointClient reconnect(String host, int port) throws PinpointSocketException {
-        SocketAddress address = new InetSocketAddress(host, port);
-        ChannelFuture connectFuture = bootstrap.connect(address);
-        PinpointClientHandler pinpointClientHandler = getSocketHandler(connectFuture, address);
-
-        PinpointClient pinpointClient = new DefaultPinpointClient(pinpointClientHandler);
-        traceSocket(pinpointClient);
-        return pinpointClient;
-    }
-
     /*
         trace mechanism is needed in case of calling close without closing socket
         it is okay to make that later because this is a exceptional case.

--- a/rpc/src/main/java/com/navercorp/pinpoint/rpc/client/DefaultPinpointClientHandler.java
+++ b/rpc/src/main/java/com/navercorp/pinpoint/rpc/client/DefaultPinpointClientHandler.java
@@ -148,7 +148,7 @@ public class DefaultPinpointClientHandler extends SimpleChannelHandler implement
 
     @Override
     public void channelConnected(ChannelHandlerContext ctx, ChannelStateEvent e) throws Exception {
-        Channel channel = ctx.getChannel();
+        Channel channel = e.getChannel();
         if ((null == channel) || (this.channel != channel)) {
             throw new IllegalArgumentException("Invalid channel variable. this.channel:" + this.channel + ", channel:" + channel + ".");
         }

--- a/rpc/src/main/java/com/navercorp/pinpoint/rpc/client/PinpointClientFactory.java
+++ b/rpc/src/main/java/com/navercorp/pinpoint/rpc/client/PinpointClientFactory.java
@@ -17,19 +17,18 @@
 package com.navercorp.pinpoint.rpc.client;
 
 
-import java.net.InetSocketAddress;
-import java.net.SocketAddress;
-import java.util.List;
-import java.util.Map;
-
-import org.jboss.netty.channel.ChannelFuture;
-
 import com.navercorp.pinpoint.rpc.MessageListener;
 import com.navercorp.pinpoint.rpc.PinpointSocketException;
 import com.navercorp.pinpoint.rpc.StateChangeEventListener;
 import com.navercorp.pinpoint.rpc.cluster.ClusterOption;
 import com.navercorp.pinpoint.rpc.cluster.Role;
 import com.navercorp.pinpoint.rpc.stream.ServerStreamChannelMessageListener;
+import org.jboss.netty.channel.ChannelFuture;
+
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.util.List;
+import java.util.Map;
 
 /**
  * @author emeroad
@@ -62,8 +61,6 @@ public interface PinpointClientFactory {
     PinpointClient connect(String host, int port) throws PinpointSocketException;
 
     PinpointClient connect(InetSocketAddress connectAddress) throws PinpointSocketException;
-
-    PinpointClient reconnect(String host, int port) throws PinpointSocketException;
 
 
     PinpointClient scheduledConnect(String host, int port);


### PR DESCRIPTION
1. remove unused code (since 2015 ~ )
2. use same method as method used elsewhere (ChannelHandlerContext.getChannel() -> ChannelStateEvent.getChannel). result is same.
   (http://netty.io/3.5/guide/ netty guide)