### PR TITLE
Separates producer/consumer trace verification

### DIFF
--- a/agent-it/src/test/java/com/navercorp/pinpoint/plugin/jdk7/rabbitmq/RabbitMQTestRunner.java
+++ b/agent-it/src/test/java/com/navercorp/pinpoint/plugin/jdk7/rabbitmq/RabbitMQTestRunner.java
@@ -219,10 +219,10 @@ class RabbitMQTestRunner {
         ExpectedTrace handleCompleteInboundCommandTrace = Expectations.event(
                 RabbitMQTestConstants.RABBITMQ_CLIENT_INTERNAL, // serviceType
                 handleCompleteInboundCommand); // method
-        verifier.verifyDiscreteTrace(
-                channelBasicPublishTrace,
-                rabbitMqConsumerInvocationTrace,
-                handleCompleteInboundCommandTrace);
+        ExpectedTrace[] producerTraces = {channelBasicPublishTrace};
+        ExpectedTrace[] consumerTraces = {rabbitMqConsumerInvocationTrace, handleCompleteInboundCommandTrace};
+        verifier.verifyDiscreteTrace(producerTraces);
+        verifier.verifyDiscreteTrace(consumerTraces);
 
         // verify consumer traces
         Class<?> consumerChannelClass = consumerChannel.getClass();

--- a/agent-it/src/test/java/com/navercorp/pinpoint/plugin/jdk7/rabbitmq/spring/SpringAmqpRabbit_1_3_3_to_1_4_2_IT.java
+++ b/agent-it/src/test/java/com/navercorp/pinpoint/plugin/jdk7/rabbitmq/spring/SpringAmqpRabbit_1_3_3_to_1_4_2_IT.java
@@ -130,9 +130,11 @@ public class SpringAmqpRabbit_1_3_3_to_1_4_2_IT {
                 ServiceType.INTERNAL_METHOD.getName(),
                 propagationMarkerMark);
 
-        ExpectedTrace[] expectedTraces = {
+        ExpectedTrace[] producerTraces = {
                 rabbitTemplateConvertAndSendTrace,
-                channelNBasicPublishTrace,
+                channelNBasicPublishTrace
+        };
+        ExpectedTrace[] consumerTraces = {
                 rabbitMqConsumerInvocationTrace,
                 consumerDispatcherHandleDeliveryTrace,
                 asynchronousInvocationTrace,
@@ -143,9 +145,11 @@ public class SpringAmqpRabbit_1_3_3_to_1_4_2_IT {
                 markTrace
         };
 
-        final PluginTestVerifier verifier = testRunner.runPush(expectedTraces.length);
+        final int expectedTraceCount = producerTraces.length + consumerTraces.length;
+        final PluginTestVerifier verifier = testRunner.runPush(expectedTraceCount);
 
-        verifier.verifyTrace(expectedTraces);
+        verifier.verifyDiscreteTrace(producerTraces);
+        verifier.verifyDiscreteTrace(consumerTraces);
         verifier.verifyTraceCount(0);
     }
 
@@ -183,9 +187,11 @@ public class SpringAmqpRabbit_1_3_3_to_1_4_2_IT {
                 RabbitMQTestConstants.RABBITMQ_CLIENT_INTERNAL, // method
                 amqChannelHandleCompleteInboundCommand);
 
-        ExpectedTrace[] queueInitiatedTraces = {
+        ExpectedTrace[] producerTraces = {
                 rabbitTemplateConvertAndSendTrace,
-                channelNBasicPublishTrace,
+                channelNBasicPublishTrace
+        };
+        ExpectedTrace[] consumerTraces = {
                 rabbitMqConsumerInvocationTrace,
                 amqChannelHandleCompleteInboundCommandTrace
         };
@@ -211,10 +217,11 @@ public class SpringAmqpRabbit_1_3_3_to_1_4_2_IT {
                 markTrace
         };
 
-        int expectedTraceCount = queueInitiatedTraces.length + clientInitiatedTraces.length;
+        final int expectedTraceCount = producerTraces.length + consumerTraces.length + clientInitiatedTraces.length;
         final PluginTestVerifier verifier = testRunner.runPull(expectedTraceCount);
 
-        verifier.verifyDiscreteTrace(queueInitiatedTraces);
+        verifier.verifyDiscreteTrace(producerTraces);
+        verifier.verifyDiscreteTrace(consumerTraces);
         verifier.verifyDiscreteTrace(clientInitiatedTraces);
 
         verifier.verifyTraceCount(0);

--- a/agent-it/src/test/java/com/navercorp/pinpoint/plugin/jdk7/rabbitmq/spring/SpringAmqpRabbit_1_4_2_to_1_7_0_IT.java
+++ b/agent-it/src/test/java/com/navercorp/pinpoint/plugin/jdk7/rabbitmq/spring/SpringAmqpRabbit_1_4_2_to_1_7_0_IT.java
@@ -131,9 +131,11 @@ public class SpringAmqpRabbit_1_4_2_to_1_7_0_IT {
                 ServiceType.INTERNAL_METHOD.getName(),
                 propagationMarkerMark);
 
-        ExpectedTrace[] expectedTraces = {
+        ExpectedTrace[] producerTraces = {
                 rabbitTemplateConvertAndSendTrace,
-                channelNBasicPublishTrace,
+                channelNBasicPublishTrace
+        };
+        ExpectedTrace[] consumerTraces = {
                 rabbitMqConsumerInvocationTrace,
                 consumerDispatcherHandleDeliveryTrace,
                 asynchronousInvocationTrace,
@@ -144,9 +146,11 @@ public class SpringAmqpRabbit_1_4_2_to_1_7_0_IT {
                 markTrace
         };
 
-        final PluginTestVerifier verifier = testRunner.runPush(expectedTraces.length);
+        final int expectedTraceCount = producerTraces.length + consumerTraces.length;
+        final PluginTestVerifier verifier = testRunner.runPush(expectedTraceCount);
 
-        verifier.verifyTrace(expectedTraces);
+        verifier.verifyDiscreteTrace(producerTraces);
+        verifier.verifyDiscreteTrace(consumerTraces);
         verifier.verifyTraceCount(0);
     }
 
@@ -184,9 +188,11 @@ public class SpringAmqpRabbit_1_4_2_to_1_7_0_IT {
                 RabbitMQTestConstants.RABBITMQ_CLIENT_INTERNAL, // method
                 amqChannelHandleCompleteInboundCommand);
 
-        ExpectedTrace[] queueInitiatedTraces = {
+        ExpectedTrace[] producerTraces = {
                 rabbitTemplateConvertAndSendTrace,
-                channelNBasicPublishTrace,
+                channelNBasicPublishTrace
+        };
+        ExpectedTrace[] consumerTraces = {
                 rabbitMqConsumerInvocationTrace,
                 amqChannelHandleCompleteInboundCommandTrace
         };
@@ -212,10 +218,11 @@ public class SpringAmqpRabbit_1_4_2_to_1_7_0_IT {
                 markTrace
         };
 
-        int expectedTraceCount = queueInitiatedTraces.length + clientInitiatedTraces.length;
+        final int expectedTraceCount = producerTraces.length + consumerTraces.length + clientInitiatedTraces.length;
         final PluginTestVerifier verifier = testRunner.runPull(expectedTraceCount);
 
-        verifier.verifyDiscreteTrace(queueInitiatedTraces);
+        verifier.verifyDiscreteTrace(producerTraces);
+        verifier.verifyDiscreteTrace(consumerTraces);
         verifier.verifyDiscreteTrace(clientInitiatedTraces);
 
         verifier.verifyTraceCount(0);

--- a/agent-it/src/test/java/com/navercorp/pinpoint/plugin/jdk7/rabbitmq/spring/SpringAmqpRabbit_1_7_0_to_1_7_7_IT.java
+++ b/agent-it/src/test/java/com/navercorp/pinpoint/plugin/jdk7/rabbitmq/spring/SpringAmqpRabbit_1_7_0_to_1_7_7_IT.java
@@ -130,9 +130,11 @@ public class SpringAmqpRabbit_1_7_0_to_1_7_7_IT {
                 ServiceType.INTERNAL_METHOD.getName(),
                 propagationMarkerMark);
 
-        ExpectedTrace[] expectedTraces = {
+        ExpectedTrace[] producerTraces = {
                 rabbitTemplateConvertAndSendTrace,
-                channelNBasicPublishTrace,
+                channelNBasicPublishTrace
+        };
+        ExpectedTrace[] consumerTraces = {
                 rabbitMqConsumerInvocationTrace,
                 consumerDispatcherHandleDeliveryTrace,
                 asynchronousInvocationTrace,
@@ -143,9 +145,11 @@ public class SpringAmqpRabbit_1_7_0_to_1_7_7_IT {
                 markTrace
         };
 
-        final PluginTestVerifier verifier = testRunner.runPush(expectedTraces.length);
+        final int expectedTraceCount = producerTraces.length + consumerTraces.length;
+        final PluginTestVerifier verifier = testRunner.runPush(expectedTraceCount);
 
-        verifier.verifyTrace(expectedTraces);
+        verifier.verifyDiscreteTrace(producerTraces);
+        verifier.verifyDiscreteTrace(consumerTraces);
         verifier.verifyTraceCount(0);
     }
 
@@ -183,9 +187,11 @@ public class SpringAmqpRabbit_1_7_0_to_1_7_7_IT {
                 RabbitMQTestConstants.RABBITMQ_CLIENT_INTERNAL, // method
                 amqChannelHandleCompleteInboundCommand);
 
-        ExpectedTrace[] queueInitiatedTraces = {
+        ExpectedTrace[] producerTraces = {
                 rabbitTemplateConvertAndSendTrace,
-                channelNBasicPublishTrace,
+                channelNBasicPublishTrace
+        };
+        ExpectedTrace[] consumerTraces = {
                 rabbitMqConsumerInvocationTrace,
                 amqChannelHandleCompleteInboundCommandTrace
         };
@@ -211,10 +217,11 @@ public class SpringAmqpRabbit_1_7_0_to_1_7_7_IT {
                 markTrace
         };
 
-        int expectedTraceCount = queueInitiatedTraces.length + clientInitiatedTraces.length;
+        final int expectedTraceCount = producerTraces.length + consumerTraces.length + clientInitiatedTraces.length;
         final PluginTestVerifier verifier = testRunner.runPull(expectedTraceCount);
 
-        verifier.verifyDiscreteTrace(queueInitiatedTraces);
+        verifier.verifyDiscreteTrace(producerTraces);
+        verifier.verifyDiscreteTrace(consumerTraces);
         verifier.verifyDiscreteTrace(clientInitiatedTraces);
 
         verifier.verifyTraceCount(0);
@@ -267,9 +274,11 @@ public class SpringAmqpRabbit_1_7_0_to_1_7_7_IT {
                 RabbitMQTestConstants.RABBITMQ_CLIENT_INTERNAL,
                 queueingConsumerDeliveryConstructor);
 
-        ExpectedTrace[] queueInitiatedTraces = {
+        ExpectedTrace[] producerTraces = {
                 rabbitTemplateConvertAndSendTrace,
-                channelNBasicPublishTrace,
+                channelNBasicPublishTrace
+        };
+        ExpectedTrace[] consumerTraces = {
                 rabbitMqConsumerInvocationTrace,
                 consumerDispatcherHandleDeliveryTrace,
                 asynchronousInvocationTrace,
@@ -298,10 +307,11 @@ public class SpringAmqpRabbit_1_7_0_to_1_7_7_IT {
                 markTrace
         };
 
-        int expectedTraceCount = queueInitiatedTraces.length + clientInitiatedTraces.length;
+        final int expectedTraceCount = producerTraces.length + consumerTraces.length + clientInitiatedTraces.length;
         final PluginTestVerifier verifier = testRunner.runPull(expectedTraceCount, 5000L);
 
-        verifier.verifyDiscreteTrace(queueInitiatedTraces);
+        verifier.verifyDiscreteTrace(producerTraces);
+        verifier.verifyDiscreteTrace(consumerTraces);
         verifier.verifyDiscreteTrace(clientInitiatedTraces);
 
         verifier.verifyTraceCount(0);

--- a/agent-it/src/test/java/com/navercorp/pinpoint/plugin/jdk7/rabbitmq/spring/SpringAmqpRabbit_1_7_7_to_2_0_0_IT.java
+++ b/agent-it/src/test/java/com/navercorp/pinpoint/plugin/jdk7/rabbitmq/spring/SpringAmqpRabbit_1_7_7_to_2_0_0_IT.java
@@ -133,9 +133,11 @@ public class SpringAmqpRabbit_1_7_7_to_2_0_0_IT {
                 ServiceType.INTERNAL_METHOD.getName(),
                 propagationMarkerMark);
 
-        ExpectedTrace[] expectedTraces = {
+        ExpectedTrace[] producerTraces = {
                 rabbitTemplateConvertAndSendTrace,
-                channelNBasicPublishTrace,
+                channelNBasicPublishTrace
+        };
+        ExpectedTrace[] consumerTraces = {
                 rabbitMqConsumerInvocationTrace,
                 consumerDispatcherHandleDeliveryTrace,
                 asynchronousInvocationTrace,
@@ -146,9 +148,11 @@ public class SpringAmqpRabbit_1_7_7_to_2_0_0_IT {
                 markTrace
         };
 
-        final PluginTestVerifier verifier = testRunner.runPush(expectedTraces.length);
+        final int expectedTraceCount = producerTraces.length + consumerTraces.length;
+        final PluginTestVerifier verifier = testRunner.runPush(expectedTraceCount);
 
-        verifier.verifyTrace(expectedTraces);
+        verifier.verifyDiscreteTrace(producerTraces);
+        verifier.verifyDiscreteTrace(consumerTraces);
         verifier.verifyTraceCount(0);
     }
 
@@ -186,9 +190,11 @@ public class SpringAmqpRabbit_1_7_7_to_2_0_0_IT {
                 RabbitMQTestConstants.RABBITMQ_CLIENT_INTERNAL, // method
                 amqChannelHandleCompleteInboundCommand);
 
-        ExpectedTrace[] queueInitiatedTraces = {
+        ExpectedTrace[] producerTraces = {
                 rabbitTemplateConvertAndSendTrace,
-                channelNBasicPublishTrace,
+                channelNBasicPublishTrace
+        };
+        ExpectedTrace[] consumerTraces = {
                 rabbitMqConsumerInvocationTrace,
                 amqChannelHandleCompleteInboundCommandTrace
         };
@@ -214,10 +220,11 @@ public class SpringAmqpRabbit_1_7_7_to_2_0_0_IT {
                 markTrace
         };
 
-        int expectedTraceCount = queueInitiatedTraces.length + clientInitiatedTraces.length;
+        final int expectedTraceCount = producerTraces.length + consumerTraces.length + clientInitiatedTraces.length;
         final PluginTestVerifier verifier = testRunner.runPull(expectedTraceCount);
 
-        verifier.verifyDiscreteTrace(queueInitiatedTraces);
+        verifier.verifyDiscreteTrace(producerTraces);
+        verifier.verifyDiscreteTrace(consumerTraces);
         verifier.verifyDiscreteTrace(clientInitiatedTraces);
 
         verifier.verifyTraceCount(0);
@@ -270,9 +277,11 @@ public class SpringAmqpRabbit_1_7_7_to_2_0_0_IT {
                 RabbitMQTestConstants.RABBITMQ_CLIENT_INTERNAL,
                 queueingConsumerDeliveryConstructor);
 
-        ExpectedTrace[] queueInitiatedTraces = {
+        ExpectedTrace[] producerTraces = {
                 rabbitTemplateConvertAndSendTrace,
-                channelNBasicPublishTrace,
+                channelNBasicPublishTrace
+        };
+        ExpectedTrace[] consumerTraces = {
                 rabbitMqConsumerInvocationTrace,
                 consumerDispatcherHandleDeliveryTrace,
                 asynchronousInvocationTrace,
@@ -301,10 +310,11 @@ public class SpringAmqpRabbit_1_7_7_to_2_0_0_IT {
                 markTrace
         };
 
-        int expectedTraceCount = queueInitiatedTraces.length + clientInitiatedTraces.length;
+        final int expectedTraceCount = producerTraces.length + consumerTraces.length + clientInitiatedTraces.length;
         final PluginTestVerifier verifier = testRunner.runPull(expectedTraceCount, 5000L);
 
-        verifier.verifyDiscreteTrace(queueInitiatedTraces);
+        verifier.verifyDiscreteTrace(producerTraces);
+        verifier.verifyDiscreteTrace(consumerTraces);
         verifier.verifyDiscreteTrace(clientInitiatedTraces);
 
         verifier.verifyTraceCount(0);

--- a/agent-it/src/test/java/com/navercorp/pinpoint/plugin/jdk7/rabbitmq/spring/SpringAmqpRabbit_2_0_0_to_2_0_3_IT.java
+++ b/agent-it/src/test/java/com/navercorp/pinpoint/plugin/jdk7/rabbitmq/spring/SpringAmqpRabbit_2_0_0_to_2_0_3_IT.java
@@ -140,9 +140,11 @@ public class SpringAmqpRabbit_2_0_0_to_2_0_3_IT {
                 ServiceType.INTERNAL_METHOD.getName(),
                 propagationMarkerMark);
 
-        ExpectedTrace[] expectedTraces = {
+        ExpectedTrace[] producerTraces = {
                 rabbitTemplateConvertAndSendTrace,
-                channelNBasicPublishTrace,
+                channelNBasicPublishTrace
+        };
+        ExpectedTrace[] consumerTraces = {
                 rabbitMqConsumerInvocationTrace,
                 consumerDispatcherHandleDeliveryTrace,
                 asynchronousInvocationTrace,
@@ -153,9 +155,11 @@ public class SpringAmqpRabbit_2_0_0_to_2_0_3_IT {
                 markTrace
         };
 
-        final PluginTestVerifier verifier = testRunner.runPush(expectedTraces.length);
+        final int expectedTraceCount = producerTraces.length + consumerTraces.length;
+        final PluginTestVerifier verifier = testRunner.runPush(expectedTraceCount);
 
-        verifier.verifyTrace(expectedTraces);
+        verifier.verifyDiscreteTrace(producerTraces);
+        verifier.verifyDiscreteTrace(consumerTraces);
         verifier.verifyTraceCount(0);
     }
 
@@ -193,9 +197,11 @@ public class SpringAmqpRabbit_2_0_0_to_2_0_3_IT {
                 RabbitMQTestConstants.RABBITMQ_CLIENT_INTERNAL, // method
                 amqChannelHandleCompleteInboundCommand);
 
-        ExpectedTrace[] queueInitiatedTraces = {
+        ExpectedTrace[] producerTraces = {
                 rabbitTemplateConvertAndSendTrace,
-                channelNBasicPublishTrace,
+                channelNBasicPublishTrace
+        };
+        ExpectedTrace[] consumerTraces = {
                 rabbitMqConsumerInvocationTrace,
                 amqChannelHandleCompleteInboundCommandTrace
         };
@@ -221,10 +227,11 @@ public class SpringAmqpRabbit_2_0_0_to_2_0_3_IT {
                 markTrace
         };
 
-        int expectedTraceCount = queueInitiatedTraces.length + clientInitiatedTraces.length;
+        final int expectedTraceCount = producerTraces.length + consumerTraces.length + clientInitiatedTraces.length;
         final PluginTestVerifier verifier = testRunner.runPull(expectedTraceCount);
 
-        verifier.verifyDiscreteTrace(queueInitiatedTraces);
+        verifier.verifyDiscreteTrace(producerTraces);
+        verifier.verifyDiscreteTrace(consumerTraces);
         verifier.verifyDiscreteTrace(clientInitiatedTraces);
 
         verifier.verifyTraceCount(0);
@@ -279,9 +286,11 @@ public class SpringAmqpRabbit_2_0_0_to_2_0_3_IT {
                 RabbitMQTestConstants.RABBITMQ_CLIENT_INTERNAL, // serviceType
                 deliveryConstructor);
 
-        ExpectedTrace[] queueInitiatedTraces = {
+        ExpectedTrace[] producerTraces = {
                 rabbitTemplateConvertAndSendTrace,
-                channelNBasicPublishTrace,
+                channelNBasicPublishTrace
+        };
+        ExpectedTrace[] consumerTraces = {
                 rabbitMqConsumerInvocationTrace,
                 consumerDispatcherHandleDeliveryTrace,
                 asynchronousInvocationTrace,
@@ -305,10 +314,11 @@ public class SpringAmqpRabbit_2_0_0_to_2_0_3_IT {
                 markTrace
         };
 
-        int expectedTraceCount = queueInitiatedTraces.length + clientInitiatedTraces.length;
+        final int expectedTraceCount = producerTraces.length + consumerTraces.length + clientInitiatedTraces.length;
         final PluginTestVerifier verifier = testRunner.runPull(expectedTraceCount, 5000L);
 
-        verifier.verifyDiscreteTrace(queueInitiatedTraces);
+        verifier.verifyDiscreteTrace(producerTraces);
+        verifier.verifyDiscreteTrace(consumerTraces);
         verifier.verifyDiscreteTrace(clientInitiatedTraces);
 
         verifier.verifyTraceCount(0);

--- a/agent-it/src/test/java/com/navercorp/pinpoint/plugin/jdk7/rabbitmq/spring/SpringAmqpRabbit_2_0_3_to_2_1_0_IT.java
+++ b/agent-it/src/test/java/com/navercorp/pinpoint/plugin/jdk7/rabbitmq/spring/SpringAmqpRabbit_2_0_3_to_2_1_0_IT.java
@@ -139,9 +139,11 @@ public class SpringAmqpRabbit_2_0_3_to_2_1_0_IT {
                 ServiceType.INTERNAL_METHOD.getName(),
                 propagationMarkerMark);
 
-        ExpectedTrace[] expectedTraces = {
+        ExpectedTrace[] producerTraces = {
                 rabbitTemplateConvertAndSendTrace,
-                channelNBasicPublishTrace,
+                channelNBasicPublishTrace
+        };
+        ExpectedTrace[] consumerTraces = {
                 rabbitMqConsumerInvocationTrace,
                 consumerDispatcherHandleDeliveryTrace,
                 asynchronousInvocationTrace,
@@ -152,9 +154,11 @@ public class SpringAmqpRabbit_2_0_3_to_2_1_0_IT {
                 markTrace
         };
 
-        final PluginTestVerifier verifier = testRunner.runPush(expectedTraces.length);
+        final int expectedTraceCount = producerTraces.length + consumerTraces.length;
+        final PluginTestVerifier verifier = testRunner.runPush(expectedTraceCount);
 
-        verifier.verifyTrace(expectedTraces);
+        verifier.verifyDiscreteTrace(producerTraces);
+        verifier.verifyDiscreteTrace(consumerTraces);
         verifier.verifyTraceCount(0);
     }
 
@@ -192,9 +196,11 @@ public class SpringAmqpRabbit_2_0_3_to_2_1_0_IT {
                 RabbitMQTestConstants.RABBITMQ_CLIENT_INTERNAL, // method
                 amqChannelHandleCompleteInboundCommand);
 
-        ExpectedTrace[] queueInitiatedTraces = {
+        ExpectedTrace[] producerTraces = {
                 rabbitTemplateConvertAndSendTrace,
-                channelNBasicPublishTrace,
+                channelNBasicPublishTrace
+        };
+        ExpectedTrace[] consumerTraces = {
                 rabbitMqConsumerInvocationTrace,
                 amqChannelHandleCompleteInboundCommandTrace
         };
@@ -220,10 +226,11 @@ public class SpringAmqpRabbit_2_0_3_to_2_1_0_IT {
                 markTrace
         };
 
-        int expectedTraceCount = queueInitiatedTraces.length + clientInitiatedTraces.length;
+        final int expectedTraceCount = producerTraces.length + consumerTraces.length + clientInitiatedTraces.length;
         final PluginTestVerifier verifier = testRunner.runPull(expectedTraceCount);
 
-        verifier.verifyDiscreteTrace(queueInitiatedTraces);
+        verifier.verifyDiscreteTrace(producerTraces);
+        verifier.verifyDiscreteTrace(consumerTraces);
         verifier.verifyDiscreteTrace(clientInitiatedTraces);
 
         verifier.verifyTraceCount(0);
@@ -278,9 +285,11 @@ public class SpringAmqpRabbit_2_0_3_to_2_1_0_IT {
                 RabbitMQTestConstants.RABBITMQ_CLIENT_INTERNAL, // serviceType
                 deliveryConstructor);
 
-        ExpectedTrace[] queueInitiatedTraces = {
+        ExpectedTrace[] producerTraces = {
                 rabbitTemplateConvertAndSendTrace,
-                channelNBasicPublishTrace,
+                channelNBasicPublishTrace
+        };
+        ExpectedTrace[] consumerTraces = {
                 rabbitMqConsumerInvocationTrace,
                 consumerDispatcherHandleDeliveryTrace,
                 asynchronousInvocationTrace,
@@ -304,10 +313,11 @@ public class SpringAmqpRabbit_2_0_3_to_2_1_0_IT {
                 markTrace
         };
 
-        int expectedTraceCount = queueInitiatedTraces.length + clientInitiatedTraces.length;
+        final int expectedTraceCount = producerTraces.length + consumerTraces.length + clientInitiatedTraces.length;
         final PluginTestVerifier verifier = testRunner.runPull(expectedTraceCount, 5000L);
 
-        verifier.verifyDiscreteTrace(queueInitiatedTraces);
+        verifier.verifyDiscreteTrace(producerTraces);
+        verifier.verifyDiscreteTrace(consumerTraces);
         verifier.verifyDiscreteTrace(clientInitiatedTraces);
 
         verifier.verifyTraceCount(0);

--- a/agent-it/src/test/java/com/navercorp/pinpoint/plugin/jdk7/rabbitmq/spring/SpringAmqpRabbit_2_1_x_to_2_x_IT.java
+++ b/agent-it/src/test/java/com/navercorp/pinpoint/plugin/jdk7/rabbitmq/spring/SpringAmqpRabbit_2_1_x_to_2_x_IT.java
@@ -136,9 +136,11 @@ public class SpringAmqpRabbit_2_1_x_to_2_x_IT {
                 ServiceType.INTERNAL_METHOD.getName(),
                 propagationMarkerMark);
 
-        ExpectedTrace[] expectedTraces = {
+        ExpectedTrace[] producerTraces = {
                 rabbitTemplateConvertAndSendTrace,
-                channelNBasicPublishTrace,
+                channelNBasicPublishTrace
+        };
+        ExpectedTrace[] consumerTraces = {
                 rabbitMqConsumerInvocationTrace,
                 consumerDispatcherHandleDeliveryTrace,
                 asynchronousInvocationTrace,
@@ -149,9 +151,11 @@ public class SpringAmqpRabbit_2_1_x_to_2_x_IT {
                 markTrace
         };
 
-        final PluginTestVerifier verifier = testRunner.runPush(expectedTraces.length);
+        final int expectedTraceCount = producerTraces.length + consumerTraces.length;
+        final PluginTestVerifier verifier = testRunner.runPush(expectedTraceCount);
 
-        verifier.verifyTrace(expectedTraces);
+        verifier.verifyDiscreteTrace(producerTraces);
+        verifier.verifyDiscreteTrace(consumerTraces);
         verifier.verifyTraceCount(0);
     }
 
@@ -189,9 +193,11 @@ public class SpringAmqpRabbit_2_1_x_to_2_x_IT {
                 RabbitMQTestConstants.RABBITMQ_CLIENT_INTERNAL, // method
                 amqChannelHandleCompleteInboundCommand);
 
-        ExpectedTrace[] queueInitiatedTraces = {
+        ExpectedTrace[] producerTraces = {
                 rabbitTemplateConvertAndSendTrace,
-                channelNBasicPublishTrace,
+                channelNBasicPublishTrace
+        };
+        ExpectedTrace[] consumerTraces = {
                 rabbitMqConsumerInvocationTrace,
                 amqChannelHandleCompleteInboundCommandTrace
         };
@@ -217,10 +223,11 @@ public class SpringAmqpRabbit_2_1_x_to_2_x_IT {
                 markTrace
         };
 
-        int expectedTraceCount = queueInitiatedTraces.length + clientInitiatedTraces.length;
+        final int expectedTraceCount = producerTraces.length + consumerTraces.length + clientInitiatedTraces.length;
         final PluginTestVerifier verifier = testRunner.runPull(expectedTraceCount);
 
-        verifier.verifyDiscreteTrace(queueInitiatedTraces);
+        verifier.verifyDiscreteTrace(producerTraces);
+        verifier.verifyDiscreteTrace(consumerTraces);
         verifier.verifyDiscreteTrace(clientInitiatedTraces);
 
         verifier.verifyTraceCount(0);
@@ -275,9 +282,11 @@ public class SpringAmqpRabbit_2_1_x_to_2_x_IT {
                 RabbitMQTestConstants.RABBITMQ_CLIENT_INTERNAL, // serviceType
                 deliveryConstructor);
 
-        ExpectedTrace[] queueInitiatedTraces = {
+        ExpectedTrace[] producerTraces = {
                 rabbitTemplateConvertAndSendTrace,
-                channelNBasicPublishTrace,
+                channelNBasicPublishTrace
+        };
+        ExpectedTrace[] consumerTraces = {
                 rabbitMqConsumerInvocationTrace,
                 consumerDispatcherHandleDeliveryTrace,
                 asynchronousInvocationTrace,
@@ -301,10 +310,11 @@ public class SpringAmqpRabbit_2_1_x_to_2_x_IT {
                 markTrace
         };
 
-        int expectedTraceCount = queueInitiatedTraces.length + clientInitiatedTraces.length;
+        final int expectedTraceCount = producerTraces.length + consumerTraces.length + clientInitiatedTraces.length;
         final PluginTestVerifier verifier = testRunner.runPull(expectedTraceCount, 5000L);
 
-        verifier.verifyDiscreteTrace(queueInitiatedTraces);
+        verifier.verifyDiscreteTrace(producerTraces);
+        verifier.verifyDiscreteTrace(consumerTraces);
         verifier.verifyDiscreteTrace(clientInitiatedTraces);
 
         verifier.verifyTraceCount(0);


### PR DESCRIPTION
Consumer traces would occasionally arrive before producer traces resulting in test failures.
Change so that consumer traces and producer traces are checked separately while still checking for trace ordering within them.