### PR TITLE
Ups hbase shaded client version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -358,7 +358,7 @@
             <dependency>
                 <groupId>org.apache.hbase</groupId>
                 <artifactId>hbase-shaded-client</artifactId>
-                <version>1.2.4</version>
+                <version>1.2.6.1</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
This changes hbase shaded client version to 1.2.6.1.
resolves #4385 