### PR TITLE
Adds additional trace support for Spring-amqp-rabbitmq

### DIFF
--- a/agent/pom.xml
+++ b/agent/pom.xml
@@ -262,9 +262,9 @@
 
         <!-- for rabbitmq -->
         <dependency>
-            <groupId>com.rabbitmq</groupId>
-            <artifactId>amqp-client</artifactId>
-            <version>4.4.2</version>
+            <groupId>org.springframework.amqp</groupId>
+            <artifactId>spring-rabbit</artifactId>
+            <version>1.7.5.RELEASE</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/agent/src/test/java/com/navercorp/pinpoint/plugin/jdk7/rabbitmq/spring/SpringAmqpRabbitTestRunner.java
+++ b/agent/src/test/java/com/navercorp/pinpoint/plugin/jdk7/rabbitmq/spring/SpringAmqpRabbitTestRunner.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2018 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.plugin.jdk7.rabbitmq.spring;
+
+import com.navercorp.pinpoint.bootstrap.plugin.test.PluginTestVerifier;
+import com.navercorp.pinpoint.bootstrap.plugin.test.PluginTestVerifierHolder;
+import com.navercorp.pinpoint.plugin.jdk7.rabbitmq.util.RabbitMQTestConstants;
+import com.navercorp.test.pinpoint.plugin.rabbitmq.MessageConverter;
+import com.navercorp.test.pinpoint.plugin.rabbitmq.spring.TestMessageHolder;
+import com.navercorp.test.pinpoint.plugin.rabbitmq.spring.service.TestReceiverService;
+import com.navercorp.test.pinpoint.plugin.rabbitmq.spring.service.TestSenderService;
+import org.junit.Assert;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * @author HyunGil Jeong
+ */
+public class SpringAmqpRabbitTestRunner {
+
+    private static final long TRACE_WAIT_TIME_MS = 3000L;
+
+    private final TestSenderService testSenderService;
+    private final TestReceiverService testReceiverService;
+    private final TestMessageHolder testMessageHolder;
+    private final ConnectionFactory connectionFactory;
+    private final String remoteAddress;
+
+    SpringAmqpRabbitTestRunner(TestApplicationContext context) {
+        if (context == null) {
+            throw new NullPointerException("context must not be null");
+        }
+        this.testSenderService = context.getTestSenderService();
+        this.testMessageHolder = context.getTestMessageHolder();
+        this.testReceiverService = context.getTestReceiverService();
+        this.connectionFactory = context.getConnectionFactory();
+        this.remoteAddress = connectionFactory.getHost() + ":" + connectionFactory.getPort();
+    }
+
+    String getRemoteAddress() {
+        return remoteAddress;
+    }
+
+    PluginTestVerifier runPush(int expectedTraceCount) throws InterruptedException {
+        final String message = "hello rabbit mq";
+
+        testSenderService.sendMessage(RabbitMQTestConstants.EXCHANGE, RabbitMQTestConstants.ROUTING_KEY_PUSH, message);
+        Assert.assertEquals(message, testMessageHolder.getMessage(10, TimeUnit.SECONDS));
+
+        PluginTestVerifier verifier = PluginTestVerifierHolder.getInstance();
+        // Wait till all traces are recorded (consumer traces are recorded from another thread)
+        awaitAndVerifyTraceCount(verifier, expectedTraceCount, TRACE_WAIT_TIME_MS);
+        return verifier;
+    }
+
+    PluginTestVerifier runPull(int expectedTraceCount) throws InterruptedException {
+        final String message = "hello rabbit mq!";
+
+        testSenderService.sendMessage(RabbitMQTestConstants.EXCHANGE, RabbitMQTestConstants.ROUTING_KEY_PULL, message);
+        Assert.assertEquals(message, testReceiverService.receiveMessage(MessageConverter.FOR_TEST));
+
+        PluginTestVerifier verifier = PluginTestVerifierHolder.getInstance();
+        // Wait till all traces are recorded (consumer traces are recorded from another thread)
+        awaitAndVerifyTraceCount(verifier, expectedTraceCount, TRACE_WAIT_TIME_MS);
+        return verifier;
+    }
+
+    PluginTestVerifier runPull(int expectedTraceCount, long timeoutMs) throws InterruptedException {
+        final String message = "hello rabbit mq!";
+
+        testSenderService.sendMessage(RabbitMQTestConstants.EXCHANGE, RabbitMQTestConstants.ROUTING_KEY_PULL, message);
+        Assert.assertEquals(message, testReceiverService.receiveMessage(MessageConverter.FOR_TEST, timeoutMs));
+
+        PluginTestVerifier verifier = PluginTestVerifierHolder.getInstance();
+        // Wait till all traces are recorded (consumer traces are recorded from another thread)
+        awaitAndVerifyTraceCount(verifier, expectedTraceCount, TRACE_WAIT_TIME_MS);
+        return verifier;
+    }
+
+    private static void awaitAndVerifyTraceCount(PluginTestVerifier verifier, int expectedTraceCount, long maxWaitMs) throws InterruptedException {
+        final long waitIntervalMs = 100L;
+        long maxWaitTime = maxWaitMs;
+        if (maxWaitMs < waitIntervalMs) {
+            maxWaitTime = waitIntervalMs;
+        }
+        long startTime = System.currentTimeMillis();
+        try {
+            while (System.currentTimeMillis() - startTime < maxWaitTime) {
+                try {
+                    verifier.verifyTraceCount(expectedTraceCount);
+                    return;
+                } catch (AssertionError e) {
+                    // ignore and retry
+                    Thread.sleep(waitIntervalMs);
+                }
+            }
+            verifier.verifyTraceCount(expectedTraceCount);
+        } finally {
+            verifier.printCache();
+        }
+    }
+}

