### PR TITLE
[#4785] Refactor Kafka Plugin and Add ConsumerRecords Interceptor.

### DIFF
--- a/agent/src/main/resources-local/pinpoint.config
+++ b/agent/src/main/resources-local/pinpoint.config
@@ -873,8 +873,8 @@ profiler.akka.http.transform.targetparameter=scala.Function1,scala.Function1,akk
 ###########################################################
 profiler.kafka.producer.enable=false
 profiler.kafka.consumer.enable=false
-// you must set target that handles ConsumerRecord as a argument for remote trace
-// ex) profiler.kafka.entryPoint=clazzName.methodName
+// you must set target that handles ConsumerRecord or ConsumerRecords(Remote Trace feature is not enabled.) as a argument for remote trace
+// ex) profiler.kafka.consumer.entryPoint=clazzName.methodName
 profiler.kafka.consumer.entryPoint=
 
 ###########################################################

--- a/agent/src/main/resources-release/pinpoint-real-env-lowoverhead-sample.config
+++ b/agent/src/main/resources-release/pinpoint-real-env-lowoverhead-sample.config
@@ -739,8 +739,8 @@ profiler.netty.http=false
 ###########################################################
 profiler.kafka.producer.enable=false
 profiler.kafka.consumer.enable=false
-// you must set target that handles ConsumerRecord as a argument for remote trace
-// ex) profiler.kafka.entryPoint=clazzName.methodName
+// you must set target that handles ConsumerRecord or ConsumerRecords(Remote Trace feature is not enabled.) as a argument for remote trace
+// ex) profiler.kafka.consumer.entryPoint=clazzName.methodName
 profiler.kafka.consumer.entryPoint=
 
 ###########################################################

--- a/agent/src/main/resources-release/pinpoint.config
+++ b/agent/src/main/resources-release/pinpoint.config
@@ -864,8 +864,8 @@ profiler.akka.http.transform.targetparameter=scala.Function1,scala.Function1,akk
 ###########################################################
 profiler.kafka.producer.enable=false
 profiler.kafka.consumer.enable=false
-// you must set target that handles ConsumerRecord as a argument for remote trace
-// ex) profiler.kafka.entryPoint=clazzName.methodName
+// you must set target that handles ConsumerRecord or ConsumerRecords(Remote Trace feature is not enabled.) as a argument for remote trace
+// ex) profiler.kafka.consumer.entryPoint=clazzName.methodName
 profiler.kafka.consumer.entryPoint=
 
 ###########################################################

--- a/plugins/kafka/src/main/java/com/navercorp/pinpoint/plugin/kafka/KafkaConstants.java
+++ b/plugins/kafka/src/main/java/com/navercorp/pinpoint/plugin/kafka/KafkaConstants.java
@@ -37,6 +37,7 @@ public class KafkaConstants {
     public static final AnnotationKey KAFKA_TOPIC_ANNOTATION_KEY = AnnotationKeyFactory.of(140, "kafka.topic", VIEW_IN_RECORD_SET);
     public static final AnnotationKey KAFKA_PARTITION_ANNOTATION_KEY = AnnotationKeyFactory.of(141, "kafka.partition", VIEW_IN_RECORD_SET);
     public static final AnnotationKey KAFKA_OFFSET_ANNOTATION_KEY = AnnotationKeyFactory.of(142, "kafka.offset", VIEW_IN_RECORD_SET);
+    public static final AnnotationKey KAFKA_BATCH_ANNOTATION_KEY = AnnotationKeyFactory.of(143, "kafka.batch", VIEW_IN_RECORD_SET);
 
     public static final String REMOTE_ADDRESS_ACCESSOR = RemoteAddressFieldAccessor.class.getName();
 
@@ -48,6 +49,10 @@ public class KafkaConstants {
     public static final String CONSUMER_POLL_INTERCEPTOR = "com.navercorp.pinpoint.plugin.kafka.interceptor.ConsumerPollInterceptor";
 
     public static final String CONSUMER_RECORD_ENTRYPOINT_INTERCEPTOR = "com.navercorp.pinpoint.plugin.kafka.interceptor.ConsumerRecordEntryPointInterceptor";
+
+    public static final String CONSUMER_MULTI_RECORD_ENTRYPOINT_INTERCEPTOR = "com.navercorp.pinpoint.plugin.kafka.interceptor.ConsumerMultiRecordEntryPointInterceptor";
+
+    public static final String CONSUMER_MULTI_RECORD_CLASS_NAME = "org.apache.kafka.clients.consumer.ConsumerRecords";
 
     public static final String CONSUMER_RECORD_CLASS_NAME = "org.apache.kafka.clients.consumer.ConsumerRecord";
 

--- a/plugins/kafka/src/main/java/com/navercorp/pinpoint/plugin/kafka/KafkaMetadataProvider.java
+++ b/plugins/kafka/src/main/java/com/navercorp/pinpoint/plugin/kafka/KafkaMetadataProvider.java
@@ -29,6 +29,7 @@ public class KafkaMetadataProvider implements TraceMetadataProvider {
         context.addAnnotationKey(KafkaConstants.KAFKA_TOPIC_ANNOTATION_KEY);
         context.addAnnotationKey(KafkaConstants.KAFKA_PARTITION_ANNOTATION_KEY);
         context.addAnnotationKey(KafkaConstants.KAFKA_OFFSET_ANNOTATION_KEY);
+        context.addAnnotationKey(KafkaConstants.KAFKA_BATCH_ANNOTATION_KEY);
     }
 
 }

--- a/plugins/kafka/src/main/java/com/navercorp/pinpoint/plugin/kafka/interceptor/ConsumerMultiRecordEntryPointInterceptor.java
+++ b/plugins/kafka/src/main/java/com/navercorp/pinpoint/plugin/kafka/interceptor/ConsumerMultiRecordEntryPointInterceptor.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2018 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.plugin.kafka.interceptor;
+
+import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
+import com.navercorp.pinpoint.bootstrap.context.SpanRecorder;
+import com.navercorp.pinpoint.bootstrap.context.Trace;
+import com.navercorp.pinpoint.bootstrap.context.TraceContext;
+import com.navercorp.pinpoint.bootstrap.logging.PLogger;
+import com.navercorp.pinpoint.bootstrap.logging.PLoggerFactory;
+import com.navercorp.pinpoint.common.util.StringUtils;
+import com.navercorp.pinpoint.plugin.kafka.KafkaConstants;
+import com.navercorp.pinpoint.plugin.kafka.field.accessor.RemoteAddressFieldAccessor;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+
+import java.util.Iterator;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * The type Consumer multi record entry point interceptor.
+ *
+ * @author Victor.Zxy
+ */
+public class ConsumerMultiRecordEntryPointInterceptor extends ConsumerRecordEntryPointInterceptor {
+
+    private final AtomicReference<TraceFactoryProvider.TraceFactory> tracyFactoryReference = new AtomicReference<TraceFactoryProvider.TraceFactory>();
+
+    /**
+     * Instantiates a new Consumer multi record entry point interceptor.
+     *
+     * @param traceContext     the trace context
+     * @param methodDescriptor the method descriptor
+     */
+    public ConsumerMultiRecordEntryPointInterceptor(TraceContext traceContext, MethodDescriptor methodDescriptor) {
+        super(traceContext, methodDescriptor);
+    }
+
+    @Override
+    protected Trace createTrace(Object target, Object[] args) {
+
+        ConsumerRecords consumerRecords = getConsumerRecords(args);
+
+        if (consumerRecords == null || consumerRecords.isEmpty()) {
+            return null;
+        }
+        Trace newTrace = createTrace(consumerRecords);
+
+        return newTrace;
+    }
+
+    private ConsumerRecords getConsumerRecords(Object[] args) {
+        if (args == null) {
+            return null;
+        }
+
+        for (Object arg : args) {
+            if (arg instanceof ConsumerRecords) {
+                return (ConsumerRecords) arg;
+            }
+        }
+        return null;
+    }
+
+    private Trace createTrace(ConsumerRecords consumerRecords) {
+        TraceFactoryProvider.TraceFactory createTrace = tracyFactoryReference.get();
+        if (createTrace == null) {
+            createTrace = TraceFactoryProvider.get();
+            tracyFactoryReference.compareAndSet(null, createTrace);
+        }
+        return createTrace.createTrace(traceContext, consumerRecords);
+    }
+
+    private static class TraceFactoryProvider {
+
+        private static TraceFactory get() {
+
+            return new DefaultTraceFactory();
+        }
+
+        private interface TraceFactory {
+
+            /**
+             * Create trace trace.
+             *
+             * @param traceContext    the trace context
+             * @param consumerRecords the consumer records
+             * @return the trace
+             */
+            Trace createTrace(TraceContext traceContext, ConsumerRecords consumerRecords);
+        }
+
+        private static class DefaultTraceFactory implements TraceFactory {
+
+            /**
+             * The Logger.
+             */
+            final PLogger logger = PLoggerFactory.getLogger(this.getClass());
+
+            @Override
+            public Trace createTrace(TraceContext traceContext, ConsumerRecords consumerRecords) {
+
+                final Trace trace = traceContext.newTraceObject();
+                if (trace.canSampled()) {
+                    final SpanRecorder recorder = trace.getSpanRecorder();
+                    recordRootSpan(recorder, consumerRecords);
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("TraceID not exist. start new trace.");
+                    }
+                    return trace;
+                } else {
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("TraceID not exist. camSampled is false. skip trace.");
+                    }
+                    return null;
+                }
+            }
+
+            private void recordRootSpan(SpanRecorder recorder, ConsumerRecords consumerRecords) {
+                recorder.recordServiceType(KafkaConstants.KAFKA_CLIENT);
+                recorder.recordApi(ENTRY_POINT_METHOD_DESCRIPTOR);
+
+                int count = consumerRecords.count();
+                Iterator<ConsumerRecord> iterator = consumerRecords.iterator();
+                ConsumerRecord consumerRecord = iterator.next();
+
+                String remoteAddress = getRemoteAddress(consumerRecord);
+                recorder.recordEndPoint(remoteAddress);
+                recorder.recordRemoteAddress(remoteAddress);
+
+                String topic = consumerRecord.topic();
+                recorder.recordRpcName(createRpcName(topic, count));
+                recorder.recordAcceptorHost("topic:" + topic);
+                recorder.recordAttribute(KafkaConstants.KAFKA_TOPIC_ANNOTATION_KEY, topic);
+                recorder.recordAttribute(KafkaConstants.KAFKA_BATCH_ANNOTATION_KEY, count);
+
+            }
+
+            private String getRemoteAddress(Object remoteAddressFieldAccessor) {
+                String remoteAddress = null;
+                if (remoteAddressFieldAccessor instanceof RemoteAddressFieldAccessor) {
+                    remoteAddress = ((RemoteAddressFieldAccessor) remoteAddressFieldAccessor)._$PINPOINT$_getRemoteAddress();
+                }
+
+                if (StringUtils.isEmpty(remoteAddress)) {
+                    return KafkaConstants.UNKNOWN;
+                } else {
+                    return remoteAddress;
+                }
+            }
+
+            private String createRpcName(String topic, int count) {
+                StringBuilder rpcName = new StringBuilder("kafka://");
+                rpcName.append("topic=").append(topic);
+                rpcName.append("?batch=").append(count);
+                return rpcName.toString();
+            }
+        }
+    }
+}

