### PR TITLE
[#3611] Change HikariCP data source trace scope

### DIFF
--- a/agent/src/test/java/com/navercorp/pinpoint/plugin/hikaricp/HikariCpIT.java
+++ b/agent/src/test/java/com/navercorp/pinpoint/plugin/hikaricp/HikariCpIT.java
@@ -18,21 +18,23 @@ package com.navercorp.pinpoint.plugin.hikaricp;
 
 import com.navercorp.pinpoint.bootstrap.plugin.test.PluginTestVerifier;
 import com.navercorp.pinpoint.bootstrap.plugin.test.PluginTestVerifierHolder;
+import com.navercorp.pinpoint.common.trace.AnnotationKey;
 import com.navercorp.pinpoint.test.plugin.Dependency;
 import com.navercorp.pinpoint.test.plugin.PinpointPluginTestSuite;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 import com.zaxxer.hikari.proxy.ConnectionProxy;
-import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.sql.Connection;
 import java.sql.SQLException;
 
+import static com.navercorp.pinpoint.bootstrap.plugin.test.Expectations.annotation;
 import static com.navercorp.pinpoint.bootstrap.plugin.test.Expectations.event;
 
 /**
@@ -43,44 +45,111 @@ import static com.navercorp.pinpoint.bootstrap.plugin.test.Expectations.event;
 public class HikariCpIT {
 
     private static final String serviceType = "HIKARICP";
+    private static final String DATA_SOURCE_CLASS_NAME = "org.h2.jdbcx.JdbcDataSource";
+    private static final String JDBC_URL = "jdbc:h2:mem:test;DB_CLOSE_DELAY=-1";
 
-    private static HikariDataSource dataSource;
+    private static Method getConnectionMethod1;
+    private static Method getConnectionMethod2;
+    private static Method proxyConnectionMethod;
 
     @BeforeClass
-    public static void setup() {
-        final HikariConfig config = new HikariConfig();
-        config.setDataSourceClassName("org.h2.jdbcx.JdbcDataSource");
-        config.addDataSourceProperty("url", "jdbc:h2:mem:test;DB_CLOSE_DELAY=-1");
-
-        dataSource = new HikariDataSource(config);
+    public static void setUp() throws NoSuchMethodException {
+        getConnectionMethod1 = HikariDataSource.class.getDeclaredMethod("getConnection");
+        getConnectionMethod2 = HikariDataSource.class.getDeclaredMethod("getConnection", String.class, String.class);
+        proxyConnectionMethod = ConnectionProxy.class.getDeclaredMethod("close");
     }
 
-    @AfterClass
-    public static void tearDown() {
-        if (dataSource != null) {
-            dataSource.close();
+    @Test
+    public void defaultTest1() throws InterruptedException, SQLException, NoSuchMethodException {
+        final HikariConfig config = new HikariConfig();
+        config.setDataSourceClassName(DATA_SOURCE_CLASS_NAME);
+        config.addDataSourceProperty("url", JDBC_URL);
+
+        HikariDataSource dataSource = new HikariDataSource(config);
+        try {
+            Connection connection = dataSource.getConnection();
+            Assert.assertNotNull(connection);
+
+            Thread.sleep(500);
+
+            connection.close();
+
+            Thread.sleep(500);
+
+            Constructor<HikariDataSource> constructor = HikariDataSource.class.getConstructor(HikariConfig.class);
+
+            PluginTestVerifier verifier = PluginTestVerifierHolder.getInstance();
+            verifier.printCache();
+
+            verifier.verifyTrace(event(serviceType, "com.zaxxer.hikari.HikariDataSource.HikariDataSource(com.zaxxer.hikari.HikariConfig)"));
+            verifier.verifyTrace(event(serviceType, "com.zaxxer.hikari.pool.BaseHikariPool.BaseHikariPool(com.zaxxer.hikari.HikariConfig, java.lang.String, java.lang.String)"));
+            verifier.verifyTrace(event(serviceType, getConnectionMethod1));
+            verifier.verifyTrace(event(serviceType, proxyConnectionMethod));
+        } finally {
+            if (dataSource != null) {
+                dataSource.close();
+            }
         }
     }
 
     @Test
-    public void testIdleTimeout4() throws InterruptedException, SQLException, NoSuchMethodException {
-        Connection connection = dataSource.getConnection();
-        Assert.assertNotNull(connection);
+    public void defaultTest2() throws InterruptedException, SQLException, NoSuchMethodException {
+        HikariDataSource dataSource = new HikariDataSource();
+        dataSource.setDataSourceClassName(DATA_SOURCE_CLASS_NAME);
+        dataSource.addDataSourceProperty("url", JDBC_URL);
 
-        Thread.sleep(500);
+        try {
+            Connection connection = dataSource.getConnection();
+            Assert.assertNotNull(connection);
 
-        connection.close();
+            Thread.sleep(500);
 
-        Thread.sleep(500);
+            connection.close();
 
-        Method getConnection = HikariDataSource.class.getDeclaredMethod("getConnection");
-        Method proxyConnection = ConnectionProxy.class.getDeclaredMethod("close");
+            Thread.sleep(500);
 
-        PluginTestVerifier verifier = PluginTestVerifierHolder.getInstance();
-        verifier.printCache();
+            PluginTestVerifier verifier = PluginTestVerifierHolder.getInstance();
+            verifier.printCache();
 
-        verifier.verifyTrace(event(serviceType, getConnection));
-        verifier.verifyTrace(event(serviceType, proxyConnection));
+            verifier.verifyTrace(event(serviceType, "com.zaxxer.hikari.HikariDataSource.HikariDataSource()"));
+            verifier.verifyTrace(event(serviceType, getConnectionMethod1));
+            verifier.verifyTrace(event(serviceType, "com.zaxxer.hikari.pool.BaseHikariPool.BaseHikariPool(com.zaxxer.hikari.HikariConfig, java.lang.String, java.lang.String)"));
+            verifier.verifyTrace(event(serviceType, proxyConnectionMethod));
+
+        } finally {
+            if (dataSource != null) {
+                dataSource.close();
+            }
+        }
+    }
+
+    @Test
+    public void defaultTest3() throws InterruptedException, SQLException, NoSuchMethodException {
+        HikariDataSource dataSource = new HikariDataSource();
+        dataSource.setDataSourceClassName(DATA_SOURCE_CLASS_NAME);
+        dataSource.addDataSourceProperty("url", JDBC_URL);
+
+        try {
+            Connection connection = dataSource.getConnection("", "");
+            Assert.assertNotNull(connection);
+
+            Thread.sleep(500);
+
+            connection.close();
+
+            Thread.sleep(500);
+
+            PluginTestVerifier verifier = PluginTestVerifierHolder.getInstance();
+            verifier.printCache();
+
+            verifier.verifyTrace(event(serviceType, "com.zaxxer.hikari.HikariDataSource.HikariDataSource()"));
+            verifier.verifyTrace(event(serviceType, getConnectionMethod2, annotation(AnnotationKey.ARGS0.getName(), "")));
+            verifier.verifyTrace(event(serviceType, proxyConnectionMethod));
+        } finally {
+            if (dataSource != null) {
+                dataSource.close();
+            }
+        }
     }
 
 }

--- a/plugins/hikaricp/src/main/java/com/navercorp/pinpoint/plugin/hikaricp/HikariCpConstants.java
+++ b/plugins/hikaricp/src/main/java/com/navercorp/pinpoint/plugin/hikaricp/HikariCpConstants.java
@@ -25,10 +25,13 @@ import com.navercorp.pinpoint.common.trace.ServiceTypeFactory;
 public final class HikariCpConstants {
 
     public static final String SCOPE = "HIKARICP_SCOPE";
+    public static final String SCOPE_DEPRECATED = "DEPRECATED_HIKARICP_SCOPE";
 
     public static final ServiceType SERVICE_TYPE = ServiceTypeFactory.of(6060, "HIKARICP");
 
     public static final String ACCESSOR_DATASOURCE_MONITOR = "com.navercorp.pinpoint.plugin.hikaricp.DataSourceMonitorAccessor";
+
+    public static final String INTERCEPTOR_BASIC = "com.navercorp.pinpoint.bootstrap.interceptor.BasicMethodInterceptor";
 
     public static final String INTERCEPTOR_CONSTRUCTOR = "com.navercorp.pinpoint.plugin.hikaricp.interceptor.DataSourceConstructorInterceptor";
     public static final String INTERCEPTOR_CLOSE = "com.navercorp.pinpoint.plugin.hikaricp.interceptor.DataSourceCloseInterceptor";

--- a/plugins/hikaricp/src/main/java/com/navercorp/pinpoint/plugin/hikaricp/interceptor/DataSourceConstructorInterceptor.java
+++ b/plugins/hikaricp/src/main/java/com/navercorp/pinpoint/plugin/hikaricp/interceptor/DataSourceConstructorInterceptor.java
@@ -16,35 +16,43 @@
 
 package com.navercorp.pinpoint.plugin.hikaricp.interceptor;
 
-import com.navercorp.pinpoint.bootstrap.interceptor.AroundInterceptor;
+import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
+import com.navercorp.pinpoint.bootstrap.context.SpanEventRecorder;
+import com.navercorp.pinpoint.bootstrap.context.TraceContext;
+import com.navercorp.pinpoint.bootstrap.interceptor.SpanEventSimpleAroundInterceptorForPlugin;
 import com.navercorp.pinpoint.bootstrap.logging.PLogger;
 import com.navercorp.pinpoint.bootstrap.logging.PLoggerFactory;
 import com.navercorp.pinpoint.bootstrap.plugin.monitor.DataSourceMonitorRegistry;
 import com.navercorp.pinpoint.bootstrap.util.InterceptorUtils;
 import com.navercorp.pinpoint.plugin.hikaricp.DataSourceMonitorAccessor;
+import com.navercorp.pinpoint.plugin.hikaricp.HikariCpConstants;
 import com.navercorp.pinpoint.plugin.hikaricp.HikariCpDataSourceMonitor;
 
 import java.lang.reflect.Method;
+import java.util.Properties;
 
 /**
  * @author Taejin Koo
  */
-public class DataSourceConstructorInterceptor implements AroundInterceptor {
+public class DataSourceConstructorInterceptor extends SpanEventSimpleAroundInterceptorForPlugin {
 
     private final PLogger logger = PLoggerFactory.getLogger(getClass());
+    private final boolean isDebug = logger.isDebugEnabled();
 
     private final DataSourceMonitorRegistry dataSourceMonitorRegistry;
 
-    public DataSourceConstructorInterceptor(DataSourceMonitorRegistry dataSourceMonitorRegistry) {
+    public DataSourceConstructorInterceptor(TraceContext traceContext, MethodDescriptor descriptor, DataSourceMonitorRegistry dataSourceMonitorRegistry) {
+        super(traceContext, descriptor);
         this.dataSourceMonitorRegistry = dataSourceMonitorRegistry;
     }
 
     @Override
-    public void before(Object target, Object[] args) {
+    protected void doInBeforeTrace(SpanEventRecorder recorder, Object target, Object[] args) {
     }
 
     @Override
-    public void after(Object target, Object[] args, Object result, Throwable throwable) {
+    protected void prepareAfterTrace(Object target, Object[] args, Object result, Throwable throwable) {
+        // create DataSourceMonitor object even if it is not being traced
         if (!InterceptorUtils.isSuccess(throwable)) {
             return;
         }
@@ -52,11 +60,21 @@ public class DataSourceConstructorInterceptor implements AroundInterceptor {
         if (args.length >= 1) {
             try {
                 String jdbcUrl = getJdbcUrl(args[0]);
-                HikariCpDataSourceMonitor dataSourceMonitor = new HikariCpDataSourceMonitor(target, jdbcUrl);
-                dataSourceMonitorRegistry.register(dataSourceMonitor);
+                if (jdbcUrl == null) {
+                    jdbcUrl = findJdbcUrl(args[0]);
+                }
 
-                if (target instanceof DataSourceMonitorAccessor) {
-                    ((DataSourceMonitorAccessor) target)._$PINPOINT$_setDataSourceMonitor(dataSourceMonitor);
+                if (jdbcUrl != null) {
+                    HikariCpDataSourceMonitor dataSourceMonitor = new HikariCpDataSourceMonitor(target, jdbcUrl);
+                    dataSourceMonitorRegistry.register(dataSourceMonitor);
+
+                    if (target instanceof DataSourceMonitorAccessor) {
+                        ((DataSourceMonitorAccessor) target)._$PINPOINT$_setDataSourceMonitor(dataSourceMonitor);
+                    }
+
+                    logger.debug("create HikariCpDataSourceMonitor success. jdbcUrl:{}", jdbcUrl);
+                } else {
+                    logger.info("failed while creating HikariCpDataSourceMonitor. can't find jdbclUrl");
                 }
             } catch (Exception e) {
                 logger.info("failed while creating HikariCpDataSourceMonitor. message:{}", e.getMessage(), e);
@@ -65,21 +83,52 @@ public class DataSourceConstructorInterceptor implements AroundInterceptor {
     }
 
     private String getJdbcUrl(Object object) {
+        // get JdbcUrl using getJdbcUrl method
+        if (object == null) {
+            return null;
+        }
+
         try {
-            if (object == null) {
-                return null;
-            }
-
             Method getJdbcUrl = object.getClass().getMethod("getJdbcUrl");
-            if (getJdbcUrl == null) {
+            if (getJdbcUrl != null) {
+                Object result = getJdbcUrl.invoke(object);
+                if (result instanceof String) {
+                    return (String) result;
+                }
                 return null;
             }
-
-            return String.valueOf(getJdbcUrl.invoke(object));
         } catch (Exception e) {
             logger.info("failed while executing getJdbcUrl(). message:{}", e.getMessage(), e);
         }
         return null;
+    }
+
+    private String findJdbcUrl(Object object) {
+        // find jdbcUrl in dataSourceProperties
+        if (object == null) {
+            return null;
+        }
+
+        try {
+            Method getDataSourceProperties = object.getClass().getMethod("getDataSourceProperties");
+            if (getDataSourceProperties != null) {
+                Object result = getDataSourceProperties.invoke(object);
+                if (result instanceof Properties) {
+                    return ((Properties) result).getProperty("url");
+                }
+                return null;
+            }
+        } catch (Exception e) {
+            logger.info("failed while executing getJdbcUrl(). message:{}", e.getMessage(), e);
+        }
+        return null;
+    }
+
+    @Override
+    protected void doInAfterTrace(SpanEventRecorder recorder, Object target, Object[] args, Object result, Throwable throwable) {
+        recorder.recordServiceType(HikariCpConstants.SERVICE_TYPE);
+        recorder.recordApi(getMethodDescriptor());
+        recorder.recordException(throwable);
     }
 
 }


### PR DESCRIPTION
1. trace support to create HikaiPool using com.zaxxer.hikari.HikariDataSource.getConnection() method