### PR TITLE
Fixes travis ci security provider error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,14 @@ addons:
 jdk:
  - openjdk7
 
-env: JAVA_6_HOME=/usr/lib/jvm/java-6-openjdk-amd64 JAVA_7_HOME=/usr/lib/jvm/java-7-openjdk-amd64 JAVA_8_HOME=/usr/lib/jvm/java-8-oracle JAVA_9_HOME=/usr/lib/jvm/java-9-oracle
+env:
+ - JAVA_6_HOME=/usr/lib/jvm/java-6-openjdk-amd64
+   JAVA_7_HOME=/usr/lib/jvm/java-7-openjdk-amd64
+   JAVA_8_HOME=/usr/lib/jvm/java-8-oracle
+   JAVA_9_HOME=/usr/lib/jvm/java-9-oracle
+
+before_install:
+  - sudo sed -i 's/security.provider.9/#security.provider.9/g' $JAVA_HOME/jre/lib/security/java.security
 
 install:
  - set -o pipefail
@@ -21,11 +28,11 @@ install:
  - $JAVA_7_HOME/bin/java -version
  - $JAVA_8_HOME/bin/java -version
  - $JAVA_9_HOME/bin/java -version
- - mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V | grep -Fv '[copy'
+ - ./mvnw install -DskipTests=true -Dmaven.javadoc.skip=true -B -V | grep -Fv '[copy'
 
 script:
  - jdk_switcher use openjdk7
- - mvn clover:setup test -Ptest clover:aggregate clover:clover -e | grep -Fv 'DEBUG' | grep -Fv '[copy'
+ - ./mvnw clover:setup test -Ptest clover:aggregate clover:clover -e | grep -Fv 'DEBUG' | grep -Fv '[copy'
 
 after_success:
  - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
Build throws `java.security.ProviderException`, with root cause: no such provider: SunEC when fetching npm from registry.
May be due to openjdk 7 not having the proper security provider.
Try a potential workaround suggested in https://bugs.launchpad.net/ubuntu/+source/openjdk-6/+bug/1006776