--- a/agent/src/test/java/com/navercorp/pinpoint/plugin/jdk7/rabbitmq/spring/SpringAmqpRabbit_1_3_3_to_1_4_2_IT.java
+++ b/agent/src/test/java/com/navercorp/pinpoint/plugin/jdk7/rabbitmq/spring/SpringAmqpRabbit_1_3_3_to_1_4_2_IT.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright 2018 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.plugin.jdk7.rabbitmq.spring;
+
+import com.navercorp.pinpoint.bootstrap.plugin.test.Expectations;
+import com.navercorp.pinpoint.bootstrap.plugin.test.ExpectedTrace;
+import com.navercorp.pinpoint.bootstrap.plugin.test.PluginTestVerifier;
+import com.navercorp.pinpoint.common.trace.ServiceType;
+import com.navercorp.test.pinpoint.plugin.rabbitmq.spring.config.CommonConfig;
+import com.navercorp.test.pinpoint.plugin.rabbitmq.spring.config.MessageListenerConfig_Pre_1_4_0;
+import com.navercorp.test.pinpoint.plugin.rabbitmq.spring.config.ReceiverConfig_Pre_1_6_0;
+import com.navercorp.pinpoint.plugin.jdk7.rabbitmq.util.RabbitMQTestConstants;
+import com.navercorp.pinpoint.plugin.jdk7.rabbitmq.util.TestBroker;
+import com.navercorp.pinpoint.test.plugin.Dependency;
+import com.navercorp.pinpoint.test.plugin.JvmArgument;
+import com.navercorp.pinpoint.test.plugin.PinpointConfig;
+import com.navercorp.pinpoint.test.plugin.PinpointPluginTestSuite;
+import com.navercorp.test.pinpoint.plugin.rabbitmq.PropagationMarker;
+import com.rabbitmq.client.AMQP;
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.Consumer;
+import com.rabbitmq.client.Envelope;
+import com.rabbitmq.client.impl.AMQCommand;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.amqp.core.Message;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+
+/**
+ * @author HyunGil Jeong
+ */
+@RunWith(PinpointPluginTestSuite.class)
+@PinpointConfig("rabbitmq/client/pinpoint-rabbitmq.config")
+@Dependency({"org.springframework.amqp:spring-rabbit:[1.3.3.RELEASE,1.4.2.RELEASE)", "com.fasterxml.jackson.core:jackson-core:2.8.11", "org.apache.qpid:qpid-broker:6.1.1"})
+@JvmArgument({"-Dpinpoint.configcenter=false"})
+public class SpringAmqpRabbit_1_3_3_to_1_4_2_IT {
+
+    private static final TestBroker BROKER = new TestBroker();
+    private static final TestApplicationContext CONTEXT = new TestApplicationContext();
+
+    private final SpringAmqpRabbitTestRunner testRunner = new SpringAmqpRabbitTestRunner(CONTEXT);
+
+    @BeforeClass
+    public static void setUpBeforeClass() throws Exception {
+        BROKER.start();
+        CONTEXT.init(
+                CommonConfig.class,
+                MessageListenerConfig_Pre_1_4_0.class,
+                ReceiverConfig_Pre_1_6_0.class);
+    }
+
+    @AfterClass
+    public static void tearDownAfterClass() {
+        CONTEXT.close();
+        BROKER.shutdown();
+    }
+
+    @Test
+    public void testPush() throws Exception {
+        final String remoteAddress = testRunner.getRemoteAddress();
+
+        Class<?> rabbitTemplateClass = Class.forName("org.springframework.amqp.rabbit.core.RabbitTemplate");
+        Method rabbitTemplateConvertAndSend = rabbitTemplateClass.getDeclaredMethod("convertAndSend", String.class, String.class, Object.class);
+        ExpectedTrace rabbitTemplateConvertAndSendTrace = Expectations.event(
+                RabbitMQTestConstants.RABBITMQ_CLIENT_INTERNAL, // serviceType
+                rabbitTemplateConvertAndSend); // method
+        // automatic recovery deliberately disabled as Spring has it's own recovery mechanism
+        Class<?> channelNClass = Class.forName("com.rabbitmq.client.impl.ChannelN");
+        Method channelNBasicPublish = channelNClass.getDeclaredMethod("basicPublish", String.class, String.class, boolean.class, boolean.class, AMQP.BasicProperties.class, byte[].class);
+        ExpectedTrace channelNBasicPublishTrace = Expectations.event(
+                RabbitMQTestConstants.RABBITMQ_CLIENT, // serviceType
+                channelNBasicPublish, // method
+                null, // rpc
+                remoteAddress, // endPoint
+                "exchange-" + RabbitMQTestConstants.EXCHANGE, // destinationId
+                Expectations.annotation("rabbitmq.exchange", RabbitMQTestConstants.EXCHANGE),
+                Expectations.annotation("rabbitmq.routingkey", RabbitMQTestConstants.ROUTING_KEY_PUSH));
+        ExpectedTrace rabbitMqConsumerInvocationTrace = Expectations.root(
+                RabbitMQTestConstants.RABBITMQ_CLIENT, // serviceType
+                "RabbitMQ Consumer Invocation", // method
+                "rabbitmq://exchange=" + RabbitMQTestConstants.EXCHANGE, // rpc
+                null, // endPoint (collected but API to retrieve local address is not available in all versions, so skip)
+                remoteAddress, // remoteAddress
+                Expectations.annotation("rabbitmq.routingkey", RabbitMQTestConstants.ROUTING_KEY_PUSH));
+        Class<?> consumerDispatcherClass = Class.forName("com.rabbitmq.client.impl.ConsumerDispatcher");
+        Method consumerDispatcherHandleDelivery = consumerDispatcherClass.getDeclaredMethod("handleDelivery", Consumer.class, String.class, Envelope.class, AMQP.BasicProperties.class, byte[].class);
+        ExpectedTrace consumerDispatcherHandleDeliveryTrace = Expectations.event(
+                RabbitMQTestConstants.RABBITMQ_CLIENT_INTERNAL, // serviceType
+                consumerDispatcherHandleDelivery); // method
+        ExpectedTrace asynchronousInvocationTrace = Expectations.event(
+                ServiceType.ASYNC.getName(),
+                "Asynchronous Invocation");
+        Class<?> blockingQueueConsumerInternalConsumerClass = Class.forName("org.springframework.amqp.rabbit.listener.BlockingQueueConsumer$InternalConsumer");
+        Method blockingQueueConsumerInternalConsumerHandleDelivery = blockingQueueConsumerInternalConsumerClass.getDeclaredMethod("handleDelivery", String.class, Envelope.class, AMQP.BasicProperties.class, byte[].class);
+        ExpectedTrace blockingQueueConsumerInternalConsumerHandleDeliveryTrace = Expectations.event(
+                RabbitMQTestConstants.RABBITMQ_CLIENT_INTERNAL, // serviceType
+                blockingQueueConsumerInternalConsumerHandleDelivery);
+        Class<?> deliveryClass = Class.forName("org.springframework.amqp.rabbit.listener.BlockingQueueConsumer$Delivery");
+        Constructor<?> deliveryConstructor = deliveryClass.getDeclaredConstructor(Envelope.class, AMQP.BasicProperties.class, byte[].class);
+        ExpectedTrace deliveryConstructorTrace = Expectations.event(
+                RabbitMQTestConstants.RABBITMQ_CLIENT_INTERNAL, // serviceType
+                deliveryConstructor);
+        Class<?> abstractMessageListenerContainerClass = Class.forName("org.springframework.amqp.rabbit.listener.AbstractMessageListenerContainer");
+        Method abstractMessageListenerContainerExecuteListener = abstractMessageListenerContainerClass.getDeclaredMethod("executeListener", Channel.class, Message.class);
+        ExpectedTrace abstractMessageListenerContainerExecuteListenerTrace = Expectations.event(
+                ServiceType.INTERNAL_METHOD.getName(),
+                abstractMessageListenerContainerExecuteListener);
+        Class<?> propagationMarkerClass = PropagationMarker.class;
+        Method propagationMarkerMark = propagationMarkerClass.getDeclaredMethod("mark");
+        ExpectedTrace markTrace = Expectations.event(
+                ServiceType.INTERNAL_METHOD.getName(),
+                propagationMarkerMark);
+
+        ExpectedTrace[] expectedTraces = {
+                rabbitTemplateConvertAndSendTrace,
+                channelNBasicPublishTrace,
+                rabbitMqConsumerInvocationTrace,
+                consumerDispatcherHandleDeliveryTrace,
+                asynchronousInvocationTrace,
+                blockingQueueConsumerInternalConsumerHandleDeliveryTrace,
+                deliveryConstructorTrace,
+                asynchronousInvocationTrace,
+                abstractMessageListenerContainerExecuteListenerTrace,
+                markTrace
+        };
+
+        final PluginTestVerifier verifier = testRunner.runPush(expectedTraces.length);
+
+        verifier.verifyTrace(expectedTraces);
+        verifier.verifyTraceCount(0);
+    }
+
+    @Test
+    public void testPull() throws Exception {
+        final String remoteAddress = testRunner.getRemoteAddress();
+
+        Class<?> rabbitTemplateClass = Class.forName("org.springframework.amqp.rabbit.core.RabbitTemplate");
+        // verify queue-initiated traces
+        Method rabbitTemplateConvertAndSend = rabbitTemplateClass.getDeclaredMethod("convertAndSend", String.class, String.class, Object.class);
+        ExpectedTrace rabbitTemplateConvertAndSendTrace = Expectations.event(
+                RabbitMQTestConstants.RABBITMQ_CLIENT_INTERNAL, // serviceType
+                rabbitTemplateConvertAndSend); // method
+        // automatic recovery deliberately disabled as Spring has it's own recovery mechanism
+        Class<?> channelNClass = Class.forName("com.rabbitmq.client.impl.ChannelN");
+        Method channelNBasicPublish = channelNClass.getDeclaredMethod("basicPublish", String.class, String.class, boolean.class, boolean.class, AMQP.BasicProperties.class, byte[].class);
+        ExpectedTrace channelNBasicPublishTrace = Expectations.event(
+                RabbitMQTestConstants.RABBITMQ_CLIENT, // serviceType
+                channelNBasicPublish, // method
+                null, // rpc
+                remoteAddress, // endPoint
+                "exchange-" + RabbitMQTestConstants.EXCHANGE, // destinationId
+                Expectations.annotation("rabbitmq.exchange", RabbitMQTestConstants.EXCHANGE),
+                Expectations.annotation("rabbitmq.routingkey", RabbitMQTestConstants.ROUTING_KEY_PULL));
+        ExpectedTrace rabbitMqConsumerInvocationTrace = Expectations.root(
+                RabbitMQTestConstants.RABBITMQ_CLIENT, // serviceType
+                "RabbitMQ Consumer Invocation", // method
+                "rabbitmq://exchange=" + RabbitMQTestConstants.EXCHANGE, // rpc
+                null, // endPoint (collected but API to retrieve local address is not available in all versions, so skip)
+                remoteAddress, // remoteAddress
+                Expectations.annotation("rabbitmq.routingkey", RabbitMQTestConstants.ROUTING_KEY_PULL));
+        Class<?> amqChannelClass = Class.forName("com.rabbitmq.client.impl.AMQChannel");
+        Method amqChannelHandleCompleteInboundCommand = amqChannelClass.getDeclaredMethod("handleCompleteInboundCommand", AMQCommand.class);
+        ExpectedTrace amqChannelHandleCompleteInboundCommandTrace = Expectations.event(
+                RabbitMQTestConstants.RABBITMQ_CLIENT_INTERNAL, // method
+                amqChannelHandleCompleteInboundCommand);
+
+        ExpectedTrace[] queueInitiatedTraces = {
+                rabbitTemplateConvertAndSendTrace,
+                channelNBasicPublishTrace,
+                rabbitMqConsumerInvocationTrace,
+                amqChannelHandleCompleteInboundCommandTrace
+        };
+
+        // verify client-initiated traces
+        Method rabbitTemplateReceive = rabbitTemplateClass.getDeclaredMethod("receive", String.class);
+        ExpectedTrace rabbitTemplateReceiveTrace = Expectations.event(
+                RabbitMQTestConstants.RABBITMQ_CLIENT_INTERNAL, // serviceType
+                rabbitTemplateReceive); // method
+        Method channelNBasicGet = channelNClass.getDeclaredMethod("basicGet", String.class, boolean.class);
+        ExpectedTrace channelNBasicGetTrace = Expectations.event(
+                RabbitMQTestConstants.RABBITMQ_CLIENT_INTERNAL,
+                channelNBasicGet);
+        Class<?> propagationMarkerClass = PropagationMarker.class;
+        Method propagationMarkerMark = propagationMarkerClass.getDeclaredMethod("mark");
+        ExpectedTrace markTrace = Expectations.event(
+                ServiceType.INTERNAL_METHOD.getName(),
+                propagationMarkerMark);
+
+        ExpectedTrace[] clientInitiatedTraces = {
+                rabbitTemplateReceiveTrace,
+                channelNBasicGetTrace,
+                markTrace
+        };
+
+        int expectedTraceCount = queueInitiatedTraces.length + clientInitiatedTraces.length;
+        final PluginTestVerifier verifier = testRunner.runPull(expectedTraceCount);
+
+        verifier.verifyDiscreteTrace(queueInitiatedTraces);
+        verifier.verifyDiscreteTrace(clientInitiatedTraces);
+
+        verifier.verifyTraceCount(0);
+    }
+}

