### PR TITLE
Allows empty caller host for virtual queue nodes

### DIFF
--- a/web/src/main/java/com/navercorp/pinpoint/web/mapper/MapStatisticsCalleeMapper.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/mapper/MapStatisticsCalleeMapper.java
@@ -27,6 +27,7 @@ import com.navercorp.pinpoint.web.applicationmap.rawdata.LinkDataMap;
 import com.navercorp.pinpoint.web.service.ApplicationFactory;
 import com.navercorp.pinpoint.web.vo.Application;
 import com.sematext.hbase.wd.RowKeyDistributorByHashPrefix;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.CellUtil;
 import org.apache.hadoop.hbase.client.Result;
@@ -96,6 +97,12 @@ public class MapStatisticsCalleeMapper implements RowMapper<LinkDataMap> {
             short histogramSlot = ApplicationMapStatisticsUtils.getHistogramSlotFromColumnName(qualifier);
 
             String callerHost = ApplicationMapStatisticsUtils.getHost(qualifier);
+            // There may be no callerHost for virtual queue nodes from user-defined entry points.
+            // Terminal nodes, such as httpclient will not have callerHost set as well, but since they're terminal
+            // nodes, they would not have reached here in the first place.
+            if (calleeApplication.getServiceType().isQueue()) {
+                callerHost = StringUtils.defaultString(callerHost);
+            }
             boolean isError = histogramSlot == (short) -1;
 
             if (logger.isDebugEnabled()) {


### PR DESCRIPTION
Since virtual queue nodes are emulated, they do not have an agent id they can use to record statistics. Callee statistics for producer -> virtual queue node therefore must be emulated using producer's message queue span event.
Callee statistics generated this way use the caller span's end point as caller host.

When user-defined entry points are defined and caller spans are generated from this, they will not have an end point, throwing an NPE when querying for the server map.
Since this is a valid use-case, we must handle cases where the caller host is null when a virtual queue node's callee statistics is queried for the server map.

related to #3985 