### PR TITLE
add kerberos auth

### DIFF
--- a/collector/src/main/resources/applicationContext-hbase.xml
+++ b/collector/src/main/resources/applicationContext-hbase.xml
@@ -29,7 +29,13 @@
                 <prop key="hbase.client.async.enable">${hbase.client.async.enable:false}</prop>
                 <prop key="hbase.client.async.in.queuesize">${hbase.client.async.in.queuesize:10000}</prop>
                 <prop key="hbase.tablemultiplexer.flush.period.ms">${hbase.client.async.flush.period.ms:100}</prop>
-                <prop key="hbase.client.max.retries.in.queue">${hbase.client.async.max.retries.in.queue:10}</prop>
+		<prop key="hbase.client.max.retries.in.queue">${hbase.client.async.max.retries.in.queue:10}</prop>
+		<!--hbase kerberos-->
+                <prop key="hbase.kerberos.auth">${hbase.kerberos.auth:false}</prop>
+                <prop key="hbase.kerberos.user">${hbase.kerberos.user:test}</prop>
+                <prop key="hbase.kerberos.keytab.path">${hbase.kerberos.keytab.path:/tmp}</prop>
+                <prop key="hbase.master.kerberos.principal">${hbase.master.kerberos.principal:test}</prop>
+                <prop key="hbase.regionserver.kerberos.principal">${hbase.regionserver.kerberos.principal:test}</prop>
             </props>
         </property>
     </bean>

--- a/collector/src/main/resources/hbase.properties
+++ b/collector/src/main/resources/hbase.properties
@@ -35,3 +35,10 @@ hbase.client.async.in.queuesize=10000
 hbase.client.async.flush.period.ms=100
 # the max number of the retry attempts before dropping the request. default:10
 hbase.client.async.max.retries.in.queue=10
+
+# kerberos
+hbase.kerberos.auth=true
+hbase.kerberos.user=test_add@HADOOP.COM
+hbase.kerberos.keytab.path=/path/test_add.keytab
+hbase.master.kerberos.principal=hbase/_HOST@HADOOP.COM
+hbase.regionserver.kerberos.principal=hbase/_HOST@HADOOP.COM

--- a/web/src/main/resources/applicationContext-hbase.xml
+++ b/web/src/main/resources/applicationContext-hbase.xml
@@ -28,7 +28,14 @@
                 <prop key="hbase.client.async.enable">${hbase.client.async.enable:false}</prop>
                 <prop key="hbase.client.async.in.queuesize">${hbase.client.async.in.queuesize:10000}</prop>
                 <prop key="hbase.tablemultiplexer.flush.period.ms">${hbase.client.async.flush.period.ms:100}</prop>
-                <prop key="hbase.client.max.retries.in.queue">${hbase.client.async.max.retries.in.queue:10}</prop>
+		<prop key="hbase.client.max.retries.in.queue">${hbase.client.async.max.retries.in.queue:10}</prop>
+
+		<!--hbase kerberos-->
+                <prop key="hbase.kerberos.auth">${hbase.kerberos.auth:false}</prop>
+                <prop key="hbase.kerberos.user">${hbase.kerberos.user:test}</prop>
+                <prop key="hbase.kerberos.keytab.path">${hbase.kerberos.keytab.path:/tmp}</prop>
+                <prop key="hbase.master.kerberos.principal">${hbase.master.kerberos.principal:test}</prop>
+                <prop key="hbase.regionserver.kerberos.principal">${hbase.regionserver.kerberos.principal:test}</prop>
             </props>
         </property>
     </bean>

--- a/web/src/main/resources/hbase.properties
+++ b/web/src/main/resources/hbase.properties
@@ -32,3 +32,10 @@ hbase.client.threadPool.prestart=false
 hbase.client.parallel.scan.enable=true
 hbase.client.parallel.scan.maxthreads=64
 hbase.client.parallel.scan.maxthreadsperscan=16
+
+ # kerberos
+ hbase.kerberos.auth=true
+ hbase.kerberos.user=test_add@HADOOP.COM
+ hbase.kerberos.keytab.path=/path/test_add.keytab
+ hbase.master.kerberos.principal=hbase/_HOST@HADOOP.COM
+ hbase.regionserver.kerberos.principal=hbase/_HOST@HADOOP.COM


### PR DESCRIPTION
Add support HBase kerberos auth.
1、change PooledHTableFactory class, add auth Kerberos code.
2、add hbase.properties and  applicationContext-hbase.xml property.
3、add hbase.kerberos.auth property,if hbase no need Kerberos auth, set hbase.kerberos.auth=false.
4、add JVM options ,-Djava.security.krb5.conf=/path/krb5.conf -Djava.security.krb5.realm=HADOOP.COM -Djava.security.krb5.kdc={ip} , The last two parameters are not needed。