--- a/agent/src/test/java/com/navercorp/pinpoint/plugin/jdk7/rabbitmq/spring/SpringAmqpRabbit_1_4_2_to_1_7_0_IT.java
+++ b/agent/src/test/java/com/navercorp/pinpoint/plugin/jdk7/rabbitmq/spring/SpringAmqpRabbit_1_4_2_to_1_7_0_IT.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright 2018 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.plugin.jdk7.rabbitmq.spring;
+
+import com.navercorp.pinpoint.bootstrap.plugin.test.Expectations;
+import com.navercorp.pinpoint.bootstrap.plugin.test.ExpectedTrace;
+import com.navercorp.pinpoint.bootstrap.plugin.test.PluginTestVerifier;
+import com.navercorp.pinpoint.common.trace.ServiceType;
+import com.navercorp.test.pinpoint.plugin.rabbitmq.spring.config.CommonConfig;
+import com.navercorp.test.pinpoint.plugin.rabbitmq.spring.config.MessageListenerConfig_Post_1_4_0;
+import com.navercorp.test.pinpoint.plugin.rabbitmq.spring.config.ReceiverConfig_Pre_1_6_0;
+import com.navercorp.pinpoint.plugin.jdk7.rabbitmq.util.RabbitMQTestConstants;
+import com.navercorp.pinpoint.plugin.jdk7.rabbitmq.util.TestBroker;
+import com.navercorp.pinpoint.test.plugin.Dependency;
+import com.navercorp.pinpoint.test.plugin.JvmArgument;
+import com.navercorp.pinpoint.test.plugin.PinpointConfig;
+import com.navercorp.pinpoint.test.plugin.PinpointPluginTestSuite;
+import com.navercorp.test.pinpoint.plugin.rabbitmq.PropagationMarker;
+import com.rabbitmq.client.AMQP;
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.Consumer;
+import com.rabbitmq.client.Envelope;
+import com.rabbitmq.client.impl.AMQCommand;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.amqp.core.Message;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+
+/**
+ * @author HyunGil Jeong
+ */
+@RunWith(PinpointPluginTestSuite.class)
+@PinpointConfig("rabbitmq/client/pinpoint-rabbitmq.config")
+// 1.4.5, 1.4.6, 1.6.4.RELEASE has dependency issues
+@Dependency({"org.springframework.amqp:spring-rabbit:[1.4.2.RELEASE,1.4.5.RELEASE),[1.5.0.RELEASE,1.6.4.RELEASE),[1.6.5.RELEASE,1.7.0.RELEASE)", "com.fasterxml.jackson.core:jackson-core:2.8.11", "org.apache.qpid:qpid-broker:6.1.1"})
+@JvmArgument({"-Dpinpoint.configcenter=false"})
+public class SpringAmqpRabbit_1_4_2_to_1_7_0_IT {
+
+    private static final TestBroker BROKER = new TestBroker();
+    private static final TestApplicationContext CONTEXT = new TestApplicationContext();
+
+    private final SpringAmqpRabbitTestRunner testRunner = new SpringAmqpRabbitTestRunner(CONTEXT);
+
+    @BeforeClass
+    public static void setUpBeforeClass() throws Exception {
+        BROKER.start();
+        CONTEXT.init(
+                CommonConfig.class,
+                MessageListenerConfig_Post_1_4_0.class,
+                ReceiverConfig_Pre_1_6_0.class);
+    }
+
+    @AfterClass
+    public static void tearDownAfterClass() {
+        CONTEXT.close();
+        BROKER.shutdown();
+    }
+
+    @Test
+    public void testPush() throws Exception {
+        final String remoteAddress = testRunner.getRemoteAddress();
+
+        Class<?> rabbitTemplateClass = Class.forName("org.springframework.amqp.rabbit.core.RabbitTemplate");
+        Method rabbitTemplateConvertAndSend = rabbitTemplateClass.getDeclaredMethod("convertAndSend", String.class, String.class, Object.class);
+        ExpectedTrace rabbitTemplateConvertAndSendTrace = Expectations.event(
+                RabbitMQTestConstants.RABBITMQ_CLIENT_INTERNAL, // serviceType
+                rabbitTemplateConvertAndSend); // method
+        // automatic recovery deliberately disabled as Spring has it's own recovery mechanism
+        Class<?> channelNClass = Class.forName("com.rabbitmq.client.impl.ChannelN");
+        Method channelNBasicPublish = channelNClass.getDeclaredMethod("basicPublish", String.class, String.class, boolean.class, boolean.class, AMQP.BasicProperties.class, byte[].class);
+        ExpectedTrace channelNBasicPublishTrace = Expectations.event(
+                RabbitMQTestConstants.RABBITMQ_CLIENT, // serviceType
+                channelNBasicPublish, // method
+                null, // rpc
+                remoteAddress, // endPoint
+                "exchange-" + RabbitMQTestConstants.EXCHANGE, // destinationId
+                Expectations.annotation("rabbitmq.exchange", RabbitMQTestConstants.EXCHANGE),
+                Expectations.annotation("rabbitmq.routingkey", RabbitMQTestConstants.ROUTING_KEY_PUSH));
+        ExpectedTrace rabbitMqConsumerInvocationTrace = Expectations.root(
+                RabbitMQTestConstants.RABBITMQ_CLIENT, // serviceType
+                "RabbitMQ Consumer Invocation", // method
+                "rabbitmq://exchange=" + RabbitMQTestConstants.EXCHANGE, // rpc
+                null, // endPoint (collected but API to retrieve local address is not available in all versions, so skip)
+                remoteAddress, // remoteAddress
+                Expectations.annotation("rabbitmq.routingkey", RabbitMQTestConstants.ROUTING_KEY_PUSH));
+        Class<?> consumerDispatcherClass = Class.forName("com.rabbitmq.client.impl.ConsumerDispatcher");
+        Method consumerDispatcherHandleDelivery = consumerDispatcherClass.getDeclaredMethod("handleDelivery", Consumer.class, String.class, Envelope.class, AMQP.BasicProperties.class, byte[].class);
+        ExpectedTrace consumerDispatcherHandleDeliveryTrace = Expectations.event(
+                RabbitMQTestConstants.RABBITMQ_CLIENT_INTERNAL, // serviceType
+                consumerDispatcherHandleDelivery); // method
+        ExpectedTrace asynchronousInvocationTrace = Expectations.event(
+                ServiceType.ASYNC.getName(),
+                "Asynchronous Invocation");
+        Class<?> blockingQueueConsumerInternalConsumerClass = Class.forName("org.springframework.amqp.rabbit.listener.BlockingQueueConsumer$InternalConsumer");
+        Method blockingQueueConsumerInternalConsumerHandleDelivery = blockingQueueConsumerInternalConsumerClass.getDeclaredMethod("handleDelivery", String.class, Envelope.class, AMQP.BasicProperties.class, byte[].class);
+        ExpectedTrace blockingQueueConsumerInternalConsumerHandleDeliveryTrace = Expectations.event(
+                RabbitMQTestConstants.RABBITMQ_CLIENT_INTERNAL, // serviceType
+                blockingQueueConsumerInternalConsumerHandleDelivery);
+        Class<?> deliveryClass = Class.forName("org.springframework.amqp.rabbit.listener.BlockingQueueConsumer$Delivery");
+        Constructor<?> deliveryConstructor = deliveryClass.getDeclaredConstructor(String.class, Envelope.class, AMQP.BasicProperties.class, byte[].class);
+        ExpectedTrace deliveryConstructorTrace = Expectations.event(
+                RabbitMQTestConstants.RABBITMQ_CLIENT_INTERNAL, // serviceType
+                deliveryConstructor);
+        Class<?> abstractMessageListenerContainerClass = Class.forName("org.springframework.amqp.rabbit.listener.AbstractMessageListenerContainer");
+        Method abstractMessageListenerContainerExecuteListener = abstractMessageListenerContainerClass.getDeclaredMethod("executeListener", Channel.class, Message.class);
+        ExpectedTrace abstractMessageListenerContainerExecuteListenerTrace = Expectations.event(
+                ServiceType.INTERNAL_METHOD.getName(),
+                abstractMessageListenerContainerExecuteListener);
+        Class<?> propagationMarkerClass = PropagationMarker.class;
+        Method propagationMarkerMark = propagationMarkerClass.getDeclaredMethod("mark");
+        ExpectedTrace markTrace = Expectations.event(
+                ServiceType.INTERNAL_METHOD.getName(),
+                propagationMarkerMark);
+
+        ExpectedTrace[] expectedTraces = {
+                rabbitTemplateConvertAndSendTrace,
+                channelNBasicPublishTrace,
+                rabbitMqConsumerInvocationTrace,
+                consumerDispatcherHandleDeliveryTrace,
+                asynchronousInvocationTrace,
+                blockingQueueConsumerInternalConsumerHandleDeliveryTrace,
+                deliveryConstructorTrace,
+                asynchronousInvocationTrace,
+                abstractMessageListenerContainerExecuteListenerTrace,
+                markTrace
+        };
+
+        final PluginTestVerifier verifier = testRunner.runPush(expectedTraces.length);
+
+        verifier.verifyTrace(expectedTraces);
+        verifier.verifyTraceCount(0);
+    }
+
+    @Test
+    public void testPull() throws Exception {
+        final String remoteAddress = testRunner.getRemoteAddress();
+
+        Class<?> rabbitTemplateClass = Class.forName("org.springframework.amqp.rabbit.core.RabbitTemplate");
+        // verify queue-initiated traces
+        Method rabbitTemplateConvertAndSend = rabbitTemplateClass.getDeclaredMethod("convertAndSend", String.class, String.class, Object.class);
+        ExpectedTrace rabbitTemplateConvertAndSendTrace = Expectations.event(
+                RabbitMQTestConstants.RABBITMQ_CLIENT_INTERNAL, // serviceType
+                rabbitTemplateConvertAndSend); // method
+        // automatic recovery deliberately disabled as Spring has it's own recovery mechanism
+        Class<?> channelNClass = Class.forName("com.rabbitmq.client.impl.ChannelN");
+        Method channelNBasicPublish = channelNClass.getDeclaredMethod("basicPublish", String.class, String.class, boolean.class, boolean.class, AMQP.BasicProperties.class, byte[].class);
+        ExpectedTrace channelNBasicPublishTrace = Expectations.event(
+                RabbitMQTestConstants.RABBITMQ_CLIENT, // serviceType
+                channelNBasicPublish, // method
+                null, // rpc
+                remoteAddress, // endPoint
+                "exchange-" + RabbitMQTestConstants.EXCHANGE, // destinationId
+                Expectations.annotation("rabbitmq.exchange", RabbitMQTestConstants.EXCHANGE),
+                Expectations.annotation("rabbitmq.routingkey", RabbitMQTestConstants.ROUTING_KEY_PULL));
+        ExpectedTrace rabbitMqConsumerInvocationTrace = Expectations.root(
+                RabbitMQTestConstants.RABBITMQ_CLIENT, // serviceType
+                "RabbitMQ Consumer Invocation", // method
+                "rabbitmq://exchange=" + RabbitMQTestConstants.EXCHANGE, // rpc
+                null, // endPoint (collected but API to retrieve local address is not available in all versions, so skip)
+                remoteAddress, // remoteAddress
+                Expectations.annotation("rabbitmq.routingkey", RabbitMQTestConstants.ROUTING_KEY_PULL));
+        Class<?> amqChannelClass = Class.forName("com.rabbitmq.client.impl.AMQChannel");
+        Method amqChannelHandleCompleteInboundCommand = amqChannelClass.getDeclaredMethod("handleCompleteInboundCommand", AMQCommand.class);
+        ExpectedTrace amqChannelHandleCompleteInboundCommandTrace = Expectations.event(
+                RabbitMQTestConstants.RABBITMQ_CLIENT_INTERNAL, // method
+                amqChannelHandleCompleteInboundCommand);
+
+        ExpectedTrace[] queueInitiatedTraces = {
+                rabbitTemplateConvertAndSendTrace,
+                channelNBasicPublishTrace,
+                rabbitMqConsumerInvocationTrace,
+                amqChannelHandleCompleteInboundCommandTrace
+        };
+
+        // verify client-initiated traces
+        Method rabbitTemplateReceive = rabbitTemplateClass.getDeclaredMethod("receive", String.class);
+        ExpectedTrace rabbitTemplateReceiveTrace = Expectations.event(
+                RabbitMQTestConstants.RABBITMQ_CLIENT_INTERNAL, // serviceType
+                rabbitTemplateReceive); // method
+        Method channelNBasicGet = channelNClass.getDeclaredMethod("basicGet", String.class, boolean.class);
+        ExpectedTrace channelNBasicGetTrace = Expectations.event(
+                RabbitMQTestConstants.RABBITMQ_CLIENT_INTERNAL,
+                channelNBasicGet);
+        Class<?> propagationMarkerClass = PropagationMarker.class;
+        Method propagationMarkerMark = propagationMarkerClass.getDeclaredMethod("mark");
+        ExpectedTrace markTrace = Expectations.event(
+                ServiceType.INTERNAL_METHOD.getName(),
+                propagationMarkerMark);
+
+        ExpectedTrace[] clientInitiatedTraces = {
+                rabbitTemplateReceiveTrace,
+                channelNBasicGetTrace,
+                markTrace
+        };
+
+        int expectedTraceCount = queueInitiatedTraces.length + clientInitiatedTraces.length;
+        final PluginTestVerifier verifier = testRunner.runPull(expectedTraceCount);
+
+        verifier.verifyDiscreteTrace(queueInitiatedTraces);
+        verifier.verifyDiscreteTrace(clientInitiatedTraces);
+
+        verifier.verifyTraceCount(0);
+    }
+}

