### PR TITLE
[#github_4168] Add SerializerProvider parameter for TcpDataSenderProv…

### DIFF
--- a/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/module/RpcModule.java
+++ b/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/module/RpcModule.java
@@ -21,6 +21,7 @@ import com.google.inject.PrivateModule;
 import com.google.inject.Scopes;
 import com.navercorp.pinpoint.profiler.context.provider.CommandDispatcherProvider;
 import com.navercorp.pinpoint.profiler.context.provider.ConnectionFactoryProviderProvider;
+import com.navercorp.pinpoint.profiler.context.provider.HeaderTBaseSerializerProvider;
 import com.navercorp.pinpoint.profiler.context.provider.PinpointClientFactoryProvider;
 import com.navercorp.pinpoint.profiler.context.provider.SpanDataSenderProvider;
 import com.navercorp.pinpoint.profiler.context.provider.SpanStatClientFactoryProvider;
@@ -31,6 +32,7 @@ import com.navercorp.pinpoint.profiler.sender.DataSender;
 import com.navercorp.pinpoint.profiler.sender.EnhancedDataSender;
 import com.navercorp.pinpoint.rpc.client.ConnectionFactoryProvider;
 import com.navercorp.pinpoint.rpc.client.PinpointClientFactory;
+import com.navercorp.pinpoint.thrift.io.HeaderTBaseSerializer;
 
 /**
  * @author Woonduk Kang(emeroad)
@@ -46,9 +48,10 @@ public class RpcModule extends PrivateModule {
         bind(pinpointClientFactory).toProvider(PinpointClientFactoryProvider.class).in(Scopes.SINGLETON);
         expose(pinpointClientFactory);
 
+        bind(HeaderTBaseSerializer.class).toProvider(HeaderTBaseSerializerProvider.class).in(Scopes.SINGLETON);
+
         bind(EnhancedDataSender.class).toProvider(TcpDataSenderProvider.class).in(Scopes.SINGLETON);
         expose(EnhancedDataSender.class);
-
 
         Key<PinpointClientFactory> pinpointStatClientFactory = Key.get(PinpointClientFactory.class, SpanStatClientFactory.class);
         bind(pinpointStatClientFactory).toProvider(SpanStatClientFactoryProvider.class).in(Scopes.SINGLETON);
@@ -63,6 +66,6 @@ public class RpcModule extends PrivateModule {
         bind(DataSender.class).annotatedWith(StatDataSender.class)
                 .toProvider(StatDataSenderProvider.class).in(Scopes.SINGLETON);
         expose(statDataSender);
-
     }
+
 }

--- a/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/provider/HeaderTBaseSerializerProvider.java
+++ b/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/provider/HeaderTBaseSerializerProvider.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2018 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.profiler.context.provider;
+
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import com.navercorp.pinpoint.rpc.client.PinpointClientFactory;
+import com.navercorp.pinpoint.thrift.io.AgentEventTBaseLocator;
+import com.navercorp.pinpoint.thrift.io.HeaderTBaseSerializer;
+import com.navercorp.pinpoint.thrift.io.HeaderTBaseSerializerFactory;
+
+/**
+ * @author Taejin Koo
+ */
+public class HeaderTBaseSerializerProvider implements Provider<HeaderTBaseSerializer> {
+
+    private static final HeaderTBaseSerializerFactory DEFAULT_FACTORY = new HeaderTBaseSerializerFactory();
+
+    @Inject
+    public HeaderTBaseSerializerProvider() {
+    }
+
+    @Override
+    public HeaderTBaseSerializer get() {
+        return DEFAULT_FACTORY.createSerializer();
+    }
+
+}

--- a/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/provider/TcpDataSenderProvider.java
+++ b/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/provider/TcpDataSenderProvider.java
@@ -19,10 +19,12 @@ package com.navercorp.pinpoint.profiler.context.provider;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 import com.navercorp.pinpoint.bootstrap.config.ProfilerConfig;
+import com.navercorp.pinpoint.common.util.Assert;
 import com.navercorp.pinpoint.profiler.context.module.DefaultClientFactory;
 import com.navercorp.pinpoint.profiler.sender.EnhancedDataSender;
 import com.navercorp.pinpoint.profiler.sender.TcpDataSender;
 import com.navercorp.pinpoint.rpc.client.PinpointClientFactory;
+import com.navercorp.pinpoint.thrift.io.HeaderTBaseSerializer;
 
 /**
  * @author Woonduk Kang(emeroad)
@@ -30,19 +32,13 @@ import com.navercorp.pinpoint.rpc.client.PinpointClientFactory;
 public class TcpDataSenderProvider implements Provider<EnhancedDataSender> {
     private final ProfilerConfig profilerConfig;
     private final Provider<PinpointClientFactory> clientFactoryProvider;
+    private final Provider<HeaderTBaseSerializer> tBaseSerializerProvider;
 
     @Inject
-    public TcpDataSenderProvider(ProfilerConfig profilerConfig, @DefaultClientFactory Provider<PinpointClientFactory> clientFactoryProvider) {
-        if (profilerConfig == null) {
-            throw new NullPointerException("profilerConfig must not be null");
-        }
-        if (clientFactoryProvider == null) {
-            throw new NullPointerException("clientFactoryProvider must not be null");
-        }
-
-        this.profilerConfig = profilerConfig;
-        this.clientFactoryProvider = clientFactoryProvider;
-
+    public TcpDataSenderProvider(ProfilerConfig profilerConfig, @DefaultClientFactory Provider<PinpointClientFactory> clientFactoryProvider, Provider<HeaderTBaseSerializer> tBaseSerializerProvider) {
+        this.profilerConfig = Assert.requireNonNull(profilerConfig, "profilerConfig must not be null");
+        this.clientFactoryProvider = Assert.requireNonNull(clientFactoryProvider, "clientFactoryProvider must not be null");
+        this.tBaseSerializerProvider = Assert.requireNonNull(tBaseSerializerProvider, "tBaseSerializerProvider must not be null");
     }
 
     @Override
@@ -50,6 +46,7 @@ public class TcpDataSenderProvider implements Provider<EnhancedDataSender> {
         PinpointClientFactory clientFactory = clientFactoryProvider.get();
         String collectorTcpServerIp = profilerConfig.getCollectorTcpServerIp();
         int collectorTcpServerPort = profilerConfig.getCollectorTcpServerPort();
-        return new TcpDataSender("Default", collectorTcpServerIp, collectorTcpServerPort, clientFactory);
+        HeaderTBaseSerializer headerTBaseSerializer = tBaseSerializerProvider.get();
+        return new TcpDataSender("Default", collectorTcpServerIp, collectorTcpServerPort, clientFactory, headerTBaseSerializer);
     }
 }


### PR DESCRIPTION
…ider

Allows the TcpDataSenderProvider to allocate the HeaderTBaseSerializer externally.
This allows the TcpDataSender to extend or modify the writable TBase object.