--- a/plugins/kafka/src/test/java/com/navercorp/pinpoint/plugin/kafka/interceptor/ConsumerConstructorInterceptorTest.java
+++ b/plugins/kafka/src/test/java/com/navercorp/pinpoint/plugin/kafka/interceptor/ConsumerConstructorInterceptorTest.java
@@ -1,0 +1,44 @@
+package com.navercorp.pinpoint.plugin.kafka.interceptor;
+
+import com.navercorp.pinpoint.plugin.kafka.field.accessor.RemoteAddressFieldAccessor;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.Collections;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ConsumerConstructorInterceptorTest {
+
+    @Mock
+    private RemoteAddressFieldAccessor addressFieldAccessor;
+
+    @Mock
+    private ConsumerConfig consumerConfig;
+
+    @Test
+    public void before() {
+
+        ConsumerConstructorInterceptor interceptor = new ConsumerConstructorInterceptor();
+        Object target = new Object();
+        Object[] args = new Object[]{};
+        interceptor.before(target, args);
+    }
+
+    @Test
+    public void after() {
+
+        doReturn(Collections.singletonList("localhost:9092")).when(consumerConfig).getList("bootstrap.servers");
+
+        ConsumerConstructorInterceptor interceptor = new ConsumerConstructorInterceptor();
+        Object[] args = new Object[]{consumerConfig};
+        interceptor.after(addressFieldAccessor, args, null, null);
+
+        verify(addressFieldAccessor)._$PINPOINT$_setRemoteAddress("localhost:9092");
+    }
+}