--- a/agent/src/test/java/com/navercorp/pinpoint/plugin/jdk7/rabbitmq/spring/SpringAmqpRabbit_1_7_0_to_2_0_0_IT.java
+++ b/agent/src/test/java/com/navercorp/pinpoint/plugin/jdk7/rabbitmq/spring/SpringAmqpRabbit_1_7_0_to_2_0_0_IT.java
@@ -1,0 +1,308 @@
+/*
+ * Copyright 2018 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.plugin.jdk7.rabbitmq.spring;
+
+import com.navercorp.pinpoint.bootstrap.plugin.test.Expectations;
+import com.navercorp.pinpoint.bootstrap.plugin.test.ExpectedTrace;
+import com.navercorp.pinpoint.bootstrap.plugin.test.PluginTestVerifier;
+import com.navercorp.pinpoint.common.trace.ServiceType;
+import com.navercorp.test.pinpoint.plugin.rabbitmq.spring.config.CommonConfig;
+import com.navercorp.test.pinpoint.plugin.rabbitmq.spring.config.MessageListenerConfig_Post_1_4_0;
+import com.navercorp.test.pinpoint.plugin.rabbitmq.spring.config.ReceiverConfig_Post_1_6_0;
+import com.navercorp.pinpoint.plugin.jdk7.rabbitmq.util.RabbitMQTestConstants;
+import com.navercorp.pinpoint.plugin.jdk7.rabbitmq.util.TestBroker;
+import com.navercorp.pinpoint.test.plugin.Dependency;
+import com.navercorp.pinpoint.test.plugin.JvmArgument;
+import com.navercorp.pinpoint.test.plugin.PinpointConfig;
+import com.navercorp.pinpoint.test.plugin.PinpointPluginTestSuite;
+import com.navercorp.test.pinpoint.plugin.rabbitmq.PropagationMarker;
+import com.rabbitmq.client.AMQP;
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.Consumer;
+import com.rabbitmq.client.Envelope;
+import com.rabbitmq.client.impl.AMQCommand;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.amqp.core.Message;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+
+/**
+ * @author HyunGil Jeong
+ */
+@RunWith(PinpointPluginTestSuite.class)
+@PinpointConfig("rabbitmq/client/pinpoint-rabbitmq.config")
+@Dependency({"org.springframework.amqp:spring-rabbit:[1.7.0.RELEASE,2.0.0.RELEASE)", "com.fasterxml.jackson.core:jackson-core:2.8.11", "org.apache.qpid:qpid-broker:6.1.1"})
+@JvmArgument({"-Dpinpoint.configcenter=false"})
+public class SpringAmqpRabbit_1_7_0_to_2_0_0_IT {
+
+    private static final TestBroker BROKER = new TestBroker();
+    private static final TestApplicationContext CONTEXT = new TestApplicationContext();
+
+    private final SpringAmqpRabbitTestRunner testRunner = new SpringAmqpRabbitTestRunner(CONTEXT);
+
+    @BeforeClass
+    public static void setUpBeforeClass() throws Exception {
+        BROKER.start();
+        CONTEXT.init(
+                CommonConfig.class,
+                MessageListenerConfig_Post_1_4_0.class,
+                ReceiverConfig_Post_1_6_0.class);
+    }
+
+    @AfterClass
+    public static void tearDownAfterClass() {
+        CONTEXT.close();
+        BROKER.shutdown();
+    }
+
+    @Test
+    public void testPush() throws Exception {
+        final String remoteAddress = testRunner.getRemoteAddress();
+
+        Class<?> rabbitTemplateClass = Class.forName("org.springframework.amqp.rabbit.core.RabbitTemplate");
+        Method rabbitTemplateConvertAndSend = rabbitTemplateClass.getDeclaredMethod("convertAndSend", String.class, String.class, Object.class);
+        ExpectedTrace rabbitTemplateConvertAndSendTrace = Expectations.event(
+                RabbitMQTestConstants.RABBITMQ_CLIENT_INTERNAL, // serviceType
+                rabbitTemplateConvertAndSend); // method
+        // automatic recovery deliberately disabled as Spring has it's own recovery mechanism
+        Class<?> channelNClass = Class.forName("com.rabbitmq.client.impl.ChannelN");
+        Method channelNBasicPublish = channelNClass.getDeclaredMethod("basicPublish", String.class, String.class, boolean.class, boolean.class, AMQP.BasicProperties.class, byte[].class);
+        ExpectedTrace channelNBasicPublishTrace = Expectations.event(
+                RabbitMQTestConstants.RABBITMQ_CLIENT, // serviceType
+                channelNBasicPublish, // method
+                null, // rpc
+                remoteAddress, // endPoint
+                "exchange-" + RabbitMQTestConstants.EXCHANGE, // destinationId
+                Expectations.annotation("rabbitmq.exchange", RabbitMQTestConstants.EXCHANGE),
+                Expectations.annotation("rabbitmq.routingkey", RabbitMQTestConstants.ROUTING_KEY_PUSH));
+        ExpectedTrace rabbitMqConsumerInvocationTrace = Expectations.root(
+                RabbitMQTestConstants.RABBITMQ_CLIENT, // serviceType
+                "RabbitMQ Consumer Invocation", // method
+                "rabbitmq://exchange=" + RabbitMQTestConstants.EXCHANGE, // rpc
+                null, // endPoint (collected but API to retrieve local address is not available in all versions, so skip)
+                remoteAddress, // remoteAddress
+                Expectations.annotation("rabbitmq.routingkey", RabbitMQTestConstants.ROUTING_KEY_PUSH));
+        Class<?> consumerDispatcherClass = Class.forName("com.rabbitmq.client.impl.ConsumerDispatcher");
+        Method consumerDispatcherHandleDelivery = consumerDispatcherClass.getDeclaredMethod("handleDelivery", Consumer.class, String.class, Envelope.class, AMQP.BasicProperties.class, byte[].class);
+        ExpectedTrace consumerDispatcherHandleDeliveryTrace = Expectations.event(
+                RabbitMQTestConstants.RABBITMQ_CLIENT_INTERNAL, // serviceType
+                consumerDispatcherHandleDelivery); // method
+        ExpectedTrace asynchronousInvocationTrace = Expectations.event(
+                ServiceType.ASYNC.getName(),
+                "Asynchronous Invocation");
+        Class<?> blockingQueueConsumerInternalConsumerClass = Class.forName("org.springframework.amqp.rabbit.listener.BlockingQueueConsumer$InternalConsumer");
+        Method blockingQueueConsumerInternalConsumerHandleDelivery = blockingQueueConsumerInternalConsumerClass.getDeclaredMethod("handleDelivery", String.class, Envelope.class, AMQP.BasicProperties.class, byte[].class);
+        ExpectedTrace blockingQueueConsumerInternalConsumerHandleDeliveryTrace = Expectations.event(
+                RabbitMQTestConstants.RABBITMQ_CLIENT_INTERNAL, // serviceType
+                blockingQueueConsumerInternalConsumerHandleDelivery);
+        Class<?> deliveryClass = Class.forName("org.springframework.amqp.rabbit.support.Delivery");
+        Constructor<?> deliveryConstructor = deliveryClass.getDeclaredConstructor(String.class, Envelope.class, AMQP.BasicProperties.class, byte[].class);
+        ExpectedTrace deliveryConstructorTrace = Expectations.event(
+                RabbitMQTestConstants.RABBITMQ_CLIENT_INTERNAL, // serviceType
+                deliveryConstructor);
+        Class<?> abstractMessageListenerContainerClass = Class.forName("org.springframework.amqp.rabbit.listener.AbstractMessageListenerContainer");
+        Method abstractMessageListenerContainerExecuteListener = abstractMessageListenerContainerClass.getDeclaredMethod("executeListener", Channel.class, Message.class);
+        ExpectedTrace abstractMessageListenerContainerExecuteListenerTrace = Expectations.event(
+                ServiceType.INTERNAL_METHOD.getName(),
+                abstractMessageListenerContainerExecuteListener);
+        Class<?> propagationMarkerClass = PropagationMarker.class;
+        Method propagationMarkerMark = propagationMarkerClass.getDeclaredMethod("mark");
+        ExpectedTrace markTrace = Expectations.event(
+                ServiceType.INTERNAL_METHOD.getName(),
+                propagationMarkerMark);
+
+        ExpectedTrace[] expectedTraces = {
+                rabbitTemplateConvertAndSendTrace,
+                channelNBasicPublishTrace,
+                rabbitMqConsumerInvocationTrace,
+                consumerDispatcherHandleDeliveryTrace,
+                asynchronousInvocationTrace,
+                blockingQueueConsumerInternalConsumerHandleDeliveryTrace,
+                deliveryConstructorTrace,
+                asynchronousInvocationTrace,
+                abstractMessageListenerContainerExecuteListenerTrace,
+                markTrace
+        };
+
+        final PluginTestVerifier verifier = testRunner.runPush(expectedTraces.length);
+
+        verifier.verifyTrace(expectedTraces);
+        verifier.verifyTraceCount(0);
+    }
+
+    @Test
+    public void testPull() throws Exception {
+        final String remoteAddress = testRunner.getRemoteAddress();
+
+        Class<?> rabbitTemplateClass = Class.forName("org.springframework.amqp.rabbit.core.RabbitTemplate");
+        // verify queue-initiated traces
+        Method rabbitTemplateConvertAndSend = rabbitTemplateClass.getDeclaredMethod("convertAndSend", String.class, String.class, Object.class);
+        ExpectedTrace rabbitTemplateConvertAndSendTrace = Expectations.event(
+                RabbitMQTestConstants.RABBITMQ_CLIENT_INTERNAL, // serviceType
+                rabbitTemplateConvertAndSend); // method
+        // automatic recovery deliberately disabled as Spring has it's own recovery mechanism
+        Class<?> channelNClass = Class.forName("com.rabbitmq.client.impl.ChannelN");
+        Method channelNBasicPublish = channelNClass.getDeclaredMethod("basicPublish", String.class, String.class, boolean.class, boolean.class, AMQP.BasicProperties.class, byte[].class);
+        ExpectedTrace channelNBasicPublishTrace = Expectations.event(
+                RabbitMQTestConstants.RABBITMQ_CLIENT, // serviceType
+                channelNBasicPublish, // method
+                null, // rpc
+                remoteAddress, // endPoint
+                "exchange-" + RabbitMQTestConstants.EXCHANGE, // destinationId
+                Expectations.annotation("rabbitmq.exchange", RabbitMQTestConstants.EXCHANGE),
+                Expectations.annotation("rabbitmq.routingkey", RabbitMQTestConstants.ROUTING_KEY_PULL));
+        ExpectedTrace rabbitMqConsumerInvocationTrace = Expectations.root(
+                RabbitMQTestConstants.RABBITMQ_CLIENT, // serviceType
+                "RabbitMQ Consumer Invocation", // method
+                "rabbitmq://exchange=" + RabbitMQTestConstants.EXCHANGE, // rpc
+                null, // endPoint (collected but API to retrieve local address is not available in all versions, so skip)
+                remoteAddress, // remoteAddress
+                Expectations.annotation("rabbitmq.routingkey", RabbitMQTestConstants.ROUTING_KEY_PULL));
+        Class<?> amqChannelClass = Class.forName("com.rabbitmq.client.impl.AMQChannel");
+        Method amqChannelHandleCompleteInboundCommand = amqChannelClass.getDeclaredMethod("handleCompleteInboundCommand", AMQCommand.class);
+        ExpectedTrace amqChannelHandleCompleteInboundCommandTrace = Expectations.event(
+                RabbitMQTestConstants.RABBITMQ_CLIENT_INTERNAL, // method
+                amqChannelHandleCompleteInboundCommand);
+
+        ExpectedTrace[] queueInitiatedTraces = {
+                rabbitTemplateConvertAndSendTrace,
+                channelNBasicPublishTrace,
+                rabbitMqConsumerInvocationTrace,
+                amqChannelHandleCompleteInboundCommandTrace
+        };
+
+        // verify client-initiated traces
+        Method rabbitTemplateReceive = rabbitTemplateClass.getDeclaredMethod("receive", String.class);
+        ExpectedTrace rabbitTemplateReceiveTrace = Expectations.event(
+                RabbitMQTestConstants.RABBITMQ_CLIENT_INTERNAL, // serviceType
+                rabbitTemplateReceive); // method
+        Method channelNBasicGet = channelNClass.getDeclaredMethod("basicGet", String.class, boolean.class);
+        ExpectedTrace channelNBasicGetTrace = Expectations.event(
+                RabbitMQTestConstants.RABBITMQ_CLIENT_INTERNAL,
+                channelNBasicGet);
+        Class<?> propagationMarkerClass = PropagationMarker.class;
+        Method propagationMarkerMark = propagationMarkerClass.getDeclaredMethod("mark");
+        ExpectedTrace markTrace = Expectations.event(
+                ServiceType.INTERNAL_METHOD.getName(),
+                propagationMarkerMark);
+
+        ExpectedTrace[] clientInitiatedTraces = {
+                rabbitTemplateReceiveTrace,
+                channelNBasicGetTrace,
+                markTrace
+        };
+
+        int expectedTraceCount = queueInitiatedTraces.length + clientInitiatedTraces.length;
+        final PluginTestVerifier verifier = testRunner.runPull(expectedTraceCount);
+
+        verifier.verifyDiscreteTrace(queueInitiatedTraces);
+        verifier.verifyDiscreteTrace(clientInitiatedTraces);
+
+        verifier.verifyTraceCount(0);
+    }
+
+    @Test
+    public void testPullWithTimeout() throws Exception {
+        final String remoteAddress = testRunner.getRemoteAddress();
+
+        Class<?> rabbitTemplateClass = Class.forName("org.springframework.amqp.rabbit.core.RabbitTemplate");
+        // verify queue-initiated traces
+        Method rabbitTemplateConvertAndSend = rabbitTemplateClass.getDeclaredMethod("convertAndSend", String.class, String.class, Object.class);
+        ExpectedTrace rabbitTemplateConvertAndSendTrace = Expectations.event(
+                RabbitMQTestConstants.RABBITMQ_CLIENT_INTERNAL, // serviceType
+                rabbitTemplateConvertAndSend); // method
+        // automatic recovery deliberately disabled as Spring has it's own recovery mechanism
+        Class<?> channelNClass = Class.forName("com.rabbitmq.client.impl.ChannelN");
+        Method channelNBasicPublish = channelNClass.getDeclaredMethod("basicPublish", String.class, String.class, boolean.class, boolean.class, AMQP.BasicProperties.class, byte[].class);
+        ExpectedTrace channelNBasicPublishTrace = Expectations.event(
+                RabbitMQTestConstants.RABBITMQ_CLIENT, // serviceType
+                channelNBasicPublish, // method
+                null, // rpc
+                remoteAddress, // endPoint
+                "exchange-" + RabbitMQTestConstants.EXCHANGE, // destinationId
+                Expectations.annotation("rabbitmq.exchange", RabbitMQTestConstants.EXCHANGE),
+                Expectations.annotation("rabbitmq.routingkey", RabbitMQTestConstants.ROUTING_KEY_PULL));
+        ExpectedTrace rabbitMqConsumerInvocationTrace = Expectations.root(
+                RabbitMQTestConstants.RABBITMQ_CLIENT, // serviceType
+                "RabbitMQ Consumer Invocation", // method
+                "rabbitmq://exchange=" + RabbitMQTestConstants.EXCHANGE, // rpc
+                null, // endPoint (collected but API to retrieve local address is not available in all versions, so skip)
+                remoteAddress, // remoteAddress
+                Expectations.annotation("rabbitmq.routingkey", RabbitMQTestConstants.ROUTING_KEY_PULL));
+        Class<?> consumerDispatcherClass = Class.forName("com.rabbitmq.client.impl.ConsumerDispatcher");
+        Method consumerDispatcherHandleDelivery = consumerDispatcherClass.getDeclaredMethod("handleDelivery", Consumer.class, String.class, Envelope.class, AMQP.BasicProperties.class, byte[].class);
+        ExpectedTrace consumerDispatcherHandleDeliveryTrace = Expectations.event(
+                RabbitMQTestConstants.RABBITMQ_CLIENT_INTERNAL, // serviceType
+                consumerDispatcherHandleDelivery); // method
+        ExpectedTrace asynchronousInvocationTrace = Expectations.event(
+                ServiceType.ASYNC.getName(),
+                "Asynchronous Invocation");
+        Class<?> queueingConsumerClass = Class.forName("com.rabbitmq.client.QueueingConsumer");
+        Method queueingConsumerHandleDelivery = queueingConsumerClass.getDeclaredMethod("handleDelivery", String.class, Envelope.class, AMQP.BasicProperties.class, byte[].class);
+        ExpectedTrace queueingConsumerHandleDeliveryTrace = Expectations.event(
+                RabbitMQTestConstants.RABBITMQ_CLIENT_INTERNAL, // serviceType
+                queueingConsumerHandleDelivery);
+        Class<?> queueingConsumerDeliveryClass = Class.forName("com.rabbitmq.client.QueueingConsumer$Delivery");
+        Constructor queueingConsumerDeliveryConstructor = queueingConsumerDeliveryClass.getDeclaredConstructor(Envelope.class, AMQP.BasicProperties.class, byte[].class);
+        ExpectedTrace queueingConsumerDeliveryConstructorTrace = Expectations.event(
+                RabbitMQTestConstants.RABBITMQ_CLIENT_INTERNAL,
+                queueingConsumerDeliveryConstructor);
+
+        ExpectedTrace[] queueInitiatedTraces = {
+                rabbitTemplateConvertAndSendTrace,
+                channelNBasicPublishTrace,
+                rabbitMqConsumerInvocationTrace,
+                consumerDispatcherHandleDeliveryTrace,
+                asynchronousInvocationTrace,
+                queueingConsumerHandleDeliveryTrace,
+                queueingConsumerDeliveryConstructorTrace
+        };
+
+        // verify client-initiated traces
+        Method rabbitTemplateReceive = rabbitTemplateClass.getDeclaredMethod("receive", String.class, long.class);
+        ExpectedTrace rabbitTemplateReceiveTrace = Expectations.event(
+                RabbitMQTestConstants.RABBITMQ_CLIENT_INTERNAL, // serviceType
+                rabbitTemplateReceive); // method
+        Method queueingConsumerNextDelivery = queueingConsumerClass.getDeclaredMethod("nextDelivery", long.class);
+        ExpectedTrace queueingConsumerNextDeliveryTrace = Expectations.event(
+                RabbitMQTestConstants.RABBITMQ_CLIENT_INTERNAL,
+                queueingConsumerNextDelivery);
+        Class<?> propagationMarkerClass = PropagationMarker.class;
+        Method propagationMarkerMark = propagationMarkerClass.getDeclaredMethod("mark");
+        ExpectedTrace markTrace = Expectations.event(
+                ServiceType.INTERNAL_METHOD.getName(),
+                propagationMarkerMark);
+
+        ExpectedTrace[] clientInitiatedTraces = {
+                rabbitTemplateReceiveTrace,
+                queueingConsumerNextDeliveryTrace,
+                markTrace
+        };
+
+        int expectedTraceCount = queueInitiatedTraces.length + clientInitiatedTraces.length;
+        final PluginTestVerifier verifier = testRunner.runPull(expectedTraceCount, 5000L);
+
+        verifier.verifyDiscreteTrace(queueInitiatedTraces);
+        verifier.verifyDiscreteTrace(clientInitiatedTraces);
+
+        verifier.verifyTraceCount(0);
+    }
+}

