### PR TITLE
[#3906] dubbo plugin: already trace exist

### DIFF
--- a/plugins/dubbo/src/main/java/com/navercorp/pinpoint/plugin/dubbo/DubboConstants.java
+++ b/plugins/dubbo/src/main/java/com/navercorp/pinpoint/plugin/dubbo/DubboConstants.java
@@ -5,6 +5,7 @@ import com.navercorp.pinpoint.common.trace.AnnotationKeyFactory;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.common.trace.ServiceTypeFactory;
 
+import static com.navercorp.pinpoint.common.trace.AnnotationKeyProperty.VIEW_IN_RECORD_SET;
 import static com.navercorp.pinpoint.common.trace.ServiceTypeProperty.RECORD_STATISTICS;
 
 /**
@@ -14,8 +15,10 @@ public interface DubboConstants {
 
     ServiceType DUBBO_PROVIDER_SERVICE_TYPE = ServiceTypeFactory.of(1110, "DUBBO_PROVIDER", RECORD_STATISTICS);
     ServiceType DUBBO_CONSUMER_SERVICE_TYPE = ServiceTypeFactory.of(9110, "DUBBO_CONSUMER", RECORD_STATISTICS);
+    ServiceType DUBBO_PROVIDER_SERVICE_NO_STATISTICS_TYPE = ServiceTypeFactory.of(9111, "DUBBO");
     AnnotationKey DUBBO_ARGS_ANNOTATION_KEY = AnnotationKeyFactory.of(90, "dubbo.args");
     AnnotationKey DUBBO_RESULT_ANNOTATION_KEY = AnnotationKeyFactory.of(91, "dubbo.result");
+    AnnotationKey DUBBO_RPC_ANNOTATION_KEY = AnnotationKeyFactory.of(92, "dubbo.rpc", VIEW_IN_RECORD_SET);
 
     String META_DO_NOT_TRACE = "_DUBBO_DO_NOT_TRACE";
     String META_TRANSACTION_ID = "_DUBBO_TRASACTION_ID";

--- a/plugins/dubbo/src/main/java/com/navercorp/pinpoint/plugin/dubbo/DubboTraceMetadataProvider.java
+++ b/plugins/dubbo/src/main/java/com/navercorp/pinpoint/plugin/dubbo/DubboTraceMetadataProvider.java
@@ -11,7 +11,9 @@ public class DubboTraceMetadataProvider implements TraceMetadataProvider {
     public void setup(TraceMetadataSetupContext context) {
         context.addServiceType(DubboConstants.DUBBO_PROVIDER_SERVICE_TYPE);
         context.addServiceType(DubboConstants.DUBBO_CONSUMER_SERVICE_TYPE);
+        context.addServiceType(DubboConstants.DUBBO_PROVIDER_SERVICE_NO_STATISTICS_TYPE);
         context.addAnnotationKey(DubboConstants.DUBBO_ARGS_ANNOTATION_KEY);
         context.addAnnotationKey(DubboConstants.DUBBO_RESULT_ANNOTATION_KEY);
+        context.addAnnotationKey(DubboConstants.DUBBO_RPC_ANNOTATION_KEY);
     }
 }


### PR DESCRIPTION
When dubbo provider try to create trace, there maybe already has a trace in threadlocal. To avoid re-create a new trace, add a scope to trace to indicate not to remove the trace when leaving dubbo provider method.
This should fix issue #3906, #2981 and #3318.
To reproduce the condition I only using injvm call mode of dubbo to verify the fix, but I am not sure this will cover all 3 issues mentions above. The test app is at https://github.com/jiaqifeng/quickdemo.