--- a/plugins/kafka/src/test/java/com/navercorp/pinpoint/plugin/kafka/interceptor/ConsumerMultiRecordEntryPointInterceptorTest.java
+++ b/plugins/kafka/src/test/java/com/navercorp/pinpoint/plugin/kafka/interceptor/ConsumerMultiRecordEntryPointInterceptorTest.java
@@ -1,0 +1,63 @@
+package com.navercorp.pinpoint.plugin.kafka.interceptor;
+
+import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
+import com.navercorp.pinpoint.bootstrap.context.SpanRecorder;
+import com.navercorp.pinpoint.bootstrap.context.Trace;
+import com.navercorp.pinpoint.bootstrap.context.TraceContext;
+import com.navercorp.pinpoint.plugin.kafka.KafkaConstants;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.Iterator;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ConsumerMultiRecordEntryPointInterceptorTest {
+
+    @Mock
+    private TraceContext traceContext;
+
+    @Mock
+    private MethodDescriptor descriptor;
+
+    @Mock
+    private Trace trace;
+
+    @Mock
+    private SpanRecorder recorder;
+
+    @Mock
+    private ConsumerRecords consumerRecords;
+
+    @Mock
+    private ConsumerRecord consumerRecord;
+
+    @Mock
+    private Iterator iterator;
+
+    @Test
+    public void createTrace() {
+
+        doReturn(trace).when(traceContext).newTraceObject();
+        doReturn(true).when(trace).canSampled();
+        doReturn(recorder).when(trace).getSpanRecorder();
+        doReturn(1).when(consumerRecords).count();
+        doReturn(iterator).when(consumerRecords).iterator();
+        doReturn(consumerRecord).when(iterator).next();
+        doReturn("Test").when(consumerRecord).topic();
+
+        ConsumerMultiRecordEntryPointInterceptor interceptor = new ConsumerMultiRecordEntryPointInterceptor(traceContext, descriptor);
+        interceptor.createTrace(new Object(), new Object[]{consumerRecords});
+
+        verify(recorder).recordAcceptorHost("topic:Test");
+        verify(recorder).recordAttribute(KafkaConstants.KAFKA_TOPIC_ANNOTATION_KEY, "Test");
+        verify(recorder).recordAttribute(KafkaConstants.KAFKA_BATCH_ANNOTATION_KEY, 1);
+        verify(recorder).recordRpcName("kafka://topic=Test?batch=1");
+    }
+}

