### PR TITLE
[#4946] Fix: Adjust the timing of the click node event for the base node 

### DIFF
--- a/web/src/main/webapp/v2/src/app/core/components/server-map/class/server-map-diagram-with-visjs.class.ts
+++ b/web/src/main/webapp/v2/src/app/core/components/server-map/class/server-map-diagram-with-visjs.class.ts
@@ -161,7 +161,7 @@ export class ServerMapDiagramWithVisjs extends ServerMapDiagram {
     }
 
     setMapData(serverMapData: ServerMapData, baseApplicationKey = ''): void {
-        this.isFirstLoad = this.serverMapData ? false : true;
+        this.isFirstLoad = !this.serverMapData || this.serverMapData.getNodeCount() === 0 ? true : false;
         this.serverMapData = serverMapData;
         this.baseApplicationKey = baseApplicationKey;
         const nodeList = serverMapData.getNodeList();

--- a/web/src/main/webapp/v2/src/app/core/components/server-map/class/server-map-diagram-with-visjs.class.ts
+++ b/web/src/main/webapp/v2/src/app/core/components/server-map/class/server-map-diagram-with-visjs.class.ts
@@ -11,6 +11,7 @@ import { NodeGroup } from './node-group.class';
 
 export class ServerMapDiagramWithVisjs extends ServerMapDiagram {
     private diagram: Network;
+    private isFirstLoad: boolean;
 
     constructor(
         private option: IServerMapOption
@@ -160,6 +161,7 @@ export class ServerMapDiagramWithVisjs extends ServerMapDiagram {
     }
 
     setMapData(serverMapData: ServerMapData, baseApplicationKey = ''): void {
+        this.isFirstLoad = this.serverMapData ? false : true;
         this.serverMapData = serverMapData;
         this.baseApplicationKey = baseApplicationKey;
         const nodeList = serverMapData.getNodeList();
@@ -243,7 +245,9 @@ export class ServerMapDiagramWithVisjs extends ServerMapDiagram {
                 return [...acc, curr];
             }, [] as Node[]),
         ).subscribe((nodes: Node[]) => {
-            this.diagram.redraw();
+            if (this.isFirstLoad) {
+                this.diagram.redraw();
+            }
             this.diagram.setData({nodes, edges});
             this.diagram.selectNodes([baseApplicationKey]);
         });


### PR DESCRIPTION
-  Adjust the timing of the click node event for the base node in order to set the right width of the container
- Redraw the diagram to set the size of it only when it's the first rendering