### PR TITLE
Applies context root for quickstart modules

### DIFF
--- a/quickstart/bin/start-collector.sh
+++ b/quickstart/bin/start-collector.sh
@@ -38,6 +38,7 @@ CLOSE_WAIT_TIME=`expr $UNIT_TIME \* $CHECK_COUNT`
 
 PROPERTIES=`cat $CONF_DIR/$CONF_FILE 2>/dev/null`
 KEY_VERSION="quickstart.version"
+KEY_CONTEXT_PATH="quickstart.collector.context.path"
 KEY_PORT="quickstart.collector.port"
 
 function func_read_properties
@@ -112,8 +113,12 @@ function func_init_log
 
 function func_check_running_pinpoint_collector
 {
+    context_path=$( func_read_properties "$KEY_CONTEXT_PATH" )
+    if [ "$context_path" == "/" ]; then
+            context_path=""
+    fi
     port=$( func_read_properties "$KEY_PORT" )
-    check_url="http://localhost:"$port"/serverTime.pinpoint"
+    check_url="http://localhost:$port$context_path/serverTime.pinpoint"
 
     process_status=`curl $check_url 2>/dev/null | grep 'currentServerTime'`
 

--- a/quickstart/bin/start-testapp.sh
+++ b/quickstart/bin/start-testapp.sh
@@ -48,6 +48,7 @@ CLOSE_WAIT_TIME=`expr $UNIT_TIME \* $CHECK_COUNT`
 
 PROPERTIES=`cat $CONF_DIR/$CONF_FILE 2>/dev/null`
 KEY_VERSION="quickstart.version"
+KEY_CONTEXT_PATH="quickstart.testapp.context.path"
 KEY_PORT="quickstart.testapp.port"
 
 function func_read_properties
@@ -147,8 +148,12 @@ function func_start_pinpoint_testapp
         pinpoint_opt="-javaagent:$pinpoint_agent -Dpinpoint.agentId=test-agent -Dpinpoint.applicationName=TESTAPP"
         export MAVEN_OPTS=$pinpoint_opt
 
+        context_path=$( func_read_properties "$KEY_CONTEXT_PATH" )
+        if [ "$context_path" == "/" ]; then
+                context_path=""
+        fi
         port=$( func_read_properties "$KEY_PORT" )
-        check_url="http://localhost:"$port"/getCurrentTimestamp.pinpoint"
+        check_url="http://localhost:$port$context_path/getCurrentTimestamp.pinpoint"
 
         pid=`nohup ${bin}/../../mvnw -f $TESTAPP_DIR/pom.xml clean package tomcat7:run -D$IDENTIFIER -Dmaven.pinpoint.version=$version >> $LOGS_DIR/$LOG_FILE 2>&1 & echo $!`
         echo $pid > $PID_DIR/$PID_FILE

--- a/quickstart/bin/start-web.sh
+++ b/quickstart/bin/start-web.sh
@@ -38,6 +38,7 @@ CLOSE_WAIT_TIME=`expr $UNIT_TIME \* $CHECK_COUNT`
 
 PROPERTIES=`cat $CONF_DIR/$CONF_FILE 2>/dev/null`
 KEY_VERSION="quickstart.version"
+KEY_CONTEXT_PATH="quickstart.web.context.path"
 KEY_PORT="quickstart.web.port"
 
 function func_read_properties
@@ -112,9 +113,13 @@ function func_init_log
 function func_start_pinpoint_web
 {
     version=$( func_read_properties "$KEY_VERSION" )
+    context_path=$( func_read_properties "$KEY_CONTEXT_PATH" )
+    if [ "$context_path" == "/" ]; then
+            context_path=""
+    fi
     port=$( func_read_properties "$KEY_PORT" )
     pid=`nohup ${bin}/../../mvnw -f $WEB_DIR/pom.xml clean package tomcat7:run -D$IDENTIFIER -Dmaven.pinpoint.version=$version > $LOGS_DIR/$LOG_FILE 2>&1 & echo $!`
-    check_url="http://localhost:"$port"/serverTime.pinpoint"
+    check_url="http://localhost:$port$context_path/serverTime.pinpoint"
     echo $pid > $PID_DIR/$PID_FILE
 
     echo "---$WEB_IDENTIFIER initialization started. pid=$pid.---"

--- a/quickstart/testapp/src/main/webapp/WEB-INF/views/apis.jsp
+++ b/quickstart/testapp/src/main/webapp/WEB-INF/views/apis.jsp
@@ -16,7 +16,7 @@
                         <h5>${apiMapping.key}</h5>
                         <dl>
                             <c:forEach items="${apiMapping.value}" var="api">
-                            <dt><a href="${api.mappedUri}.pinpoint">${api.mappedUri}</a></dt>
+                            <dt><a href="${pageContext.request.contextPath}${api.mappedUri}.pinpoint">${api.mappedUri}</a></dt>
                             <dd><small>${api.description}</small></dd>
                             </c:forEach>
                         </dl>


### PR DESCRIPTION
* Health check urls in startup scripts takes context path into account if configured.
* Links in test app UI are generated properly with context path prepended.