### PR TITLE
[4346] Allows the ClientOption setting in the setup file

### DIFF
--- a/agent/src/main/resources-local/pinpoint.config
+++ b/agent/src/main/resources-local/pinpoint.config
@@ -90,6 +90,12 @@ profiler.tcpdatasender.command.activethread.count.enable=true
 profiler.tcpdatasender.command.activethread.threaddump.enable=true
 profiler.tcpdatasender.command.activethread.threadlightdump.enable=true
 
+profiler.tcpdatasender.client.write.timeout=3000
+profiler.tcpdatasender.client.request.timeout=3000
+profiler.tcpdatasender.client.reconnect.interval=3000
+profiler.tcpdatasender.client.ping.interval=300000
+profiler.tcpdatasender.client.handshake.interval=60000
+
 # Trace Agent active thread info.
 profiler.pinpoint.activethread=true
 

--- a/agent/src/main/resources-release/pinpoint.config
+++ b/agent/src/main/resources-release/pinpoint.config
@@ -86,6 +86,12 @@ profiler.tcpdatasender.command.activethread.count.enable=true
 profiler.tcpdatasender.command.activethread.threaddump.enable=true
 profiler.tcpdatasender.command.activethread.threadlightdump.enable=true
 
+profiler.tcpdatasender.client.write.timeout=3000
+profiler.tcpdatasender.client.request.timeout=3000
+profiler.tcpdatasender.client.reconnect.interval=3000
+profiler.tcpdatasender.client.ping.interval=300000
+profiler.tcpdatasender.client.handshake.interval=60000
+
 # Trace Agent active thread info.
 profiler.pinpoint.activethread=true
 

