### PR TITLE
fixed unknown Group Node names overlap in topology

### DIFF
--- a/web/src/main/webapp/common/services/server-map-dao.service.js
+++ b/web/src/main/webapp/common/services/server-map-dao.service.js
@@ -874,6 +874,9 @@
 	        var foundNode = false;
 	        nodes.forEach(function (node) {
 	            if (node.key === key) {
+		            	if(node.category){
+		            		delete node.category;
+		            	}
 	                foundNode = node;
 	            }
 	        });


### PR DESCRIPTION
bug repeat as follows:
1 first, status
![1 first](https://user-images.githubusercontent.com/17841615/32204656-92e9b68c-be25-11e7-8412-df5799afd525.png)


2 clicked on the unknow group node
![2clickon](https://user-images.githubusercontent.com/17841615/32204662-9c1caa48-be25-11e7-9b00-89d1f7da36e5.png)


3 and refresh the topology
![3 refresh](https://user-images.githubusercontent.com/17841615/32204664-9e8272fe-be25-11e7-92ae-f59bea7a0c8a.png)


4 then display overlap
![4 overlap](https://user-images.githubusercontent.com/17841615/32204667-a15bdd12-be25-11e7-852b-b07b2e05f7ce.png)

To fix this problem, need to remove ‘category’ from the data json


