### PR TITLE
Filters agents in shutdown containers from agent list

### DIFF
--- a/web/src/main/java/com/navercorp/pinpoint/web/batch/job/AgentCountReader.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/batch/job/AgentCountReader.java
@@ -42,7 +42,8 @@ public class AgentCountReader implements ItemReader<ApplicationAgentsList>, Step
 
     @Override
     public void beforeStep(StepExecution stepExecution) {
-        ApplicationAgentsList applicationAgentList = agentInfoService.getAllApplicationAgentsList();
+        long timestamp = System.currentTimeMillis();
+        ApplicationAgentsList applicationAgentList = agentInfoService.getAllApplicationAgentsList(ApplicationAgentsList.Filter.NONE, timestamp);
         queue.add(applicationAgentList);
     }
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/AgentInfoService.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/AgentInfoService.java
@@ -33,13 +33,9 @@ import java.util.Set;
  */
 public interface AgentInfoService {
 
-    ApplicationAgentsList getAllApplicationAgentsList();
+    ApplicationAgentsList getAllApplicationAgentsList(ApplicationAgentsList.Filter filter, long timestamp);
 
-    ApplicationAgentsList getAllApplicationAgentsList(long timestamp);
-
-    ApplicationAgentsList getApplicationAgentsList(ApplicationAgentsList.GroupBy key, String applicationName);
-
-    ApplicationAgentsList getApplicationAgentsList(ApplicationAgentsList.GroupBy key, String applicationName, long timestamp);
+    ApplicationAgentsList getApplicationAgentsList(ApplicationAgentsList.GroupBy key, ApplicationAgentsList.Filter filter, String applicationName, long timestamp);
 
     ApplicationAgentHostList getApplicationAgentHostList(int offset, int limit);
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/AgentInfoServiceImpl.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/AgentInfoServiceImpl.java
@@ -85,35 +85,25 @@ public class AgentInfoServiceImpl implements AgentInfoService {
     private AgentDownloadInfoDao agentDownloadInfoDao;
 
     @Override
-    public ApplicationAgentsList getAllApplicationAgentsList() {
-        return getAllApplicationAgentsList(System.currentTimeMillis());
-    }
-
-    @Override
-    public ApplicationAgentsList getAllApplicationAgentsList(long timestamp) {
+    public ApplicationAgentsList getAllApplicationAgentsList(ApplicationAgentsList.Filter filter, long timestamp) {
         ApplicationAgentsList.GroupBy groupBy = ApplicationAgentsList.GroupBy.APPLICATION_NAME;
-        ApplicationAgentsList applicationAgentList = new ApplicationAgentsList(groupBy);
+        ApplicationAgentsList applicationAgentList = new ApplicationAgentsList(groupBy, filter);
         List<Application> applications = applicationIndexDao.selectAllApplicationNames();
         for (Application application : applications) {
-            applicationAgentList.merge(getApplicationAgentsList(groupBy, application.getName(), timestamp));
+            applicationAgentList.merge(getApplicationAgentsList(groupBy, filter, application.getName(), timestamp));
         }
         return applicationAgentList;
     }
 
     @Override
-    public ApplicationAgentsList getApplicationAgentsList(ApplicationAgentsList.GroupBy groupBy, String applicationName) {
-        return getApplicationAgentsList(groupBy, applicationName, System.currentTimeMillis());
-    }
-
-    @Override
-    public ApplicationAgentsList getApplicationAgentsList(ApplicationAgentsList.GroupBy groupBy, String applicationName, long timestamp) {
+    public ApplicationAgentsList getApplicationAgentsList(ApplicationAgentsList.GroupBy groupBy, ApplicationAgentsList.Filter filter, String applicationName, long timestamp) {
         if (applicationName == null) {
             throw new NullPointerException("applicationName must not be null");
         }
         if (groupBy == null) {
             throw new NullPointerException("groupBy must not be null");
         }
-        ApplicationAgentsList applicationAgentsList = new ApplicationAgentsList(groupBy);
+        ApplicationAgentsList applicationAgentsList = new ApplicationAgentsList(groupBy, filter);
         Set<AgentInfo> agentInfos = getAgentsByApplicationName(applicationName, timestamp);
         if (agentInfos.isEmpty()) {
             logger.warn("agent list is empty for application:{}", applicationName);

--- a/web/src/test/java/com/navercorp/pinpoint/web/vo/ApplicationAgentsListTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/vo/ApplicationAgentsListTest.java
@@ -30,7 +30,7 @@ public class ApplicationAgentsListTest {
 
     @Test
     public void groupByApplicationName() {
-        ApplicationAgentsList applicationAgentsList = new ApplicationAgentsList(ApplicationAgentsList.GroupBy.APPLICATION_NAME);
+        ApplicationAgentsList applicationAgentsList = new ApplicationAgentsList(ApplicationAgentsList.GroupBy.APPLICATION_NAME, ApplicationAgentsList.Filter.NONE);
         AgentInfo app1Agent1 = createAgentInfo("APP_1", "app1-agent1", "Host11", true);
         AgentInfo app1Agent2 = createAgentInfo("APP_1", "app1-agent2", "Host12", false);
         AgentInfo app2Agent1 = createAgentInfo("APP_2", "app2-agent1", "Host21", false);
@@ -58,7 +58,7 @@ public class ApplicationAgentsListTest {
 
     @Test
     public void groupByHostNameShouldHaveContainersLastAndGroupedSeparately() {
-        ApplicationAgentsList applicationAgentsList = new ApplicationAgentsList(ApplicationAgentsList.GroupBy.HOST_NAME);
+        ApplicationAgentsList applicationAgentsList = new ApplicationAgentsList(ApplicationAgentsList.GroupBy.HOST_NAME, ApplicationAgentsList.Filter.NONE);
         AgentInfo host1Agent1 = createAgentInfo("APP_1", "host1-agent1", "Host1", false);
         AgentInfo host2Agent1 = createAgentInfo("APP_1", "host2-agent1", "Host2", false);
         AgentInfo containerAgent1 = createAgentInfo("APP_1", "container-agent1", "Host3", true);
@@ -97,9 +97,9 @@ public class ApplicationAgentsListTest {
         AgentInfo containerAgent2 = createAgentInfo("APP_1", "container-agent2", "Host4", true);
         List<AgentInfo> agentInfos = shuffleAgentInfos(containerAgent1, host1Agent1, host2Agent1, containerAgent2);
 
-        ApplicationAgentsList applicationAgentsList = new ApplicationAgentsList(ApplicationAgentsList.GroupBy.HOST_NAME);
+        ApplicationAgentsList applicationAgentsList = new ApplicationAgentsList(ApplicationAgentsList.GroupBy.HOST_NAME, ApplicationAgentsList.Filter.NONE);
         applicationAgentsList.addAll(agentInfos.subList(0, agentInfos.size() / 2));
-        ApplicationAgentsList applicationAgentsListToMerge = new ApplicationAgentsList(ApplicationAgentsList.GroupBy.HOST_NAME);
+        ApplicationAgentsList applicationAgentsListToMerge = new ApplicationAgentsList(ApplicationAgentsList.GroupBy.HOST_NAME, ApplicationAgentsList.Filter.NONE);
         applicationAgentsListToMerge.addAll(agentInfos.subList(agentInfos.size() / 2, agentInfos.size()));
 
         applicationAgentsList.merge(applicationAgentsListToMerge);
@@ -132,9 +132,9 @@ public class ApplicationAgentsListTest {
         AgentInfo agent1 = createAgentInfo("APP_1", "app1-agent1", "Host1", false);
         AgentInfo agent2 = createAgentInfo("APP_2", "app2-agent1", "Host2", false);
         AgentInfo agent3 = createAgentInfo("APP_2", "app2-agent2", "Host2", true);
-        ApplicationAgentsList groupedByHostnameList = new ApplicationAgentsList(ApplicationAgentsList.GroupBy.HOST_NAME);
+        ApplicationAgentsList groupedByHostnameList = new ApplicationAgentsList(ApplicationAgentsList.GroupBy.HOST_NAME, ApplicationAgentsList.Filter.NONE);
         groupedByHostnameList.add(agent1);
-        ApplicationAgentsList groupedByApplicationNameList = new ApplicationAgentsList(ApplicationAgentsList.GroupBy.APPLICATION_NAME);
+        ApplicationAgentsList groupedByApplicationNameList = new ApplicationAgentsList(ApplicationAgentsList.GroupBy.APPLICATION_NAME, ApplicationAgentsList.Filter.NONE);
         groupedByApplicationNameList.add(agent2);
         groupedByApplicationNameList.add(agent3);
 


### PR DESCRIPTION
This removes agents that were shutdown before the time period queried in Inspector view to stop irrelevant agents running in containers from polluting the agent list.
resolves #4560 