--- a/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/config/DefaultProfilerConfig.java
+++ b/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/config/DefaultProfilerConfig.java
@@ -131,6 +131,17 @@ public class DefaultProfilerConfig implements ProfilerConfig {
     private boolean tcpDataSenderCommandActiveThreadDumpEnable = false;
     private boolean tcpDataSenderCommandActiveThreadLightDumpEnable = false;
 
+    private static long DEFAULT_DATA_SENDER_PINPOINT_CLIENT_WRITE_TIMEOUT = 3 * 1000;
+    private long tcpDataSenderPinpointClientWriteTimeout = DEFAULT_DATA_SENDER_PINPOINT_CLIENT_WRITE_TIMEOUT;
+    private static long DEFAULT_DATA_SENDER_PINPOINT_CLIENT_REQUEST_TIMEOUT = 3 * 1000;
+    private long tcpDataSenderPinpointClientRequestTimeout = DEFAULT_DATA_SENDER_PINPOINT_CLIENT_REQUEST_TIMEOUT;
+    private static long DEFAULT_DATA_SENDER_PINPOINT_CLIENT_RECONNECT_INTERVAL = 3 * 1000;
+    private long tcpDataSenderPinpointClientReconnectInterval = DEFAULT_DATA_SENDER_PINPOINT_CLIENT_RECONNECT_INTERVAL;
+    private static long DEFAULT_DATA_SENDER_PINPOINT_CLIENT_PING_INTERVAL = 60 * 1000 * 5;
+    private long tcpDataSenderPinpointClientPingInterval = DEFAULT_DATA_SENDER_PINPOINT_CLIENT_PING_INTERVAL;
+    private static long DEFAULT_DATA_SENDER_PINPOINT_CLIENT_HANDSHAKE_INTERVAL = 60 * 1000 * 1;
+    private long tcpDataSenderPinpointClientHandshakeInterval = DEFAULT_DATA_SENDER_PINPOINT_CLIENT_HANDSHAKE_INTERVAL;
+
     private boolean traceAgentActiveThread = true;
 
     private boolean traceAgentDataSource = false;
@@ -283,6 +294,31 @@ public class DefaultProfilerConfig implements ProfilerConfig {
     @Override
     public boolean isTcpDataSenderCommandActiveThreadLightDumpEnable() {
         return tcpDataSenderCommandActiveThreadLightDumpEnable;
+    }
+
+    @Override
+    public long getTcpDataSenderPinpointClientWriteTimeout() {
+        return tcpDataSenderPinpointClientWriteTimeout;
+    }
+
+    @Override
+    public long getTcpDataSenderPinpointClientRequestTimeout() {
+        return tcpDataSenderPinpointClientRequestTimeout;
+    }
+
+    @Override
+    public long getTcpDataSenderPinpointClientReconnectInterval() {
+        return tcpDataSenderPinpointClientReconnectInterval;
+    }
+
+    @Override
+    public long getTcpDataSenderPinpointClientPingInterval() {
+        return tcpDataSenderPinpointClientPingInterval;
+    }
+
+    @Override
+    public long getTcpDataSenderPinpointClientHandshakeInterval() {
+        return tcpDataSenderPinpointClientHandshakeInterval;
     }
 
     @Override
@@ -541,6 +577,12 @@ public class DefaultProfilerConfig implements ProfilerConfig {
         this.tcpDataSenderCommandActiveThreadDumpEnable = readBoolean("profiler.tcpdatasender.command.activethread.threaddump.enable", false);
         this.tcpDataSenderCommandActiveThreadLightDumpEnable = readBoolean("profiler.tcpdatasender.command.activethread.threadlightdump.enable", false);
 
+        this.tcpDataSenderPinpointClientWriteTimeout = readLong("profiler.tcpdatasender.client.write.timeout", DEFAULT_DATA_SENDER_PINPOINT_CLIENT_WRITE_TIMEOUT);
+        this.tcpDataSenderPinpointClientRequestTimeout = readLong("profiler.tcpdatasender.client.request.timeout", DEFAULT_DATA_SENDER_PINPOINT_CLIENT_REQUEST_TIMEOUT);
+        this.tcpDataSenderPinpointClientReconnectInterval = readLong("profiler.tcpdatasender.client.reconnect.interval", DEFAULT_DATA_SENDER_PINPOINT_CLIENT_RECONNECT_INTERVAL);
+        this.tcpDataSenderPinpointClientPingInterval = readLong("profiler.tcpdatasender.client.ping.interval", DEFAULT_DATA_SENDER_PINPOINT_CLIENT_PING_INTERVAL);
+        this.tcpDataSenderPinpointClientHandshakeInterval = readLong("profiler.tcpdatasender.client.handshake.interval", DEFAULT_DATA_SENDER_PINPOINT_CLIENT_HANDSHAKE_INTERVAL);
+
         this.traceAgentActiveThread = readBoolean("profiler.pinpoint.activethread", true);
 
         this.traceAgentDataSource = readBoolean("profiler.pinpoint.datasource", false);
@@ -742,6 +784,11 @@ public class DefaultProfilerConfig implements ProfilerConfig {
         sb.append(", tcpDataSenderCommandActiveThreadCountEnable=").append(tcpDataSenderCommandActiveThreadCountEnable);
         sb.append(", tcpDataSenderCommandActiveThreadDumpEnable=").append(tcpDataSenderCommandActiveThreadDumpEnable);
         sb.append(", tcpDataSenderCommandActiveThreadLightDumpEnable=").append(tcpDataSenderCommandActiveThreadLightDumpEnable);
+        sb.append(", tcpDataSenderPinpointClientWriteTimeout=").append(tcpDataSenderPinpointClientWriteTimeout);
+        sb.append(", tcpDataSenderPinpointClientRequestTimeout=").append(tcpDataSenderPinpointClientRequestTimeout);
+        sb.append(", tcpDataSenderPinpointClientReconnectInterval=").append(tcpDataSenderPinpointClientReconnectInterval);
+        sb.append(", tcpDataSenderPinpointClientPingInterval=").append(tcpDataSenderPinpointClientPingInterval);
+        sb.append(", tcpDataSenderPinpointClientHandshakeInterval=").append(tcpDataSenderPinpointClientHandshakeInterval);
         sb.append(", traceAgentActiveThread=").append(traceAgentActiveThread);
         sb.append(", traceAgentDataSource=").append(traceAgentDataSource);
         sb.append(", dataSourceTraceLimitSize=").append(dataSourceTraceLimitSize);
@@ -775,4 +822,5 @@ public class DefaultProfilerConfig implements ProfilerConfig {
         sb.append('}');
         return sb.toString();
     }
+
 }

--- a/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/config/ProfilerConfig.java
+++ b/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/config/ProfilerConfig.java
@@ -65,6 +65,16 @@ public interface ProfilerConfig {
 
     boolean isTcpDataSenderCommandActiveThreadLightDumpEnable();
 
+    long getTcpDataSenderPinpointClientWriteTimeout();
+
+    long getTcpDataSenderPinpointClientRequestTimeout();
+
+    long getTcpDataSenderPinpointClientReconnectInterval();
+
+    long getTcpDataSenderPinpointClientPingInterval();
+
+    long getTcpDataSenderPinpointClientHandshakeInterval();
+
     boolean isTraceAgentActiveThread();
 
     boolean isTraceAgentDataSource();

--- a/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/provider/PinpointClientFactoryProvider.java
+++ b/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/provider/PinpointClientFactoryProvider.java
@@ -61,8 +61,11 @@ public class PinpointClientFactoryProvider implements Provider<PinpointClientFac
 
     public PinpointClientFactory get() {
         PinpointClientFactory pinpointClientFactory = new DefaultPinpointClientFactory(connectionFactoryProvider.get());
-        pinpointClientFactory.setWriteTimeoutMillis(1000 * 3);
-        pinpointClientFactory.setRequestTimeoutMillis(1000 * 5);
+        pinpointClientFactory.setWriteTimeoutMillis(profilerConfig.getTcpDataSenderPinpointClientWriteTimeout());
+        pinpointClientFactory.setRequestTimeoutMillis(profilerConfig.getTcpDataSenderPinpointClientRequestTimeout());
+        pinpointClientFactory.setReconnectDelay(profilerConfig.getTcpDataSenderPinpointClientReconnectInterval());
+        pinpointClientFactory.setPingDelay(profilerConfig.getTcpDataSenderPinpointClientPingInterval());
+        pinpointClientFactory.setEnableWorkerPacketDelay(profilerConfig.getTcpDataSenderPinpointClientHandshakeInterval());
 
         AgentInformation agentInformation = this.agentInformation.get();
         Map<String, Object> properties = toMap(agentInformation);


### PR DESCRIPTION
Allows the ClientOption setting in the setup file

```
profiler.tcpdatasender.client.write.timeout=3000
profiler.tcpdatasender.client.request.timeout=3000
profiler.tcpdatasender.client.reconnect.interval=3000
profiler.tcpdatasender.client.ping.interval=300000
profiler.tcpdatasender.client.handshake.interval=60000
```