### PR TITLE
[#noissue] Fixed NPE for DefaultDataSourceMetric.collectDataSource()

### DIFF
--- a/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/monitor/DataSourceMonitorWrapper.java
+++ b/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/monitor/DataSourceMonitorWrapper.java
@@ -51,19 +51,25 @@ public class DataSourceMonitorWrapper implements PluginMonitorWrapper, DataSourc
 
     @Override
     public ServiceType getServiceType() {
-        if (this.serviceType != null) {
-            return this.serviceType;
+        final ServiceType copy = this.serviceType;
+        if (copy != null) {
+            return copy;
         }
 
-        DataSourceMonitor dataSourceMonitor = getInstance();
+        final DataSourceMonitor dataSourceMonitor = getInstance();
         if (dataSourceMonitor != null) {
-            ServiceType serviceType = dataSourceMonitor.getServiceType();
-            if (serviceType != null) {
-                this.serviceType = serviceType;
-            }
+            this.serviceType = getServiceType0(dataSourceMonitor);
             return serviceType;
         }
         return ServiceType.UNKNOWN;
+    }
+
+    public ServiceType getServiceType0(DataSourceMonitor dataSourceMonitor) {
+        final ServiceType serviceType = dataSourceMonitor.getServiceType();
+        if (serviceType == null) {
+            return ServiceType.UNKNOWN;
+        }
+        return serviceType;
     }
 
     @Override

--- a/profiler/src/test/java/com/navercorp/pinpoint/profiler/context/monitor/DataSourceMonitorWrapperTest.java
+++ b/profiler/src/test/java/com/navercorp/pinpoint/profiler/context/monitor/DataSourceMonitorWrapperTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.profiler.context.monitor;
+
+import com.navercorp.pinpoint.bootstrap.plugin.monitor.DataSourceMonitor;
+import com.navercorp.pinpoint.common.trace.ServiceType;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Woonduk Kang(emeroad)
+ */
+public class DataSourceMonitorWrapperTest {
+    @Test
+    public void getServiceType() throws Exception {
+        DataSourceMonitor mock = Mockito.mock(DataSourceMonitor.class);
+        when(mock.getServiceType()).thenReturn(null);
+
+        DataSourceMonitorWrapper dataSourceMonitorWrapper = new DataSourceMonitorWrapper(1, mock);
+        Assert.assertEquals(ServiceType.UNKNOWN, dataSourceMonitorWrapper.getServiceType());
+    }
+}


### PR DESCRIPTION
 - DataSourceMonitorWrapper.getServiceType() don't return null
 - Fixed infer static analysis issue