--- a/agent/src/test/java/com/navercorp/pinpoint/plugin/jdk7/rabbitmq/spring/SpringAmqpRabbit_2_x_IT.java
+++ b/agent/src/test/java/com/navercorp/pinpoint/plugin/jdk7/rabbitmq/spring/SpringAmqpRabbit_2_x_IT.java
@@ -1,0 +1,314 @@
+/*
+ * Copyright 2018 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.plugin.jdk7.rabbitmq.spring;
+
+import com.navercorp.pinpoint.bootstrap.plugin.test.Expectations;
+import com.navercorp.pinpoint.bootstrap.plugin.test.ExpectedTrace;
+import com.navercorp.pinpoint.bootstrap.plugin.test.PluginTestVerifier;
+import com.navercorp.pinpoint.common.trace.ServiceType;
+import com.navercorp.test.pinpoint.plugin.rabbitmq.spring.config.CommonConfig;
+import com.navercorp.test.pinpoint.plugin.rabbitmq.spring.config.MessageListenerConfig_Post_1_4_0;
+import com.navercorp.test.pinpoint.plugin.rabbitmq.spring.config.ReceiverConfig_Post_1_6_0;
+import com.navercorp.pinpoint.plugin.jdk7.rabbitmq.util.RabbitMQTestConstants;
+import com.navercorp.pinpoint.plugin.jdk7.rabbitmq.util.TestBroker;
+import com.navercorp.pinpoint.test.plugin.Dependency;
+import com.navercorp.pinpoint.test.plugin.JvmArgument;
+import com.navercorp.pinpoint.test.plugin.PinpointConfig;
+import com.navercorp.pinpoint.test.plugin.PinpointPluginTestSuite;
+import com.navercorp.test.pinpoint.plugin.rabbitmq.PropagationMarker;
+import com.rabbitmq.client.AMQP;
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.Consumer;
+import com.rabbitmq.client.Envelope;
+import com.rabbitmq.client.impl.AMQCommand;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.amqp.core.Message;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+
+/**
+ * <p>Spring-amqp rabbit 2.x uses rabbitmq 5.x, which removed <tt>QueueingConsumer</tt>.
+ *
+ * <p>This affects traces recorded inside <tt>RabbitTemplate.receive(String queueName, long timeoutMillis)</tt> as
+ * prior to 2.0.0, <tt>QueueingConsumer</tt> methods were recorded and verified for.
+ *
+ * <p>2.0.0 instead uses an anonymous class extending <tt>RabbitTemplate.TemplateConsumer</tt> and so verification must
+ * be done on the anonymous class. Affects {@link #testPullWithTimeout()}.
+ *
+ * @author HyunGil Jeong
+ */
+@RunWith(PinpointPluginTestSuite.class)
+@PinpointConfig("rabbitmq/client/pinpoint-rabbitmq.config")
+@Dependency({"org.springframework.amqp:spring-rabbit:[2.0.0.RELEASE,)", "com.fasterxml.jackson.core:jackson-core:2.8.11", "org.apache.qpid:qpid-broker:6.1.1"})
+@JvmArgument({"-Dpinpoint.configcenter=false"})
+public class SpringAmqpRabbit_2_x_IT {
+
+    private static final TestBroker BROKER = new TestBroker();
+    private static final TestApplicationContext CONTEXT = new TestApplicationContext();
+
+    private final SpringAmqpRabbitTestRunner testRunner = new SpringAmqpRabbitTestRunner(CONTEXT);
+
+    @BeforeClass
+    public static void setUpBeforeClass() throws Exception {
+        BROKER.start();
+        CONTEXT.init(
+                CommonConfig.class,
+                MessageListenerConfig_Post_1_4_0.class,
+                ReceiverConfig_Post_1_6_0.class);
+    }
+
+    @AfterClass
+    public static void tearDownAfterClass() {
+        CONTEXT.close();
+        BROKER.shutdown();
+    }
+
+    @Test
+    public void testPush() throws Exception {
+        final String remoteAddress = testRunner.getRemoteAddress();
+
+        Class<?> rabbitTemplateClass = Class.forName("org.springframework.amqp.rabbit.core.RabbitTemplate");
+        Method rabbitTemplateConvertAndSend = rabbitTemplateClass.getDeclaredMethod("convertAndSend", String.class, String.class, Object.class);
+        ExpectedTrace rabbitTemplateConvertAndSendTrace = Expectations.event(
+                RabbitMQTestConstants.RABBITMQ_CLIENT_INTERNAL, // serviceType
+                rabbitTemplateConvertAndSend); // method
+        // automatic recovery deliberately disabled as Spring has it's own recovery mechanism
+        Class<?> channelNClass = Class.forName("com.rabbitmq.client.impl.ChannelN");
+        Method channelNBasicPublish = channelNClass.getDeclaredMethod("basicPublish", String.class, String.class, boolean.class, boolean.class, AMQP.BasicProperties.class, byte[].class);
+        ExpectedTrace channelNBasicPublishTrace = Expectations.event(
+                RabbitMQTestConstants.RABBITMQ_CLIENT, // serviceType
+                channelNBasicPublish, // method
+                null, // rpc
+                remoteAddress, // endPoint
+                "exchange-" + RabbitMQTestConstants.EXCHANGE, // destinationId
+                Expectations.annotation("rabbitmq.exchange", RabbitMQTestConstants.EXCHANGE),
+                Expectations.annotation("rabbitmq.routingkey", RabbitMQTestConstants.ROUTING_KEY_PUSH));
+        ExpectedTrace rabbitMqConsumerInvocationTrace = Expectations.root(
+                RabbitMQTestConstants.RABBITMQ_CLIENT, // serviceType
+                "RabbitMQ Consumer Invocation", // method
+                "rabbitmq://exchange=" + RabbitMQTestConstants.EXCHANGE, // rpc
+                null, // endPoint (collected but API to retrieve local address is not available in all versions, so skip)
+                remoteAddress, // remoteAddress
+                Expectations.annotation("rabbitmq.routingkey", RabbitMQTestConstants.ROUTING_KEY_PUSH));
+        Class<?> consumerDispatcherClass = Class.forName("com.rabbitmq.client.impl.ConsumerDispatcher");
+        Method consumerDispatcherHandleDelivery = consumerDispatcherClass.getDeclaredMethod("handleDelivery", Consumer.class, String.class, Envelope.class, AMQP.BasicProperties.class, byte[].class);
+        ExpectedTrace consumerDispatcherHandleDeliveryTrace = Expectations.event(
+                RabbitMQTestConstants.RABBITMQ_CLIENT_INTERNAL, // serviceType
+                consumerDispatcherHandleDelivery); // method
+        ExpectedTrace asynchronousInvocationTrace = Expectations.event(
+                ServiceType.ASYNC.getName(),
+                "Asynchronous Invocation");
+        Class<?> blockingQueueConsumerInternalConsumerClass = Class.forName("org.springframework.amqp.rabbit.listener.BlockingQueueConsumer$InternalConsumer");
+        Method blockingQueueConsumerInternalConsumerHandleDelivery = blockingQueueConsumerInternalConsumerClass.getDeclaredMethod("handleDelivery", String.class, Envelope.class, AMQP.BasicProperties.class, byte[].class);
+        ExpectedTrace blockingQueueConsumerInternalConsumerHandleDeliveryTrace = Expectations.event(
+                RabbitMQTestConstants.RABBITMQ_CLIENT_INTERNAL, // serviceType
+                blockingQueueConsumerInternalConsumerHandleDelivery);
+        Class<?> deliveryClass = Class.forName("org.springframework.amqp.rabbit.support.Delivery");
+        Constructor<?> deliveryConstructor = deliveryClass.getDeclaredConstructor(String.class, Envelope.class, AMQP.BasicProperties.class, byte[].class);
+        ExpectedTrace deliveryConstructorTrace = Expectations.event(
+                RabbitMQTestConstants.RABBITMQ_CLIENT_INTERNAL, // serviceType
+                deliveryConstructor);
+        Class<?> abstractMessageListenerContainerClass = Class.forName("org.springframework.amqp.rabbit.listener.AbstractMessageListenerContainer");
+        Method abstractMessageListenerContainerExecuteListener = abstractMessageListenerContainerClass.getDeclaredMethod("executeListener", Channel.class, Message.class);
+        ExpectedTrace abstractMessageListenerContainerExecuteListenerTrace = Expectations.event(
+                ServiceType.INTERNAL_METHOD.getName(),
+                abstractMessageListenerContainerExecuteListener);
+        Class<?> propagationMarkerClass = PropagationMarker.class;
+        Method propagationMarkerMark = propagationMarkerClass.getDeclaredMethod("mark");
+        ExpectedTrace markTrace = Expectations.event(
+                ServiceType.INTERNAL_METHOD.getName(),
+                propagationMarkerMark);
+
+        ExpectedTrace[] expectedTraces = {
+                rabbitTemplateConvertAndSendTrace,
+                channelNBasicPublishTrace,
+                rabbitMqConsumerInvocationTrace,
+                consumerDispatcherHandleDeliveryTrace,
+                asynchronousInvocationTrace,
+                blockingQueueConsumerInternalConsumerHandleDeliveryTrace,
+                deliveryConstructorTrace,
+                asynchronousInvocationTrace,
+                abstractMessageListenerContainerExecuteListenerTrace,
+                markTrace
+        };
+
+        final PluginTestVerifier verifier = testRunner.runPush(expectedTraces.length);
+
+        verifier.verifyTrace(expectedTraces);
+        verifier.verifyTraceCount(0);
+    }
+
+    @Test
+    public void testPull() throws Exception {
+        final String remoteAddress = testRunner.getRemoteAddress();
+
+        Class<?> rabbitTemplateClass = Class.forName("org.springframework.amqp.rabbit.core.RabbitTemplate");
+        // verify queue-initiated traces
+        Method rabbitTemplateConvertAndSend = rabbitTemplateClass.getDeclaredMethod("convertAndSend", String.class, String.class, Object.class);
+        ExpectedTrace rabbitTemplateConvertAndSendTrace = Expectations.event(
+                RabbitMQTestConstants.RABBITMQ_CLIENT_INTERNAL, // serviceType
+                rabbitTemplateConvertAndSend); // method
+        // automatic recovery deliberately disabled as Spring has it's own recovery mechanism
+        Class<?> channelNClass = Class.forName("com.rabbitmq.client.impl.ChannelN");
+        Method channelNBasicPublish = channelNClass.getDeclaredMethod("basicPublish", String.class, String.class, boolean.class, boolean.class, AMQP.BasicProperties.class, byte[].class);
+        ExpectedTrace channelNBasicPublishTrace = Expectations.event(
+                RabbitMQTestConstants.RABBITMQ_CLIENT, // serviceType
+                channelNBasicPublish, // method
+                null, // rpc
+                remoteAddress, // endPoint
+                "exchange-" + RabbitMQTestConstants.EXCHANGE, // destinationId
+                Expectations.annotation("rabbitmq.exchange", RabbitMQTestConstants.EXCHANGE),
+                Expectations.annotation("rabbitmq.routingkey", RabbitMQTestConstants.ROUTING_KEY_PULL));
+        ExpectedTrace rabbitMqConsumerInvocationTrace = Expectations.root(
+                RabbitMQTestConstants.RABBITMQ_CLIENT, // serviceType
+                "RabbitMQ Consumer Invocation", // method
+                "rabbitmq://exchange=" + RabbitMQTestConstants.EXCHANGE, // rpc
+                null, // endPoint (collected but API to retrieve local address is not available in all versions, so skip)
+                remoteAddress, // remoteAddress
+                Expectations.annotation("rabbitmq.routingkey", RabbitMQTestConstants.ROUTING_KEY_PULL));
+        Class<?> amqChannelClass = Class.forName("com.rabbitmq.client.impl.AMQChannel");
+        Method amqChannelHandleCompleteInboundCommand = amqChannelClass.getDeclaredMethod("handleCompleteInboundCommand", AMQCommand.class);
+        ExpectedTrace amqChannelHandleCompleteInboundCommandTrace = Expectations.event(
+                RabbitMQTestConstants.RABBITMQ_CLIENT_INTERNAL, // method
+                amqChannelHandleCompleteInboundCommand);
+
+        ExpectedTrace[] queueInitiatedTraces = {
+                rabbitTemplateConvertAndSendTrace,
+                channelNBasicPublishTrace,
+                rabbitMqConsumerInvocationTrace,
+                amqChannelHandleCompleteInboundCommandTrace
+        };
+
+        // verify client-initiated traces
+        Method rabbitTemplateReceive = rabbitTemplateClass.getDeclaredMethod("receive", String.class);
+        ExpectedTrace rabbitTemplateReceiveTrace = Expectations.event(
+                RabbitMQTestConstants.RABBITMQ_CLIENT_INTERNAL, // serviceType
+                rabbitTemplateReceive); // method
+        Method channelNBasicGet = channelNClass.getDeclaredMethod("basicGet", String.class, boolean.class);
+        ExpectedTrace channelNBasicGetTrace = Expectations.event(
+                RabbitMQTestConstants.RABBITMQ_CLIENT_INTERNAL,
+                channelNBasicGet);
+        Class<?> propagationMarkerClass = PropagationMarker.class;
+        Method propagationMarkerMark = propagationMarkerClass.getDeclaredMethod("mark");
+        ExpectedTrace markTrace = Expectations.event(
+                ServiceType.INTERNAL_METHOD.getName(),
+                propagationMarkerMark);
+
+        ExpectedTrace[] clientInitiatedTraces = {
+                rabbitTemplateReceiveTrace,
+                channelNBasicGetTrace,
+                markTrace
+        };
+
+        int expectedTraceCount = queueInitiatedTraces.length + clientInitiatedTraces.length;
+        final PluginTestVerifier verifier = testRunner.runPull(expectedTraceCount);
+
+        verifier.verifyDiscreteTrace(queueInitiatedTraces);
+        verifier.verifyDiscreteTrace(clientInitiatedTraces);
+
+        verifier.verifyTraceCount(0);
+    }
+
+    @Test
+    public void testPullWithTimeout() throws Exception {
+        final String remoteAddress = testRunner.getRemoteAddress();
+
+        Class<?> rabbitTemplateClass = Class.forName("org.springframework.amqp.rabbit.core.RabbitTemplate");
+        // verify queue-initiated traces
+        Method rabbitTemplateConvertAndSend = rabbitTemplateClass.getDeclaredMethod("convertAndSend", String.class, String.class, Object.class);
+        ExpectedTrace rabbitTemplateConvertAndSendTrace = Expectations.event(
+                RabbitMQTestConstants.RABBITMQ_CLIENT_INTERNAL, // serviceType
+                rabbitTemplateConvertAndSend); // method
+        // automatic recovery deliberately disabled as Spring has it's own recovery mechanism
+        Class<?> channelNClass = Class.forName("com.rabbitmq.client.impl.ChannelN");
+        Method channelNBasicPublish = channelNClass.getDeclaredMethod("basicPublish", String.class, String.class, boolean.class, boolean.class, AMQP.BasicProperties.class, byte[].class);
+        ExpectedTrace channelNBasicPublishTrace = Expectations.event(
+                RabbitMQTestConstants.RABBITMQ_CLIENT, // serviceType
+                channelNBasicPublish, // method
+                null, // rpc
+                remoteAddress, // endPoint
+                "exchange-" + RabbitMQTestConstants.EXCHANGE, // destinationId
+                Expectations.annotation("rabbitmq.exchange", RabbitMQTestConstants.EXCHANGE),
+                Expectations.annotation("rabbitmq.routingkey", RabbitMQTestConstants.ROUTING_KEY_PULL));
+        ExpectedTrace rabbitMqConsumerInvocationTrace = Expectations.root(
+                RabbitMQTestConstants.RABBITMQ_CLIENT, // serviceType
+                "RabbitMQ Consumer Invocation", // method
+                "rabbitmq://exchange=" + RabbitMQTestConstants.EXCHANGE, // rpc
+                null, // endPoint (collected but API to retrieve local address is not available in all versions, so skip)
+                remoteAddress, // remoteAddress
+                Expectations.annotation("rabbitmq.routingkey", RabbitMQTestConstants.ROUTING_KEY_PULL));
+        Class<?> consumerDispatcherClass = Class.forName("com.rabbitmq.client.impl.ConsumerDispatcher");
+        Method consumerDispatcherHandleDelivery = consumerDispatcherClass.getDeclaredMethod("handleDelivery", Consumer.class, String.class, Envelope.class, AMQP.BasicProperties.class, byte[].class);
+        ExpectedTrace consumerDispatcherHandleDeliveryTrace = Expectations.event(
+                RabbitMQTestConstants.RABBITMQ_CLIENT_INTERNAL, // serviceType
+                consumerDispatcherHandleDelivery); // method
+        ExpectedTrace asynchronousInvocationTrace = Expectations.event(
+                ServiceType.ASYNC.getName(),
+                "Asynchronous Invocation");
+        // RabbitTemplate internal consumer implementation - may change in future versions which will cause tests to
+        // fail, in which case the integration test needs to be updated to match code changes
+        Class<?> rabbitTemplateInternalConsumerClass = Class.forName("org.springframework.amqp.rabbit.core.RabbitTemplate$2");
+        Method rabbitTemplateInternalConsumerHandleDelivery = rabbitTemplateInternalConsumerClass.getDeclaredMethod("handleDelivery", String.class, Envelope.class, AMQP.BasicProperties.class, byte[].class);
+        ExpectedTrace rabbitTemplateInternalConsumerHandleDeliveryTrace = Expectations.event(
+                RabbitMQTestConstants.RABBITMQ_CLIENT_INTERNAL, // serviceType
+                rabbitTemplateInternalConsumerHandleDelivery); // method
+        Class<?> deliveryClass = Class.forName("org.springframework.amqp.rabbit.support.Delivery");
+        Constructor<?> deliveryConstructor = deliveryClass.getDeclaredConstructor(String.class, Envelope.class, AMQP.BasicProperties.class, byte[].class);
+        ExpectedTrace deliveryConstructorTrace = Expectations.event(
+                RabbitMQTestConstants.RABBITMQ_CLIENT_INTERNAL, // serviceType
+                deliveryConstructor);
+
+        ExpectedTrace[] queueInitiatedTraces = {
+                rabbitTemplateConvertAndSendTrace,
+                channelNBasicPublishTrace,
+                rabbitMqConsumerInvocationTrace,
+                consumerDispatcherHandleDeliveryTrace,
+                asynchronousInvocationTrace,
+                rabbitTemplateInternalConsumerHandleDeliveryTrace,
+                deliveryConstructorTrace
+        };
+
+        // verify client-initiated traces
+        Method rabbitTemplateReceive = rabbitTemplateClass.getDeclaredMethod("receive", String.class, long.class);
+        ExpectedTrace rabbitTemplateReceiveTrace = Expectations.event(
+                RabbitMQTestConstants.RABBITMQ_CLIENT_INTERNAL, // serviceType
+                rabbitTemplateReceive); // method
+        Class<?> propagationMarkerClass = PropagationMarker.class;
+        Method propagationMarkerMark = propagationMarkerClass.getDeclaredMethod("mark");
+        ExpectedTrace markTrace = Expectations.event(
+                ServiceType.INTERNAL_METHOD.getName(),
+                propagationMarkerMark);
+
+        ExpectedTrace[] clientInitiatedTraces = {
+                rabbitTemplateReceiveTrace,
+                markTrace
+        };
+
+        int expectedTraceCount = queueInitiatedTraces.length + clientInitiatedTraces.length;
+        final PluginTestVerifier verifier = testRunner.runPull(expectedTraceCount, 5000L);
+//        final PluginTestVerifier verifier = testRunner.runPull(9, 5000L);
+
+        verifier.verifyDiscreteTrace(queueInitiatedTraces);
+        verifier.verifyDiscreteTrace(clientInitiatedTraces);
+
+        verifier.verifyTraceCount(0);
+    }
+}

