### PR TITLE
Adds additional information on configuring hystrix plugin

### DIFF
--- a/agent/src/main/resources-local/pinpoint.config
+++ b/agent/src/main/resources-local/pinpoint.config
@@ -678,6 +678,7 @@ profiler.rxjava=true
 ###########################################################
 # Hystrix
 ###########################################################
+# profiler.rxjava must also be enabled to properly trace hystrix commands
 profiler.hystrix=true
 
 ###########################################################

--- a/agent/src/main/resources-release/pinpoint.config
+++ b/agent/src/main/resources-release/pinpoint.config
@@ -675,6 +675,7 @@ profiler.rxjava=false
 ###########################################################
 # Hystrix
 ###########################################################
+# profiler.rxjava must also be enabled to properly trace hystrix commands
 profiler.hystrix=false
 
 ###########################################################


### PR DESCRIPTION
To trace Hystrix commands, rxjava plugin must also be enabled.
Explicitly stating this directly on the configuration file would be the easiest way to let users be aware of this.