--- a/plugins/kafka/src/test/java/com/navercorp/pinpoint/plugin/kafka/interceptor/ConsumerPollInterceptorTest.java
+++ b/plugins/kafka/src/test/java/com/navercorp/pinpoint/plugin/kafka/interceptor/ConsumerPollInterceptorTest.java
@@ -1,0 +1,57 @@
+package com.navercorp.pinpoint.plugin.kafka.interceptor;
+
+import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
+import com.navercorp.pinpoint.bootstrap.context.TraceContext;
+import com.navercorp.pinpoint.plugin.kafka.field.accessor.RemoteAddressFieldAccessor;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.Iterator;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ConsumerPollInterceptorTest {
+
+    @Mock
+    private TraceContext traceContext;
+
+    @Mock
+    private MethodDescriptor descriptor;
+
+    @Mock
+    private RemoteAddressFieldAccessor addressFieldAccessor;
+
+    @Mock
+    private ConsumerRecords consumerRecords;
+
+    @Mock
+    private Iterator iterator;
+
+
+    @Test
+    public void before() {
+        ConsumerPollInterceptor interceptor = new ConsumerPollInterceptor(traceContext, descriptor);
+        Object target = new Object();
+        Object[] args = new Object[]{};
+        interceptor.before(target, args);
+    }
+
+    @Test
+    public void after() {
+
+        doReturn("localhost:9092").when(addressFieldAccessor)._$PINPOINT$_getRemoteAddress();
+        doReturn(iterator).when(consumerRecords).iterator();
+        doReturn(false).when(iterator).hasNext();
+
+        ConsumerPollInterceptor interceptor = new ConsumerPollInterceptor(traceContext, descriptor);
+        interceptor.after(addressFieldAccessor, new Object[]{}, consumerRecords, null);
+
+        verify(addressFieldAccessor)._$PINPOINT$_getRemoteAddress();
+
+    }
+}