--- a/agent/src/test/java/com/navercorp/pinpoint/plugin/jdk7/rabbitmq/spring/SpringAmqpRabbit_2_x_IT.java
+++ b/agent/src/test/java/com/navercorp/pinpoint/plugin/jdk7/rabbitmq/spring/SpringAmqpRabbit_2_x_IT.java
@@ -20,6 +20,7 @@ import com.navercorp.pinpoint.bootstrap.plugin.test.Expectations;
 import com.navercorp.pinpoint.bootstrap.plugin.test.ExpectedTrace;
 import com.navercorp.pinpoint.bootstrap.plugin.test.PluginTestVerifier;
 import com.navercorp.pinpoint.common.trace.ServiceType;
+import com.navercorp.pinpoint.test.plugin.JvmVersion;
 import com.navercorp.test.pinpoint.plugin.rabbitmq.spring.config.CommonConfig;
 import com.navercorp.test.pinpoint.plugin.rabbitmq.spring.config.MessageListenerConfig_Post_1_4_0;
 import com.navercorp.test.pinpoint.plugin.rabbitmq.spring.config.ReceiverConfig_Post_1_6_0;
@@ -58,6 +59,7 @@ import java.lang.reflect.Method;
 @RunWith(PinpointPluginTestSuite.class)
 @PinpointConfig("rabbitmq/client/pinpoint-rabbitmq.config")
 @Dependency({"org.springframework.amqp:spring-rabbit:[2.0.0.RELEASE,)", "com.fasterxml.jackson.core:jackson-core:2.8.11", "org.apache.qpid:qpid-broker:6.1.1"})
