### PR TITLE
[#noissue] Fix get simple class name of Logger

### DIFF
--- a/profiler/src/main/java/com/navercorp/pinpoint/profiler/logging/Slf4jPLoggerAdapter.java
+++ b/profiler/src/main/java/com/navercorp/pinpoint/profiler/logging/Slf4jPLoggerAdapter.java
@@ -203,17 +203,36 @@ public class Slf4jPLoggerAdapter implements PLogger {
             if (isSimpleType(arg)) {
                 return arg.toString();
             } else {
-                return arg.getClass().getSimpleName();
+                return getSimpleName(arg.getClass());
             }
         }
     }
 
-    private static boolean isSimpleType(Object arg) {
+    static boolean isSimpleType(Object arg) {
         Class<?> find = SIMPLE_TYPE.get(arg.getClass());
         if (find == null) {
             return false;
         }
         return true;
+    }
+
+    static String getSimpleName(final Class<?> clazz) {
+        if (clazz.isArray()) {
+            return getSimpleName(clazz.getComponentType()) + "[]";
+        }
+
+        final String simpleName = clazz.getName();
+        if (simpleName == null) {
+            // Defense
+            return "";
+        }
+
+        final int lastPackagePosition = simpleName.lastIndexOf('.');
+        if (lastPackagePosition != -1) {
+            // Strip the package name
+            return simpleName.substring(lastPackagePosition + 1);
+        }
+        return simpleName;
     }
 
     @Override

--- a/profiler/src/test/java/com/navercorp/pinpoint/profiler/logging/Slf4jPLoggerAdapterTest.java
+++ b/profiler/src/test/java/com/navercorp/pinpoint/profiler/logging/Slf4jPLoggerAdapterTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2018 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.profiler.logging;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author jaehong.kim
+ */
+public class Slf4jPLoggerAdapterTest {
+
+    @Test
+    public void getSimpleName() throws Exception {
+        assertEquals("int[]", Slf4jPLoggerAdapter.getSimpleName((new int[1]).getClass()));
+        assertEquals("Slf4jPLoggerAdapterTest$Dummy", Slf4jPLoggerAdapter.getSimpleName(Dummy.class));
+
+        Runnable r = new Runnable() {
+            @Override
+            public void run() {
+            }
+        };
+        assertEquals("Slf4jPLoggerAdapterTest$1", Slf4jPLoggerAdapter.getSimpleName(r.getClass()));
+    }
+
+    @Test
+    public void isSimpletype() {
+        assertTrue(Slf4jPLoggerAdapter.isSimpleType(new Integer(1)));
+        assertTrue(Slf4jPLoggerAdapter.isSimpleType(Boolean.TRUE));
+
+        // array, object
+        assertFalse(Slf4jPLoggerAdapter.isSimpleType(new int[1]));
+        assertFalse(Slf4jPLoggerAdapter.isSimpleType(new Dummy()));
+    }
+
+    private class Dummy {
+    }
+
+}


### PR DESCRIPTION
Avoid getDeclaringClass () calls when enclosing class.
