### PR TITLE
[#2584] Added 'DisableTrace.close() to 'TraceContext.removeTraceObject()' for API compatibility

### DIFF
--- a/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/context/Trace.java
+++ b/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/context/Trace.java
@@ -31,6 +31,10 @@ public interface Trace extends StackOperation {
 
     long getStartTime();
 
+    /**
+     * @deprecated Since 1.7.0 Use {@link #getThreadId()}
+     * This API will be removed in 1.8.0
+     */
     @Deprecated
     Thread getBindThread();
 
@@ -56,7 +60,9 @@ public interface Trace extends StackOperation {
     SpanRecorder getSpanRecorder();
     
     SpanEventRecorder currentSpanEventRecorder();
-    
+
+    boolean isClosed();
+
     void close();
 
     TraceScope getScope(String name);

--- a/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/context/TraceContext.java
+++ b/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/context/TraceContext.java
@@ -58,6 +58,13 @@ public interface TraceContext {
 
     Trace removeTraceObject();
 
+    /**
+     *
+     * @param closeDisableTrace true
+     * @return
+     */
+    Trace removeTraceObject(boolean closeDisableTrace);
+
     // ActiveThreadCounter getActiveThreadCounter();
 
     String getAgentId();

--- a/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/AsyncTrace.java
+++ b/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/AsyncTrace.java
@@ -158,9 +158,19 @@ public class AsyncTrace implements Trace {
         return trace.getCallStackFrameId() == BEGIN_STACKID;
     }
 
+    /**
+     * @deprecated Since 1.7.0 Use {@link SpanEventRecorder#recordNextAsyncContext()}
+     * This API will be removed in 1.8.0
+     */
+    @Deprecated
     @Override
     public AsyncTraceId getAsyncTraceId() {
         return asyncContextFactory.newAsyncTraceId(traceRoot);
+    }
+
+    @Override
+    public boolean isClosed() {
+        return this.trace.isClosed();
     }
 
     @Override

--- a/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/DefaultReference.java
+++ b/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/DefaultReference.java
@@ -42,10 +42,19 @@ public class DefaultReference<V> implements Reference<V> {
 
 
 
-    private static final Reference<Object> EMPTY = new DefaultReference<Object>() {
+    private static final Reference<Object> EMPTY = new Reference<Object>() {
+        @Override
+        public Object get() {
+            return null;
+        }
+
         @Override
         public void set(Object value) {
-            throw new IllegalStateException("unsupported set:" + value);
+        }
+
+        @Override
+        public Object clear() {
+            return null;
         }
     };
 

--- a/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/DefaultTraceContext.java
+++ b/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/DefaultTraceContext.java
@@ -157,9 +157,28 @@ public class DefaultTraceContext implements TraceContext {
 
     @Override
     public Trace removeTraceObject() {
+        return removeTraceObject(true);
+    }
+
+    @Override
+    public Trace removeTraceObject(boolean closeUnsampledTrace) {
         final Trace trace = traceFactory.removeTraceObject();
+        if (closeUnsampledTrace) {
+            return closeUnsampledTrace(trace);
+        } else {
+            return trace;
+        }
+    }
+
+    private Trace closeUnsampledTrace(Trace trace) {
+        if (trace == null) {
+            return null;
+        }
+        // work around : unsampled trace must be closed.
         if (!trace.canSampled()) {
-            trace.close();
+            if (!trace.isClosed()) {
+                trace.close();
+            }
         }
         return trace;
     }

--- a/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/DisableTrace.java
+++ b/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/DisableTrace.java
@@ -37,6 +37,7 @@ public class DisableTrace implements Trace {
     private final long threadId;
     private final DefaultTraceScopePool scopePool = new DefaultTraceScopePool();
     private final ActiveTraceHandle handle;
+    private boolean closed = false;
 
     public DisableTrace(long id, long startTime, long threadId, ActiveTraceHandle handle) {
         this.id = id;
@@ -117,7 +118,16 @@ public class DisableTrace implements Trace {
     }
 
     @Override
+    public boolean isClosed() {
+        return closed;
+    }
+
+    @Override
     public void close() {
+        if (closed) {
+            return;
+        }
+        closed = true;
         final long purgeTime = System.currentTimeMillis();
         handle.purge(purgeTime);
     }


### PR DESCRIPTION
#2584
 - DisableTrace must be closed in 1.7.0 or later