+@JvmVersion(8)
 @JvmArgument({"-Dpinpoint.configcenter=false"})
 public class SpringAmqpRabbit_2_x_IT {
 

--- a/agent/src/test/java/com/navercorp/pinpoint/plugin/jdk7/rabbitmq/spring/TestApplicationContext.java
+++ b/agent/src/test/java/com/navercorp/pinpoint/plugin/jdk7/rabbitmq/spring/TestApplicationContext.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2018 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.plugin.jdk7.rabbitmq.spring;
+
+import com.navercorp.test.pinpoint.plugin.rabbitmq.spring.TestMessageHolder;
+import com.navercorp.test.pinpoint.plugin.rabbitmq.spring.service.TestReceiverService;
+import com.navercorp.test.pinpoint.plugin.rabbitmq.spring.service.TestSenderService;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+/**
+ * @author HyunGil Jeong
+ */
+class TestApplicationContext {
+
+    private final AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+
+    public void init(Class<?>... annotatedClasses) {
+        context.register(annotatedClasses);
+        context.refresh();
+    }
+
+    public void close() {
+        context.close();
+    }
+
+    public ConnectionFactory getConnectionFactory() {
+        return (ConnectionFactory) context.getBean("connectionFactory");
+    }
+
+    public TestMessageHolder getTestMessageHolder() {
+        return (TestMessageHolder) context.getBean("testMessageHolder");
+    }
+
+    public TestSenderService getTestSenderService() {
+        return (TestSenderService) context.getBean("testSenderService");
+    }
+
+    public TestReceiverService getTestReceiverService() {
+        return (TestReceiverService) context.getBean("testReceiverService");
+    }
+
+    public RabbitTemplate getRabbitTemplate() {
+        return (RabbitTemplate) context.getBean("rabbitTemplate");
+    }
+}

--- a/agent/src/test/java/com/navercorp/pinpoint/plugin/jdk7/rabbitmq/util/RabbitMQTestConstants.java
+++ b/agent/src/test/java/com/navercorp/pinpoint/plugin/jdk7/rabbitmq/util/RabbitMQTestConstants.java
@@ -33,7 +33,10 @@ public interface RabbitMQTestConstants {
     String RABBITMQ_CLIENT_INTERNAL = "RABBITMQ_CLIENT_INTERNAL";
 
     String EXCHANGE = "TestExchange";
-    String QUEUE = "TestQueue";
+    String QUEUE_PUSH = "TestPushQueue";
+    String QUEUE_PULL = "TestPullQueue";
+    String ROUTING_KEY_PUSH = "push";
+    String ROUTING_KEY_PULL = "pull";
 
     SaslConfig SASL_CONFIG = new SaslConfig() {
         public SaslMechanism getSaslMechanism(String[] mechanisms) {

--- a/agent/src/test/java/com/navercorp/test/pinpoint/plugin/rabbitmq/spring/TestMessageHolder.java
+++ b/agent/src/test/java/com/navercorp/test/pinpoint/plugin/rabbitmq/spring/TestMessageHolder.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2018 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.test.pinpoint.plugin.rabbitmq.spring;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * @author HyunGil Jeong
+ */
+public class TestMessageHolder {
+
+    private final BlockingQueue<String> messages = new LinkedBlockingQueue<String>();
+
+    public void addMessage(String message) {
+        messages.add(message);
+    }
+
+    public String getMessage(long timeoutMs, TimeUnit unit) throws InterruptedException {
+        return messages.poll(timeoutMs, unit);
+    }
+}

--- a/agent/src/test/java/com/navercorp/test/pinpoint/plugin/rabbitmq/spring/config/CommonConfig.java
+++ b/agent/src/test/java/com/navercorp/test/pinpoint/plugin/rabbitmq/spring/config/CommonConfig.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2018 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.test.pinpoint.plugin.rabbitmq.spring.config;
+
+import com.navercorp.pinpoint.plugin.jdk7.rabbitmq.util.RabbitMQTestConstants;
+import com.navercorp.test.pinpoint.plugin.rabbitmq.spring.TestMessageHolder;
+import org.springframework.amqp.core.AmqpAdmin;
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.BindingBuilder;
+import org.springframework.amqp.core.DirectExchange;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.rabbit.annotation.EnableRabbit;
+import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitAdmin;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * @author HyunGil Jeong
+ */
+@Configuration
+@EnableRabbit
+@ComponentScan("com.navercorp.test.pinpoint.plugin.rabbitmq.spring.service")
+public class CommonConfig {
+
+    @Bean(name = "connectionFactory")
+    public ConnectionFactory connectionFactory() {
+        com.rabbitmq.client.ConnectionFactory connectionFactory = new com.rabbitmq.client.ConnectionFactory();
+        connectionFactory.setHost(RabbitMQTestConstants.BROKER_HOST);
+        connectionFactory.setPort(RabbitMQTestConstants.BROKER_PORT);
+        connectionFactory.setSaslConfig(RabbitMQTestConstants.SASL_CONFIG);
+        connectionFactory.setAutomaticRecoveryEnabled(false);
+        return new CachingConnectionFactory(connectionFactory);
+    }
+
+    @Bean
+    public AmqpAdmin amqpAdmin(ConnectionFactory connectionFactory) {
+        return new RabbitAdmin(connectionFactory);
+    }
+
+    @Bean(name = "testExchange")
+    public DirectExchange testExchange() {
+        return new DirectExchange(RabbitMQTestConstants.EXCHANGE, false, false);
+    }
+
+    @Bean(name = "testPushQueue")
+    public Queue testPushQueue() {
+        return new Queue(RabbitMQTestConstants.QUEUE_PUSH, false, false, false);
+    }
+
+    @Bean(name = "testPullQueue")
+    public Queue testPullQueue() {
+        return new Queue(RabbitMQTestConstants.QUEUE_PULL, false, false, false);
+    }
+
+    @Bean(name = "pushBinding")
+    public Binding pushBinding() {
+        return BindingBuilder.bind(testPushQueue()).to(testExchange()).with(RabbitMQTestConstants.ROUTING_KEY_PUSH);
+    }
+
+    @Bean(name = "pullBinding")
+    public Binding pullBinding() {
+        return BindingBuilder.bind(testPullQueue()).to(testExchange()).with(RabbitMQTestConstants.ROUTING_KEY_PULL);
+    }
+
+    @Bean(name = "rabbitTemplate")
+    public RabbitTemplate rabbitTemplate(ConnectionFactory connectionFactory) {
+        return new RabbitTemplate(connectionFactory);
+    }
+
+    @Bean(name = "testMessageHolder")
+    public TestMessageHolder testMessageHolder() {
+        return new TestMessageHolder();
+    }
+}

--- a/agent/src/test/java/com/navercorp/test/pinpoint/plugin/rabbitmq/spring/config/MessageListenerConfig_Post_1_4_0.java
+++ b/agent/src/test/java/com/navercorp/test/pinpoint/plugin/rabbitmq/spring/config/MessageListenerConfig_Post_1_4_0.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2018 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.test.pinpoint.plugin.rabbitmq.spring.config;
+
+import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.listener.RabbitListenerContainerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * @author HyunGil Jeong
+ */
+@Configuration
+@ComponentScan("com.navercorp.test.pinpoint.plugin.rabbitmq.spring.listener")
+public class MessageListenerConfig_Post_1_4_0 {
+
+    @Bean(name = "rabbitListenerContainerFactory")
+    public RabbitListenerContainerFactory rabbitListenerContainerFactory(ConnectionFactory connectionFactory) {
+        SimpleRabbitListenerContainerFactory containerFactory = new SimpleRabbitListenerContainerFactory();
+        containerFactory.setConnectionFactory(connectionFactory);
+        return containerFactory;
+    }
+}

--- a/agent/src/test/java/com/navercorp/test/pinpoint/plugin/rabbitmq/spring/config/MessageListenerConfig_Pre_1_4_0.java
+++ b/agent/src/test/java/com/navercorp/test/pinpoint/plugin/rabbitmq/spring/config/MessageListenerConfig_Pre_1_4_0.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2018 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.test.pinpoint.plugin.rabbitmq.spring.config;
+
+import com.navercorp.pinpoint.plugin.jdk7.rabbitmq.util.RabbitMQTestConstants;
+import com.navercorp.test.pinpoint.plugin.rabbitmq.spring.handler.TestMessageHandler;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
+import org.springframework.amqp.rabbit.listener.adapter.MessageListenerAdapter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * @author HyunGil Jeong
+ */
+@Configuration
+@ComponentScan("com.navercorp.test.pinpoint.plugin.rabbitmq.spring.handler")
+public class MessageListenerConfig_Pre_1_4_0 {
+
+    @Bean
+    public SimpleMessageListenerContainer listenerContainer(ConnectionFactory connectionFactory, TestMessageHandler testMessageHandler) {
+        SimpleMessageListenerContainer container = new SimpleMessageListenerContainer();
+        container.setConnectionFactory(connectionFactory);
+        container.setQueueNames(RabbitMQTestConstants.QUEUE_PUSH);
+        container.setMessageListener(new MessageListenerAdapter(testMessageHandler));
+        return container;
+    }
+}

--- a/agent/src/test/java/com/navercorp/test/pinpoint/plugin/rabbitmq/spring/config/ReceiverConfig_Post_1_6_0.java
+++ b/agent/src/test/java/com/navercorp/test/pinpoint/plugin/rabbitmq/spring/config/ReceiverConfig_Post_1_6_0.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2018 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.test.pinpoint.plugin.rabbitmq.spring.config;
+
+import com.navercorp.test.pinpoint.plugin.rabbitmq.spring.receiver.TestReceiver;
+import com.navercorp.test.pinpoint.plugin.rabbitmq.spring.receiver.TestReceiver_Post_1_6_0;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * @author HyunGil Jeong
+ */
+@Configuration
+public class ReceiverConfig_Post_1_6_0 {
+
+    @Bean
+    public TestReceiver testReceiver(RabbitTemplate rabbitTemplate) {
+        return new TestReceiver_Post_1_6_0(rabbitTemplate);
+    }
+}

--- a/agent/src/test/java/com/navercorp/test/pinpoint/plugin/rabbitmq/spring/config/ReceiverConfig_Pre_1_6_0.java
+++ b/agent/src/test/java/com/navercorp/test/pinpoint/plugin/rabbitmq/spring/config/ReceiverConfig_Pre_1_6_0.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2018 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.test.pinpoint.plugin.rabbitmq.spring.config;
+
+import com.navercorp.test.pinpoint.plugin.rabbitmq.spring.receiver.TestReceiver;
+import com.navercorp.test.pinpoint.plugin.rabbitmq.spring.receiver.TestReceiver_Pre_1_6_0;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * @author HyunGil Jeong
+ */
+@Configuration
+public class ReceiverConfig_Pre_1_6_0 {
+
+    @Bean
+    public TestReceiver testReceiver(RabbitTemplate rabbitTemplate) {
+        return new TestReceiver_Pre_1_6_0(rabbitTemplate);
+    }
+}

--- a/agent/src/test/java/com/navercorp/test/pinpoint/plugin/rabbitmq/spring/handler/TestMessageHandler.java
+++ b/agent/src/test/java/com/navercorp/test/pinpoint/plugin/rabbitmq/spring/handler/TestMessageHandler.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.test.pinpoint.plugin.rabbitmq.spring.handler;
+
+import com.navercorp.test.pinpoint.plugin.rabbitmq.PropagationMarker;
+import com.navercorp.test.pinpoint.plugin.rabbitmq.spring.TestMessageHolder;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author HyunGil Jeong
+ */
+@Component
+public class TestMessageHandler {
+
+    private final PropagationMarker marker = new PropagationMarker();
+    private final TestMessageHolder testMessageHolder;
+
+    @Autowired
+    public TestMessageHandler(TestMessageHolder testMessageHolder) {
+        if (testMessageHolder == null) {
+            throw new NullPointerException("testMessageHolder must not be null");
+        }
+        this.testMessageHolder = testMessageHolder;
+    }
+
+    public void handleMessage(String message) {
+        marker.mark();
+        testMessageHolder.addMessage(message);
+    }
+}

--- a/agent/src/test/java/com/navercorp/test/pinpoint/plugin/rabbitmq/spring/listener/TestMessageListener.java
+++ b/agent/src/test/java/com/navercorp/test/pinpoint/plugin/rabbitmq/spring/listener/TestMessageListener.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2018 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.test.pinpoint.plugin.rabbitmq.spring.listener;
+
+import com.navercorp.pinpoint.plugin.jdk7.rabbitmq.util.RabbitMQTestConstants;
+import com.navercorp.test.pinpoint.plugin.rabbitmq.PropagationMarker;
+import com.navercorp.test.pinpoint.plugin.rabbitmq.spring.TestMessageHolder;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author HyunGil Jeong
+ */
+@Component
+public class TestMessageListener {
+
+    private final PropagationMarker marker = new PropagationMarker();
+    private final TestMessageHolder testMessageHolder;
+
+    @Autowired
+    public TestMessageListener(TestMessageHolder testMessageHolder) {
+        if (testMessageHolder == null) {
+            throw new NullPointerException("testMessageHolder must not be null");
+        }
+        this.testMessageHolder = testMessageHolder;
+    }
+
+    @RabbitListener(queues = RabbitMQTestConstants.QUEUE_PUSH)
+    public void receiveMessage(String message) {
+        marker.mark();
+        testMessageHolder.addMessage(message);
+    }
+}

--- a/agent/src/test/java/com/navercorp/test/pinpoint/plugin/rabbitmq/spring/receiver/TestReceiver.java
+++ b/agent/src/test/java/com/navercorp/test/pinpoint/plugin/rabbitmq/spring/receiver/TestReceiver.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2018 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.test.pinpoint.plugin.rabbitmq.spring.receiver;
+
+import com.navercorp.test.pinpoint.plugin.rabbitmq.MessageConverter;
+
+/**
+ * @author HyunGil Jeong
+ */
+public interface TestReceiver {
+
+    <T> T receiveMessage(String queueName, MessageConverter<T> messageConverter);
+
+    <T> T receiveMessage(String queueName, MessageConverter<T> messageConverter, long timeoutMs) throws InterruptedException;
+}

--- a/agent/src/test/java/com/navercorp/test/pinpoint/plugin/rabbitmq/spring/receiver/TestReceiver_Post_1_6_0.java
+++ b/agent/src/test/java/com/navercorp/test/pinpoint/plugin/rabbitmq/spring/receiver/TestReceiver_Post_1_6_0.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2018 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.test.pinpoint.plugin.rabbitmq.spring.receiver;
+
+import com.navercorp.test.pinpoint.plugin.rabbitmq.MessageConverter;
+import org.springframework.amqp.core.Message;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+
+/**
+ * @author HyunGil Jeong
+ */
+public class TestReceiver_Post_1_6_0 implements TestReceiver {
+
+    private final RabbitTemplate rabbitTemplate;
+
+    public TestReceiver_Post_1_6_0(RabbitTemplate rabbitTemplate) {
+        if (rabbitTemplate == null) {
+            throw new NullPointerException("rabbitTemplate must not be null");
+        }
+        this.rabbitTemplate = rabbitTemplate;
+    }
+
+    @Override
+    public <T> T receiveMessage(String queueName, MessageConverter<T> messageConverter) {
+        Message message = rabbitTemplate.receive(queueName);
+        return convertMessage(messageConverter, message);
+    }
+
+    @Override
+    public <T> T receiveMessage(String queueName, MessageConverter<T> messageConverter, long timeoutMs) throws InterruptedException {
+        Message message = rabbitTemplate.receive(queueName, timeoutMs);
+        return convertMessage(messageConverter, message);
+    }
+
+    private <T> T convertMessage(MessageConverter<T> messageConverter, Message message) {
+        if (message == null) {
+            return null;
+        }
+        byte[] body = message.getBody();
+        return messageConverter.convertMessage(body);
+    }
+}

--- a/agent/src/test/java/com/navercorp/test/pinpoint/plugin/rabbitmq/spring/receiver/TestReceiver_Pre_1_6_0.java
+++ b/agent/src/test/java/com/navercorp/test/pinpoint/plugin/rabbitmq/spring/receiver/TestReceiver_Pre_1_6_0.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2018 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.test.pinpoint.plugin.rabbitmq.spring.receiver;
+
+import com.navercorp.test.pinpoint.plugin.rabbitmq.MessageConverter;
+import org.springframework.amqp.core.Message;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+
+/**
+ * @author HyunGil Jeong
+ */
+public class TestReceiver_Pre_1_6_0 implements TestReceiver {
+
+    private final RabbitTemplate rabbitTemplate;
+
+    public TestReceiver_Pre_1_6_0(RabbitTemplate rabbitTemplate) {
+        if (rabbitTemplate == null) {
+            throw new NullPointerException("rabbitTemplate must not be null");
+        }
+        this.rabbitTemplate = rabbitTemplate;
+    }
+
+    @Override
+    public <T> T receiveMessage(String queueName, MessageConverter<T> messageConverter) {
+        Message message = rabbitTemplate.receive(queueName);
+        if (message == null) {
+            return null;
+        }
+        byte[] body = message.getBody();
+        return messageConverter.convertMessage(body);
+    }
+
+    @Override
+    public <T> T receiveMessage(String queueName, MessageConverter<T> messageConverter, long timeoutMs) throws InterruptedException {
+        // RabbitTemplate.receive with timeout is only available from 1.6.0+
+        // We could instead utilize RabbitTemplate.setReceiveTimeout, but it's just the same thing as above for
+        // trace verification purposes.
+        throw new UnsupportedOperationException("receive with timeout not available");
+    }
+}

--- a/agent/src/test/java/com/navercorp/test/pinpoint/plugin/rabbitmq/spring/service/TestReceiverService.java
+++ b/agent/src/test/java/com/navercorp/test/pinpoint/plugin/rabbitmq/spring/service/TestReceiverService.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2018 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.test.pinpoint.plugin.rabbitmq.spring.service;
+
+import com.navercorp.pinpoint.plugin.jdk7.rabbitmq.util.RabbitMQTestConstants;
+import com.navercorp.test.pinpoint.plugin.rabbitmq.MessageConverter;
+import com.navercorp.test.pinpoint.plugin.rabbitmq.PropagationMarker;
+import com.navercorp.test.pinpoint.plugin.rabbitmq.spring.receiver.TestReceiver;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+/**
+ * @author HyunGil Jeong
+ */
+@Service
+public class TestReceiverService {
+
+    private final TestReceiver testReceiver;
+    private final PropagationMarker propagationMarker;
+
+    @Autowired
+    public TestReceiverService(TestReceiver testReceiver) {
+        if (testReceiver == null) {
+            throw new NullPointerException("testReceiver must not be null");
+        }
+        this.testReceiver = testReceiver;
+        this.propagationMarker = new PropagationMarker();
+    }
+
+    public <T> T receiveMessage(MessageConverter<T> messageConverter) {
+        T message = testReceiver.receiveMessage(RabbitMQTestConstants.QUEUE_PULL, messageConverter);
+        if (message == null) {
+            return null;
+        }
+        propagationMarker.mark();
+        return message;
+    }
+
+    public <T> T receiveMessage(MessageConverter<T> messageConverter, long timeoutMs) throws InterruptedException {
+        T message = testReceiver.receiveMessage(RabbitMQTestConstants.QUEUE_PULL, messageConverter, timeoutMs);
+        if (message == null) {
+            return null;
+        }
+        propagationMarker.mark();
+        return message;
+    }
+}

--- a/agent/src/test/java/com/navercorp/test/pinpoint/plugin/rabbitmq/spring/service/TestSenderService.java
+++ b/agent/src/test/java/com/navercorp/test/pinpoint/plugin/rabbitmq/spring/service/TestSenderService.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2018 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.test.pinpoint.plugin.rabbitmq.spring.service;
+
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+
+/**
+ * @author HyunGil Jeong
+ */
+@Service
+@Qualifier("testSenderService")
+public class TestSenderService {
+
+    @Autowired
+    private RabbitTemplate rabbitTemplate;
+
+    public void sendMessage(String exchange, String routingKey, String message) {
+        rabbitTemplate.convertAndSend(exchange, routingKey, message);
+    }
+}

--- a/plugins/rabbitmq/README.md
+++ b/plugins/rabbitmq/README.md
@@ -1,0 +1,39 @@
+### Pinpoint RabbitMQ Plugin
+
+#### Tracing custom Consumers
+RabbitMQ plugin traces `Consumer.handleDelivery(...)` implementations to record calls made when a *basic.deliver* is
+received by a consumer. 
+
+This is done automatically for consumers implemented in RabbitMQ Java Client (**DefaultConsumer**, **QueueingConsumer**)
+or in Spring-rabbit (**BlockingQueueConsumer$InternalConsumer**, **RabbitTemplate$TemplateConsumer**).
+
+However, if you implemented your own **Consumer** and registered to a channel like below, you must tell the agent what
+these consumers are unless the consumer explicitly calls `super.handleDelivery(...)`.
+```
+Consumer customConsumer = new DefaultConsumer(channel) {
+    @Override
+    public void handleDelivery(String consumerTag, Envelope envelope, AMQP.BasicProperties properties, byte[] body) throws IOException {
+        // code
+    }
+};
+channel.basicConsume(queue, customConsumer); 
+```
+To trace such consumers, please configure the following option in *pinpoint.config* with the fully qualified class name
+of the consumer.
+```
+profiler.rabbitmq.client.consumer.classes=
+```
+
+#### Excluding exchanges
+If you would like to exclude certain exchanges from being traced, please configure the following option in
+*pinpoint.config*.
+```
+profiler.rabbitmq.client.exchange.exclude=
+```
+
+#### Supported libraries
+The plugin has been tested on the following libraries.
+```
+com.rabbitmq:amqp-client - 2.7.0+
+org.springframework.amqp:spring-rabbit - 1.3.3+
+```

--- a/plugins/rabbitmq/src/main/java/com/navercorp/pinpoint/plugin/rabbitmq/client/RabbitMQClientConstants.java
+++ b/plugins/rabbitmq/src/main/java/com/navercorp/pinpoint/plugin/rabbitmq/client/RabbitMQClientConstants.java
@@ -36,6 +36,7 @@ public interface RabbitMQClientConstants {
     String RABBITMQ_SCOPE = "rabbitmqScope";
     String RABBITMQ_CONSUMER_SCOPE = "rabbitmqConsumerScope";
     String RABBITMQ_FRAME_HANDLER_CREATION_SCOPE = "rabbitmqFrameHandlerCreationScope";
+    String RABBITMQ_TEMPLATE_API_SCOPE = "rabbitmqTemplateApiScope";
 
     AnnotationKey RABBITMQ_EXCHANGE_ANNOTATION_KEY = AnnotationKeyFactory.of(130, "rabbitmq.exchange", VIEW_IN_RECORD_SET);
     AnnotationKey RABBITMQ_ROUTINGKEY_ANNOTATION_KEY = AnnotationKeyFactory.of(131, "rabbitmq.routingkey", VIEW_IN_RECORD_SET);

--- a/profiler-test/src/main/java/com/navercorp/pinpoint/test/PluginTestAgent.java
+++ b/profiler-test/src/main/java/com/navercorp/pinpoint/test/PluginTestAgent.java
@@ -744,7 +744,7 @@ public class PluginTestAgent extends DefaultAgent implements PluginTestVerifier 
 
     private String getConstructorInfo(Constructor<?> constructor) {
         Class<?>[] parameterTypes = constructor.getParameterTypes();
-        String[] parameterTypeNames = JavaAssistUtils.getParameterType(parameterTypes);
+        String[] parameterTypeNames = JavaAssistUtils.toPinpointParameterType(parameterTypes);
 
         final String constructorSimpleName = MethodDescriptionUtils.getConstructorSimpleName(constructor);
         return MethodDescriptionUtils.toJavaMethodDescriptor(constructor.getDeclaringClass().getName(), constructorSimpleName , parameterTypeNames);


### PR DESCRIPTION
This adds support for **RabbitTemplate** public APIs and integration tests for rabbitmq plugin on spring-amqp-rabbitmq.

related to #1412 