### PR TITLE
Sorts agents running in containers by their start timestamp

### DIFF
--- a/web/src/test/java/com/navercorp/pinpoint/web/vo/ApplicationAgentsListTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/vo/ApplicationAgentsListTest.java
@@ -57,44 +57,44 @@ public class ApplicationAgentsListTest {
     }
 
     @Test
-    public void groupByHostNameShouldHaveContainersLastAndGroupedSeparately() {
+    public void groupByHostNameShouldHaveContainersFirstAndGroupedSeparatelyByAgentStartTimestampDescendingOrder() {
         ApplicationAgentsList applicationAgentsList = new ApplicationAgentsList(ApplicationAgentsList.GroupBy.HOST_NAME, ApplicationAgentsList.Filter.NONE);
         AgentInfo host1Agent1 = createAgentInfo("APP_1", "host1-agent1", "Host1", false);
         AgentInfo host2Agent1 = createAgentInfo("APP_1", "host2-agent1", "Host2", false);
-        AgentInfo containerAgent1 = createAgentInfo("APP_1", "container-agent1", "Host3", true);
-        AgentInfo containerAgent2 = createAgentInfo("APP_1", "container-agent2", "Host4", true);
+        AgentInfo containerAgent1 = createAgentInfo("APP_1", "container-agent1", "Host3", true, 1);
+        AgentInfo containerAgent2 = createAgentInfo("APP_1", "container-agent2", "Host4", true, 2);
         applicationAgentsList.addAll(shuffleAgentInfos(containerAgent1, host1Agent1, host2Agent1, containerAgent2));
 
         List<ApplicationAgentList> applicationAgentLists = applicationAgentsList.getApplicationAgentLists();
 
         Assert.assertEquals(3, applicationAgentLists.size());
 
-        ApplicationAgentList host1AgentList = applicationAgentLists.get(0);
+        ApplicationAgentList containerAgentList = applicationAgentLists.get(0);
+        Assert.assertEquals(ApplicationAgentsList.HostNameContainerGroupingKey.CONTAINER, containerAgentList.getGroupName());
+        List<AgentInfo> containerAgents = containerAgentList.getAgentInfos();
+        Assert.assertEquals(2, containerAgents.size());
+        Assert.assertEquals(containerAgent2, containerAgents.get(0));
+        Assert.assertEquals(containerAgent1, containerAgents.get(1));
+
+        ApplicationAgentList host1AgentList = applicationAgentLists.get(1);
         Assert.assertEquals("Host1", host1AgentList.getGroupName());
         List<AgentInfo> host1Agents = host1AgentList.getAgentInfos();
         Assert.assertEquals(1, host1Agents.size());
         Assert.assertEquals(host1Agent1, host1Agents.get(0));
 
-        ApplicationAgentList host2AgentList = applicationAgentLists.get(1);
+        ApplicationAgentList host2AgentList = applicationAgentLists.get(2);
         Assert.assertEquals("Host2", host2AgentList.getGroupName());
         List<AgentInfo> host2Agents = host2AgentList.getAgentInfos();
         Assert.assertEquals(1, host2Agents.size());
         Assert.assertEquals(host2Agent1, host2Agents.get(0));
-
-        ApplicationAgentList containerAgentList = applicationAgentLists.get(2);
-        Assert.assertEquals(ApplicationAgentsList.HostNameContainerGroupingKey.CONTAINER, containerAgentList.getGroupName());
-        List<AgentInfo> containerAgents = containerAgentList.getAgentInfos();
-        Assert.assertEquals(2, containerAgents.size());
-        Assert.assertEquals(containerAgent1, containerAgents.get(0));
-        Assert.assertEquals(containerAgent2, containerAgents.get(1));
     }
 
     @Test
     public void mergeLists() {
         AgentInfo host1Agent1 = createAgentInfo("APP_1", "host1-agent1", "Host1", false);
         AgentInfo host2Agent1 = createAgentInfo("APP_1", "host2-agent1", "Host2", false);
-        AgentInfo containerAgent1 = createAgentInfo("APP_1", "container-agent1", "Host3", true);
-        AgentInfo containerAgent2 = createAgentInfo("APP_1", "container-agent2", "Host4", true);
+        AgentInfo containerAgent1 = createAgentInfo("APP_1", "container-agent1", "Host3", true, 1);
+        AgentInfo containerAgent2 = createAgentInfo("APP_1", "container-agent2", "Host4", true, 2);
         List<AgentInfo> agentInfos = shuffleAgentInfos(containerAgent1, host1Agent1, host2Agent1, containerAgent2);
 
         ApplicationAgentsList applicationAgentsList = new ApplicationAgentsList(ApplicationAgentsList.GroupBy.HOST_NAME, ApplicationAgentsList.Filter.NONE);
@@ -107,24 +107,24 @@ public class ApplicationAgentsListTest {
 
         Assert.assertEquals(3, applicationAgentLists.size());
 
-        ApplicationAgentList host1AgentList = applicationAgentLists.get(0);
+        ApplicationAgentList containerAgentList = applicationAgentLists.get(0);
+        Assert.assertEquals(ApplicationAgentsList.HostNameContainerGroupingKey.CONTAINER, containerAgentList.getGroupName());
+        List<AgentInfo> containerAgents = containerAgentList.getAgentInfos();
+        Assert.assertEquals(2, containerAgents.size());
+        Assert.assertEquals(containerAgent2, containerAgents.get(0));
+        Assert.assertEquals(containerAgent1, containerAgents.get(1));
+
+        ApplicationAgentList host1AgentList = applicationAgentLists.get(1);
         Assert.assertEquals("Host1", host1AgentList.getGroupName());
         List<AgentInfo> host1Agents = host1AgentList.getAgentInfos();
         Assert.assertEquals(1, host1Agents.size());
         Assert.assertEquals(host1Agent1, host1Agents.get(0));
 
-        ApplicationAgentList host2AgentList = applicationAgentLists.get(1);
+        ApplicationAgentList host2AgentList = applicationAgentLists.get(2);
         Assert.assertEquals("Host2", host2AgentList.getGroupName());
         List<AgentInfo> host2Agents = host2AgentList.getAgentInfos();
         Assert.assertEquals(1, host2Agents.size());
         Assert.assertEquals(host2Agent1, host2Agents.get(0));
-
-        ApplicationAgentList containerAgentList = applicationAgentLists.get(2);
-        Assert.assertEquals(ApplicationAgentsList.HostNameContainerGroupingKey.CONTAINER, containerAgentList.getGroupName());
-        List<AgentInfo> containerAgents = containerAgentList.getAgentInfos();
-        Assert.assertEquals(2, containerAgents.size());
-        Assert.assertEquals(containerAgent1, containerAgents.get(0));
-        Assert.assertEquals(containerAgent2, containerAgents.get(1));
     }
 
     @Test
@@ -143,23 +143,23 @@ public class ApplicationAgentsListTest {
 
         Assert.assertEquals(3, applicationAgentLists.size());
 
-        ApplicationAgentList host1AgentList = applicationAgentLists.get(0);
+        ApplicationAgentList containerAgentList = applicationAgentLists.get(0);
+        Assert.assertEquals(ApplicationAgentsList.HostNameContainerGroupingKey.CONTAINER, containerAgentList.getGroupName());
+        List<AgentInfo> containerAgents = containerAgentList.getAgentInfos();
+        Assert.assertEquals(1, containerAgents.size());
+        Assert.assertEquals(agent3, containerAgents.get(0));
+
+        ApplicationAgentList host1AgentList = applicationAgentLists.get(1);
         Assert.assertEquals("Host1", host1AgentList.getGroupName());
         List<AgentInfo> host1Agents = host1AgentList.getAgentInfos();
         Assert.assertEquals(1, host1Agents.size());
         Assert.assertEquals(agent1, host1Agents.get(0));
 
-        ApplicationAgentList host2AgentList = applicationAgentLists.get(1);
+        ApplicationAgentList host2AgentList = applicationAgentLists.get(2);
         Assert.assertEquals("Host2", host2AgentList.getGroupName());
         List<AgentInfo> host2Agents = host2AgentList.getAgentInfos();
         Assert.assertEquals(1, host2Agents.size());
         Assert.assertEquals(agent2, host2Agents.get(0));
-
-        ApplicationAgentList containerAgentList = applicationAgentLists.get(2);
-        Assert.assertEquals(ApplicationAgentsList.HostNameContainerGroupingKey.CONTAINER, containerAgentList.getGroupName());
-        List<AgentInfo> containerAgents = containerAgentList.getAgentInfos();
-        Assert.assertEquals(1, containerAgents.size());
-        Assert.assertEquals(agent3, containerAgents.get(0));
     }
 
     private static List<AgentInfo> shuffleAgentInfos(AgentInfo... agentInfos) {
@@ -169,11 +169,16 @@ public class ApplicationAgentsListTest {
     }
 
     private static AgentInfo createAgentInfo(String applicationName, String agentId, String hostname, boolean container) {
+        return createAgentInfo(applicationName, agentId, hostname, container, System.currentTimeMillis());
+    }
+
+    private static AgentInfo createAgentInfo(String applicationName, String agentId, String hostname, boolean container, long startTimestamp) {
         AgentInfo agentInfo = new AgentInfo();
         agentInfo.setApplicationName(applicationName);
         agentInfo.setAgentId(agentId);
         agentInfo.setHostName(hostname);
         agentInfo.setContainer(container);
+        agentInfo.setStartTimestamp(startTimestamp);
         return agentInfo;
     }
 }


### PR DESCRIPTION
Agents running in container often have meaningless agent ids, so sorting them by agent ids do not have merit.
Sorting them by their start timestamp (in descending order) would be more useful.

resolves #5026 