### PR TITLE
[#noissue] rename AgentInfoSenderListener

### DIFF
--- a/profiler/src/main/java/com/navercorp/pinpoint/profiler/AgentInfoSender.java
+++ b/profiler/src/main/java/com/navercorp/pinpoint/profiler/AgentInfoSender.java
@@ -173,7 +173,7 @@ public class AgentInfoSender {
                 final DefaultFuture<ResponseMessage> future = new DefaultFuture<ResponseMessage>();
 
                 logger.info("Sending AgentInfo {}", agentInfo);
-                dataSender.request(agentInfo, new AgentInfoSenderListener(future));
+                dataSender.request(agentInfo, new ResponseMessageFutureListener(future));
                 if (!future.await()) {
                     logger.warn("request timed out while waiting for response.");
                     return false;

--- a/profiler/src/main/java/com/navercorp/pinpoint/profiler/ResponseMessageFutureListener.java
+++ b/profiler/src/main/java/com/navercorp/pinpoint/profiler/ResponseMessageFutureListener.java
@@ -21,11 +21,11 @@ import com.navercorp.pinpoint.rpc.Future;
 import com.navercorp.pinpoint.rpc.FutureListener;
 import com.navercorp.pinpoint.rpc.ResponseMessage;
 
-public class AgentInfoSenderListener implements FutureListener<ResponseMessage> {
+public class ResponseMessageFutureListener implements FutureListener<ResponseMessage> {
 
     private final DefaultFuture<ResponseMessage> future;
 
-    public AgentInfoSenderListener(DefaultFuture<ResponseMessage> future) {
+    public ResponseMessageFutureListener(DefaultFuture<ResponseMessage> future) {
         this.future = future;
     }
 


### PR DESCRIPTION
rename (AgentInfoSenderListener -> ResponseMessageFutureListener)

AgentInfoSenderListener is a structure that can be used when set The ResponseMessage object in Future.
That's why I change the name.