### PR TITLE
add kerberos auth

### DIFF
--- a/collector/src/main/resources/applicationContext-hbase.xml
+++ b/collector/src/main/resources/applicationContext-hbase.xml
@@ -30,6 +30,14 @@
                 <prop key="hbase.client.async.in.queuesize">${hbase.client.async.in.queuesize:10000}</prop>
                 <prop key="hbase.tablemultiplexer.flush.period.ms">${hbase.client.async.flush.period.ms:100}</prop>
                 <prop key="hbase.client.max.retries.in.queue">${hbase.client.async.max.retries.in.queue:10}</prop>
+
+                <!--hbase kerberos-->
+                <prop key="hbase.kerberos.auth">${hbase.kerberos.auth:false}</prop>
+                <prop key="hbase.kerberos.user">${hbase.kerberos.user:test}</prop>
+                <prop key="hbase.kerberos.keytab.path">${hbase.kerberos.keytab.path:/tmp}</prop>
+                <prop key="hbase.master.kerberos.principal">${hbase.master.kerberos.principal:test}</prop>
+                <prop key="hbase.regionserver.kerberos.principal">${hbase.regionserver.kerberos.principal:test}</prop>
+
             </props>
         </property>
     </bean>

--- a/collector/src/main/resources/hbase.properties
+++ b/collector/src/main/resources/hbase.properties
@@ -35,3 +35,14 @@ hbase.client.async.in.queuesize=10000
 hbase.client.async.flush.period.ms=100
 # the max number of the retry attempts before dropping the request. default:10
 hbase.client.async.max.retries.in.queue=10
+
+# kerberos
+# 是否启用或者禁用
+hbase.kerberos.auth=false
+# kerberos 用户
+hbase.kerberos.user=test_add@HADOOP.COM
+# keytab 认证文件路径
+hbase.kerberos.keytab.path=./test_add.keytab
+# 默认配置
+hbase.master.kerberos.principal=hbase/_HOST@HADOOP.COM
+hbase.regionserver.kerberos.principal=hbase/_HOST@HADOOP.COM

--- a/web/src/main/resources/applicationContext-hbase.xml
+++ b/web/src/main/resources/applicationContext-hbase.xml
@@ -29,6 +29,14 @@
                 <prop key="hbase.client.async.in.queuesize">${hbase.client.async.in.queuesize:10000}</prop>
                 <prop key="hbase.tablemultiplexer.flush.period.ms">${hbase.client.async.flush.period.ms:100}</prop>
                 <prop key="hbase.client.max.retries.in.queue">${hbase.client.async.max.retries.in.queue:10}</prop>
+
+                <!--hbase kerberos-->
+                <prop key="hbase.kerberos.auth">${hbase.kerberos.auth:false}</prop>
+                <prop key="hbase.kerberos.user">${hbase.kerberos.user:test}</prop>
+                <prop key="hbase.kerberos.keytab.path">${hbase.kerberos.keytab.path:/tmp}</prop>
+                <prop key="hbase.master.kerberos.principal">${hbase.master.kerberos.principal:test}</prop>
+                <prop key="hbase.regionserver.kerberos.principal">${hbase.regionserver.kerberos.principal:test}</prop>
+
             </props>
         </property>
     </bean>

--- a/web/src/main/resources/hbase.properties
+++ b/web/src/main/resources/hbase.properties
@@ -32,3 +32,15 @@ hbase.client.threadPool.prestart=false
 hbase.client.parallel.scan.enable=true
 hbase.client.parallel.scan.maxthreads=64
 hbase.client.parallel.scan.maxthreadsperscan=16
+
+
+# kerberos
+# 是否启用或者禁用
+hbase.kerberos.auth=false
+# kerberos 用户
+hbase.kerberos.user=test_add@HADOOP.COM
+# keytab 认证文件路径
+hbase.kerberos.keytab.path=./test_add.keytab
+# 默认配置
+hbase.master.kerberos.principal=hbase/_HOST@HADOOP.COM
+hbase.regionserver.kerberos.principal=hbase/_HOST@HADOOP.COM


### PR DESCRIPTION
Add support HBase kerberos auth.
1、change PooledHTableFactory class, add auth Kerberos code.
2、add hbase.properties and applicationContext-hbase.xml property.
3、add hbase.kerberos.auth property,if hbase no need Kerberos auth, set hbase.kerberos.auth=false.
4、add JVM options ,
# 添加krb配置文件
CATALINA_OPTS="$CATALINA_OPTS -Djava.security.krb5.conf=./krb5.conf"
# 开启krb认证的bug日志
CATALINA_OPTS="$CATALINA_OPTS -Dsun.security.krb5.debug=true"
CATALINA_OPTS="$CATALINA_OPTS -Djavax.security.auth.useSubjectCredsOnly=true"
The last two parameters are not needed。