--- a/plugins/kafka/src/test/java/com/navercorp/pinpoint/plugin/kafka/interceptor/ConsumerRecordEntryPointInterceptorTest.java
+++ b/plugins/kafka/src/test/java/com/navercorp/pinpoint/plugin/kafka/interceptor/ConsumerRecordEntryPointInterceptorTest.java
@@ -1,0 +1,82 @@
+package com.navercorp.pinpoint.plugin.kafka.interceptor;
+
+import com.navercorp.pinpoint.bootstrap.context.*;
+import com.navercorp.pinpoint.plugin.kafka.KafkaConstants;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.Headers;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ConsumerRecordEntryPointInterceptorTest {
+
+    @Mock
+    private TraceContext traceContext;
+
+    @Mock
+    private MethodDescriptor descriptor;
+
+    @Mock
+    private Trace trace;
+
+    @Mock
+    private SpanRecorder recorder;
+
+    @Mock
+    private SpanEventRecorder eventRecorder;
+
+    @Mock
+    private ConsumerRecord consumerRecord;
+
+    @Mock
+    private Headers headers;
+
+    @Test
+    public void doInBeforeTrace() {
+
+        ConsumerRecordEntryPointInterceptor interceptor = new ConsumerRecordEntryPointInterceptor(traceContext, descriptor);
+
+        interceptor.doInBeforeTrace(eventRecorder, new Object(), new Object[]{});
+
+        verify(eventRecorder).recordServiceType(KafkaConstants.KAFKA_CLIENT_INTERNAL);
+    }
+
+    @Test
+    public void doInAfterTrace() {
+
+        ConsumerRecordEntryPointInterceptor interceptor = new ConsumerRecordEntryPointInterceptor(traceContext, descriptor);
+
+        interceptor.doInAfterTrace(eventRecorder, new Object(), new Object[]{}, null, null);
+
+        verify(eventRecorder).recordApi(descriptor);
+        verify(eventRecorder).recordException(null);
+    }
+
+    @Test
+    public void createTrace() {
+
+        doReturn(trace).when(traceContext).newTraceObject();
+        doReturn(true).when(trace).canSampled();
+        doReturn(recorder).when(trace).getSpanRecorder();
+
+        doReturn("Test").when(consumerRecord).topic();
+        doReturn(1l).when(consumerRecord).offset();
+        doReturn(0).when(consumerRecord).partition();
+        doReturn(headers).when(consumerRecord).headers();
+        doReturn(new Header[]{}).when(headers).toArray();
+
+        ConsumerRecordEntryPointInterceptor interceptor = new ConsumerRecordEntryPointInterceptor(traceContext, descriptor);
+
+        interceptor.createTrace(new Object(), new Object[]{consumerRecord});
+
+        verify(recorder).recordAcceptorHost("topic:Test");
+        verify(recorder).recordRpcName("kafka://topic=Test?partition=0&offset=1");
+
+    }
+}

--- a/plugins/kafka/src/test/java/com/navercorp/pinpoint/plugin/kafka/interceptor/ProducerConstructorInterceptorTest.java
+++ b/plugins/kafka/src/test/java/com/navercorp/pinpoint/plugin/kafka/interceptor/ProducerConstructorInterceptorTest.java
@@ -1,0 +1,44 @@
+package com.navercorp.pinpoint.plugin.kafka.interceptor;
+
+import com.navercorp.pinpoint.plugin.kafka.field.accessor.RemoteAddressFieldAccessor;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.Collections;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ProducerConstructorInterceptorTest {
+
+    @Mock
+    private RemoteAddressFieldAccessor addressFieldAccessor;
+    @Mock
+    private ProducerConfig producerConfig;
+
+
+    @Test
+    public void before() {
+
+        ProducerConstructorInterceptor interceptor = new ProducerConstructorInterceptor();
+        Object target = new Object();
+        Object[] args = new Object[]{};
+        interceptor.before(target, args);
+    }
+
+    @Test
+    public void after() {
+
+        doReturn(Collections.singletonList("localhost:9092")).when(producerConfig).getList("bootstrap.servers");
+
+        ProducerConstructorInterceptor interceptor = new ProducerConstructorInterceptor();
+        Object[] args = new Object[]{producerConfig};
+        interceptor.after(addressFieldAccessor, args, null, null);
+
+        verify(addressFieldAccessor)._$PINPOINT$_setRemoteAddress("localhost:9092");
+    }
+}

