### PR TITLE
[#5071] Move the location of some IntegrationTests

### DIFF
--- a/agent-it/src/test/java/com/navercorp/pinpoint/plugin/jdk7/hbase/HbaseClientIT.java
+++ b/agent-it/src/test/java/com/navercorp/pinpoint/plugin/jdk7/hbase/HbaseClientIT.java
@@ -1,4 +1,20 @@
-package com.navercorp.pinpoint.plugin.hbase;
+/*
+ * Copyright 2019 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.plugin.jdk7.hbase;
 
 import com.navercorp.pinpoint.bootstrap.plugin.test.PluginTestVerifier;
 import com.navercorp.pinpoint.bootstrap.plugin.test.PluginTestVerifierHolder;


### PR DESCRIPTION
There was a problem in the IntegrationTests that could not be loaded from jvm6,
so it make not run all of jvm6 integration tests.