### PR TITLE
Cleans up rabbitmq integration test

### DIFF
--- a/agent-it/src/test/java/com/navercorp/pinpoint/plugin/jdk7/rabbitmq/RabbitMQClient_2_7_0_to_3_3_0_IT.java
+++ b/agent-it/src/test/java/com/navercorp/pinpoint/plugin/jdk7/rabbitmq/RabbitMQClient_2_7_0_to_3_3_0_IT.java
@@ -18,7 +18,6 @@ package com.navercorp.pinpoint.plugin.jdk7.rabbitmq;
 
 import com.navercorp.pinpoint.plugin.AgentPath;
 import com.navercorp.pinpoint.test.plugin.Dependency;
-import com.navercorp.pinpoint.test.plugin.JvmArgument;
 import com.navercorp.pinpoint.test.plugin.PinpointAgent;
 import com.navercorp.pinpoint.test.plugin.PinpointConfig;
 import com.navercorp.pinpoint.test.plugin.PinpointPluginTestSuite;
@@ -33,7 +32,6 @@ import org.junit.runner.RunWith;
 @PinpointAgent(AgentPath.PATH)
 @PinpointConfig("rabbitmq/client/pinpoint-rabbitmq.config")
 @Dependency({"com.rabbitmq:amqp-client:[2.7.0,3.0.0)", "org.apache.qpid:qpid-broker:6.1.1"})
