### PR TITLE
Fixes random RabbitMQ plugin IT failures

### DIFF
--- a/agent/src/test/java/com/navercorp/pinpoint/plugin/jdk7/rabbitmq/util/RabbitMQTestConstants.java
+++ b/agent/src/test/java/com/navercorp/pinpoint/plugin/jdk7/rabbitmq/util/RabbitMQTestConstants.java
@@ -26,7 +26,7 @@ import com.rabbitmq.client.impl.LongStringHelper;
  */
 public interface RabbitMQTestConstants {
 
-    String BROKER_HOST = "localhost";
+    String BROKER_HOST = "127.0.0.1";
     int BROKER_PORT = 20179;
 
     String RABBITMQ_CLIENT = "RABBITMQ_CLIENT";


### PR DESCRIPTION
When AutorecoveringConnection is used, it shuffles the IPs mapped to a domain randomly and uses it. IT connections are made against 'localhost' and this may be resolved to more than 1 IP, which was causing random test failures.