### PR TITLE
[#4214] Improved compatibility of ClassLoader.defineClass() for java9

### DIFF
--- a/profiler-optional/profiler-optional-jdk9/pom.xml
+++ b/profiler-optional/profiler-optional-jdk9/pom.xml
@@ -70,27 +70,6 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.18.1</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>integration-test</goal>
-                            <goal>verify</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <jvm>${jdk.home}/bin/java</jvm>
-                    <!-- AbstractPinpointPluginTestSuite needs this to resolve
-                        path of required jars -->
-                    <useSystemClassLoader>false</useSystemClassLoader>
-                    <failIfNoTests>true</failIfNoTests>
-                </configuration>
-            </plugin>
-
-            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>animal-sniffer-maven-plugin</artifactId>
                 <version>1.16</version>


### PR DESCRIPTION
 - Remove maven-failsafe-plugin