-@JvmArgument({"-Dpinpoint.configcenter=false"})
 public class RabbitMQClient_2_7_0_to_3_3_0_IT extends RabbitMQClientITBase {
 
     @Test

--- a/agent-it/src/test/java/com/navercorp/pinpoint/plugin/jdk7/rabbitmq/RabbitMQClient_3_3_0_to_4_0_0_IT.java
+++ b/agent-it/src/test/java/com/navercorp/pinpoint/plugin/jdk7/rabbitmq/RabbitMQClient_3_3_0_to_4_0_0_IT.java
@@ -18,7 +18,6 @@ package com.navercorp.pinpoint.plugin.jdk7.rabbitmq;
 
 import com.navercorp.pinpoint.plugin.AgentPath;
 import com.navercorp.pinpoint.test.plugin.Dependency;
-import com.navercorp.pinpoint.test.plugin.JvmArgument;
 import com.navercorp.pinpoint.test.plugin.PinpointAgent;
 import com.navercorp.pinpoint.test.plugin.PinpointConfig;
 import com.navercorp.pinpoint.test.plugin.PinpointPluginTestSuite;
@@ -34,7 +33,6 @@ import org.junit.runner.RunWith;
 @PinpointAgent(AgentPath.PATH)
 @PinpointConfig("rabbitmq/client/pinpoint-rabbitmq.config")
 @Dependency({"com.rabbitmq:amqp-client:[3.3.0,4.0.0)", "org.apache.qpid:qpid-broker:6.1.1"})
-@JvmArgument({"-Dpinpoint.configcenter=false"})
 public class RabbitMQClient_3_3_0_to_4_0_0_IT extends RabbitMQClientITBase {
 
     @Test

--- a/agent-it/src/test/java/com/navercorp/pinpoint/plugin/jdk7/rabbitmq/RabbitMQClient_4_x_IT.java
+++ b/agent-it/src/test/java/com/navercorp/pinpoint/plugin/jdk7/rabbitmq/RabbitMQClient_4_x_IT.java
@@ -18,7 +18,6 @@ package com.navercorp.pinpoint.plugin.jdk7.rabbitmq;
 
 import com.navercorp.pinpoint.plugin.AgentPath;
 import com.navercorp.pinpoint.test.plugin.Dependency;
-import com.navercorp.pinpoint.test.plugin.JvmArgument;
 import com.navercorp.pinpoint.test.plugin.PinpointAgent;
 import com.navercorp.pinpoint.test.plugin.PinpointConfig;
 import com.navercorp.pinpoint.test.plugin.PinpointPluginTestSuite;
@@ -34,7 +33,6 @@ import org.junit.runner.RunWith;
 @PinpointAgent(AgentPath.PATH)
 @PinpointConfig("rabbitmq/client/pinpoint-rabbitmq.config")
 @Dependency({"com.rabbitmq:amqp-client:[4.0.0,4.max)", "org.apache.qpid:qpid-broker:6.1.1"})
-@JvmArgument({"-Dpinpoint.configcenter=false"})
 public class RabbitMQClient_4_x_IT extends RabbitMQClientITBase {
 
     @Test

--- a/agent-it/src/test/java/com/navercorp/pinpoint/plugin/jdk7/rabbitmq/RabbitMQClient_5_x_IT.java
+++ b/agent-it/src/test/java/com/navercorp/pinpoint/plugin/jdk7/rabbitmq/RabbitMQClient_5_x_IT.java
@@ -18,7 +18,6 @@ package com.navercorp.pinpoint.plugin.jdk7.rabbitmq;
 
 import com.navercorp.pinpoint.plugin.AgentPath;
 import com.navercorp.pinpoint.test.plugin.Dependency;
-import com.navercorp.pinpoint.test.plugin.JvmArgument;
 import com.navercorp.pinpoint.test.plugin.JvmVersion;
 import com.navercorp.pinpoint.test.plugin.PinpointAgent;
 import com.navercorp.pinpoint.test.plugin.PinpointConfig;
@@ -36,7 +35,6 @@ import org.junit.runner.RunWith;
 @PinpointConfig("rabbitmq/client/pinpoint-rabbitmq.config")
 @Dependency({"com.rabbitmq:amqp-client:[5.0.0,)", "org.apache.qpid:qpid-broker:6.1.1"})
 @JvmVersion(8)
-@JvmArgument({"-Dpinpoint.configcenter=false"})
 public class RabbitMQClient_5_x_IT extends RabbitMQClientITBase {
 
     @Test

--- a/agent-it/src/test/java/com/navercorp/pinpoint/plugin/jdk7/rabbitmq/spring/SpringAmqpRabbit_1_3_3_to_1_4_2_IT.java
+++ b/agent-it/src/test/java/com/navercorp/pinpoint/plugin/jdk7/rabbitmq/spring/SpringAmqpRabbit_1_3_3_to_1_4_2_IT.java
@@ -28,7 +28,6 @@ import com.navercorp.test.pinpoint.plugin.rabbitmq.spring.config.ReceiverConfig_
 import com.navercorp.pinpoint.plugin.jdk7.rabbitmq.util.RabbitMQTestConstants;
 import com.navercorp.pinpoint.plugin.jdk7.rabbitmq.util.TestBroker;
 import com.navercorp.pinpoint.test.plugin.Dependency;
-import com.navercorp.pinpoint.test.plugin.JvmArgument;
 import com.navercorp.pinpoint.test.plugin.PinpointConfig;
 import com.navercorp.pinpoint.test.plugin.PinpointPluginTestSuite;
 import com.navercorp.test.pinpoint.plugin.rabbitmq.PropagationMarker;
@@ -53,7 +52,6 @@ import java.lang.reflect.Method;
 @PinpointAgent(AgentPath.PATH)
 @PinpointConfig("rabbitmq/client/pinpoint-rabbitmq.config")
 @Dependency({"org.springframework.amqp:spring-rabbit:[1.3.3.RELEASE,1.4.2.RELEASE)", "com.fasterxml.jackson.core:jackson-core:2.8.11", "org.apache.qpid:qpid-broker:6.1.1"})
-@JvmArgument({"-Dpinpoint.configcenter=false"})
 public class SpringAmqpRabbit_1_3_3_to_1_4_2_IT {
 
     private static final TestBroker BROKER = new TestBroker();

--- a/agent-it/src/test/java/com/navercorp/pinpoint/plugin/jdk7/rabbitmq/spring/SpringAmqpRabbit_1_4_2_to_1_7_0_IT.java
+++ b/agent-it/src/test/java/com/navercorp/pinpoint/plugin/jdk7/rabbitmq/spring/SpringAmqpRabbit_1_4_2_to_1_7_0_IT.java
@@ -28,7 +28,6 @@ import com.navercorp.test.pinpoint.plugin.rabbitmq.spring.config.ReceiverConfig_
 import com.navercorp.pinpoint.plugin.jdk7.rabbitmq.util.RabbitMQTestConstants;
 import com.navercorp.pinpoint.plugin.jdk7.rabbitmq.util.TestBroker;
 import com.navercorp.pinpoint.test.plugin.Dependency;
-import com.navercorp.pinpoint.test.plugin.JvmArgument;
 import com.navercorp.pinpoint.test.plugin.PinpointConfig;
 import com.navercorp.pinpoint.test.plugin.PinpointPluginTestSuite;
 import com.navercorp.test.pinpoint.plugin.rabbitmq.PropagationMarker;
@@ -54,7 +53,6 @@ import java.lang.reflect.Method;
 @PinpointConfig("rabbitmq/client/pinpoint-rabbitmq.config")
 // 1.4.5, 1.4.6, 1.6.4.RELEASE has dependency issues
 @Dependency({"org.springframework.amqp:spring-rabbit:[1.4.2.RELEASE,1.4.5.RELEASE),[1.5.0.RELEASE,1.6.4.RELEASE),[1.6.5.RELEASE,1.7.0.RELEASE)", "com.fasterxml.jackson.core:jackson-core:2.8.11", "org.apache.qpid:qpid-broker:6.1.1"})
-@JvmArgument({"-Dpinpoint.configcenter=false"})
 public class SpringAmqpRabbit_1_4_2_to_1_7_0_IT {
 
     private static final TestBroker BROKER = new TestBroker();

--- a/agent-it/src/test/java/com/navercorp/pinpoint/plugin/jdk7/rabbitmq/spring/SpringAmqpRabbit_1_7_0_to_1_7_7_IT.java
+++ b/agent-it/src/test/java/com/navercorp/pinpoint/plugin/jdk7/rabbitmq/spring/SpringAmqpRabbit_1_7_0_to_1_7_7_IT.java
@@ -28,7 +28,6 @@ import com.navercorp.test.pinpoint.plugin.rabbitmq.spring.config.ReceiverConfig_
 import com.navercorp.pinpoint.plugin.jdk7.rabbitmq.util.RabbitMQTestConstants;
 import com.navercorp.pinpoint.plugin.jdk7.rabbitmq.util.TestBroker;
 import com.navercorp.pinpoint.test.plugin.Dependency;
-import com.navercorp.pinpoint.test.plugin.JvmArgument;
 import com.navercorp.pinpoint.test.plugin.PinpointConfig;
 import com.navercorp.pinpoint.test.plugin.PinpointPluginTestSuite;
 import com.navercorp.test.pinpoint.plugin.rabbitmq.PropagationMarker;
@@ -53,7 +52,6 @@ import java.lang.reflect.Method;
 @PinpointAgent(AgentPath.PATH)
 @PinpointConfig("rabbitmq/client/pinpoint-rabbitmq.config")
 @Dependency({"org.springframework.amqp:spring-rabbit:[1.7.0.RELEASE,1.7.7.RELEASE)", "com.fasterxml.jackson.core:jackson-core:2.8.11", "org.apache.qpid:qpid-broker:6.1.1"})
-@JvmArgument({"-Dpinpoint.configcenter=false"})
 public class SpringAmqpRabbit_1_7_0_to_1_7_7_IT {
 
     private static final TestBroker BROKER = new TestBroker();

--- a/agent-it/src/test/java/com/navercorp/pinpoint/plugin/jdk7/rabbitmq/spring/SpringAmqpRabbit_1_7_7_to_2_0_0_IT.java
+++ b/agent-it/src/test/java/com/navercorp/pinpoint/plugin/jdk7/rabbitmq/spring/SpringAmqpRabbit_1_7_7_to_2_0_0_IT.java
@@ -24,7 +24,6 @@ import com.navercorp.pinpoint.plugin.AgentPath;
 import com.navercorp.pinpoint.plugin.jdk7.rabbitmq.util.RabbitMQTestConstants;
 import com.navercorp.pinpoint.plugin.jdk7.rabbitmq.util.TestBroker;
 import com.navercorp.pinpoint.test.plugin.Dependency;
-import com.navercorp.pinpoint.test.plugin.JvmArgument;
 import com.navercorp.pinpoint.test.plugin.PinpointAgent;
 import com.navercorp.pinpoint.test.plugin.PinpointConfig;
 import com.navercorp.pinpoint.test.plugin.PinpointPluginTestSuite;
@@ -56,7 +55,6 @@ import java.lang.reflect.Method;
 @PinpointAgent(AgentPath.PATH)
 @PinpointConfig("rabbitmq/client/pinpoint-rabbitmq.config")
 @Dependency({"org.springframework.amqp:spring-rabbit:[1.7.7.RELEASE,2.0.0.RELEASE)", "com.fasterxml.jackson.core:jackson-core:2.8.11", "org.apache.qpid:qpid-broker:6.1.1"})
-@JvmArgument({"-Dpinpoint.configcenter=false"})
 public class SpringAmqpRabbit_1_7_7_to_2_0_0_IT {
 
     private static final TestBroker BROKER = new TestBroker();

--- a/agent-it/src/test/java/com/navercorp/pinpoint/plugin/jdk7/rabbitmq/spring/SpringAmqpRabbit_2_0_0_to_2_0_3_IT.java
+++ b/agent-it/src/test/java/com/navercorp/pinpoint/plugin/jdk7/rabbitmq/spring/SpringAmqpRabbit_2_0_0_to_2_0_3_IT.java
@@ -29,7 +29,6 @@ import com.navercorp.test.pinpoint.plugin.rabbitmq.spring.config.ReceiverConfig_
 import com.navercorp.pinpoint.plugin.jdk7.rabbitmq.util.RabbitMQTestConstants;
 import com.navercorp.pinpoint.plugin.jdk7.rabbitmq.util.TestBroker;
 import com.navercorp.pinpoint.test.plugin.Dependency;
-import com.navercorp.pinpoint.test.plugin.JvmArgument;
 import com.navercorp.pinpoint.test.plugin.PinpointConfig;
 import com.navercorp.pinpoint.test.plugin.PinpointPluginTestSuite;
 import com.navercorp.test.pinpoint.plugin.rabbitmq.PropagationMarker;
@@ -63,7 +62,6 @@ import java.lang.reflect.Method;
 @PinpointConfig("rabbitmq/client/pinpoint-rabbitmq.config")
 @Dependency({"org.springframework.amqp:spring-rabbit:[2.0.0.RELEASE,2.0.3.RELEASE)", "com.fasterxml.jackson.core:jackson-core:2.8.11", "org.apache.qpid:qpid-broker:6.1.1"})
 @JvmVersion(8)
-@JvmArgument({"-Dpinpoint.configcenter=false"})
 public class SpringAmqpRabbit_2_0_0_to_2_0_3_IT {
 
     private static final TestBroker BROKER = new TestBroker();

--- a/agent-it/src/test/java/com/navercorp/pinpoint/plugin/jdk7/rabbitmq/spring/SpringAmqpRabbit_2_0_3_to_2_x_IT.java
+++ b/agent-it/src/test/java/com/navercorp/pinpoint/plugin/jdk7/rabbitmq/spring/SpringAmqpRabbit_2_0_3_to_2_x_IT.java
@@ -24,7 +24,6 @@ import com.navercorp.pinpoint.plugin.AgentPath;
 import com.navercorp.pinpoint.plugin.jdk7.rabbitmq.util.RabbitMQTestConstants;
 import com.navercorp.pinpoint.plugin.jdk7.rabbitmq.util.TestBroker;
 import com.navercorp.pinpoint.test.plugin.Dependency;
-import com.navercorp.pinpoint.test.plugin.JvmArgument;
 import com.navercorp.pinpoint.test.plugin.JvmVersion;
 import com.navercorp.pinpoint.test.plugin.PinpointAgent;
 import com.navercorp.pinpoint.test.plugin.PinpointConfig;
@@ -62,7 +61,6 @@ import java.lang.reflect.Method;
 @PinpointConfig("rabbitmq/client/pinpoint-rabbitmq.config")
 @Dependency({"org.springframework.amqp:spring-rabbit:[2.0.3.RELEASE,)", "com.fasterxml.jackson.core:jackson-core:2.8.11", "org.apache.qpid:qpid-broker:6.1.1"})
 @JvmVersion(8)
-@JvmArgument({"-Dpinpoint.configcenter=false"})
 public class SpringAmqpRabbit_2_0_3_to_2_x_IT {
 
     private static final TestBroker BROKER = new TestBroker();

--- a/agent-it/src/test/java/com/navercorp/pinpoint/plugin/jdk7/rabbitmq/util/DerbyUtil.java
+++ b/agent-it/src/test/java/com/navercorp/pinpoint/plugin/jdk7/rabbitmq/util/DerbyUtil.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2018 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.plugin.jdk7.rabbitmq.util;
+
+import java.io.OutputStream;
+
+/**
+ * Suppress derby.log by setting <code>derby.stream.error.field</code> to "DerbyUtil.DEV_NULL".
+ *
+ * @author HyunGil Jeong
+ */
+public class DerbyUtil {
+    public static final OutputStream DEV_NULL = new OutputStream() {
+        public void write(int b) {}
+    };
+}

--- a/agent-it/src/test/java/com/navercorp/pinpoint/plugin/jdk7/rabbitmq/util/TestBroker.java
+++ b/agent-it/src/test/java/com/navercorp/pinpoint/plugin/jdk7/rabbitmq/util/TestBroker.java
@@ -19,6 +19,8 @@ package com.navercorp.pinpoint.plugin.jdk7.rabbitmq.util;
 import org.apache.qpid.server.Broker;
 import org.apache.qpid.server.BrokerOptions;
 
+import java.io.File;
+
 /**
  * @author HyunGil Jeong
  */
@@ -31,8 +33,11 @@ public class TestBroker {
     private final Broker broker = new Broker();
 
     private static void setSystemProperties() {
-        System.setProperty("qpid.work_dir", "/tmp/qpidworktmp");
+        String qpidWorkDir = new File(System.getProperty("java.io.tmpdir"), "qpidworktmp").getAbsolutePath();
+        System.setProperty("qpid.work_dir", qpidWorkDir);
         System.setProperty("qpid.initialConfigurationLocation", "rabbitmq/qpid/qpid-config.json");
+        // Suppress derby.log
+        System.setProperty("derby.stream.error.field", "DerbyUtil.DEV_NULL");
     }
 
     public void start() throws Exception {


### PR DESCRIPTION
This cleans up RabbitMQ integration tests to do the following :
* Set qpid work directory to temp directory
* Suppress generation of derby.log file
* Remove unused JvmArgument