--- a/plugins/kafka/src/test/java/com/navercorp/pinpoint/plugin/kafka/interceptor/ProducerSendInterceptorTest.java
+++ b/plugins/kafka/src/test/java/com/navercorp/pinpoint/plugin/kafka/interceptor/ProducerSendInterceptorTest.java
@@ -1,0 +1,87 @@
+package com.navercorp.pinpoint.plugin.kafka.interceptor;
+
+import com.navercorp.pinpoint.bootstrap.context.*;
+import com.navercorp.pinpoint.plugin.kafka.KafkaConstants;
+import com.navercorp.pinpoint.plugin.kafka.field.accessor.RemoteAddressFieldAccessor;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.Headers;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ProducerSendInterceptorTest {
+
+    @Mock
+    private TraceContext traceContext;
+
+    @Mock
+    private MethodDescriptor descriptor;
+
+    @Mock
+    private Trace trace;
+
+    @Mock
+    private TraceId traceId;
+
+    @Mock
+    private TraceId nextId;
+
+    @Mock
+    private SpanEventRecorder recorder;
+
+    @Mock
+    private ProducerRecord record;
+
+    @Mock
+    private Headers headers;
+
+    @Mock
+    private RemoteAddressFieldAccessor addressFieldAccessor;
+
+    @Test
+    public void before() {
+
+        doReturn(trace).when(traceContext).currentTraceObject();
+        doReturn(true).when(trace).canSampled();
+        doReturn(traceId).when(trace).getTraceId();
+        doReturn(nextId).when(traceId).getNextTraceId();
+        doReturn(recorder).when(trace).traceBlockBegin();
+        doReturn(headers).when(record).headers();
+        doReturn(new Header[]{}).when(headers).toArray();
+        doReturn("test").when(nextId).getTransactionId();
+        doReturn(0l).when(nextId).getSpanId();
+        doReturn(0l).when(nextId).getParentSpanId();
+        short s = 0;
+        doReturn(s).when(nextId).getFlags();
+
+        ProducerSendInterceptor interceptor = new ProducerSendInterceptor(traceContext, descriptor);
+        Object target = new Object();
+        Object[] args = new Object[]{record};
+        interceptor.before(target, args);
+
+        verify(recorder).recordServiceType(KafkaConstants.KAFKA_CLIENT);
+
+    }
+
+    @Test
+    public void after() {
+        doReturn(trace).when(traceContext).currentTraceObject();
+        doReturn(true).when(trace).canSampled();
+        doReturn(recorder).when(trace).currentSpanEventRecorder();
+        doReturn("test").when(record).topic();
+
+        ProducerSendInterceptor interceptor = new ProducerSendInterceptor(traceContext, descriptor);
+        Object[] args = new Object[]{record};
+        interceptor.after(addressFieldAccessor, args, null, null);
+
+        verify(recorder).recordEndPoint(KafkaConstants.UNKNOWN);
+        verify(recorder).recordDestinationId("topic:test");
+        verify(recorder).recordAttribute(KafkaConstants.KAFKA_TOPIC_ANNOTATION_KEY, "test");
+    }
+}


### PR DESCRIPTION
Title: Kafka Plugin Contribution (optimize)

Link: https://github.com/VictorZeng/pinpoint/tree/kafka-plugin/plugins/kafka
Target: pinpoint-kafka-plugin
Supported Version: kafka version 0.11+.
Description: Refactor Kafka Plugin and add ConsumerRecords Interceptor. If you consume from the same topic and want to intercept batch consumption methods.

Add Annotations:

-  (143, "kafka.batch", VIEW_IN_RECORD_SET)
