### PR TITLE
Removes unnecessary error log when instrumenting MySQL java connector 6.x

### DIFF
--- a/plugins/mysql-jdbc/src/main/java/com/navercorp/pinpoint/plugin/jdbc/mysql/MySqlPlugin.java
+++ b/plugins/mysql-jdbc/src/main/java/com/navercorp/pinpoint/plugin/jdbc/mysql/MySqlPlugin.java
@@ -197,12 +197,18 @@ public class MySqlPlugin implements ProfilerPlugin, TransformTemplateAware {
                 int maxBindValueSize = config.getMaxSqlBindValueSize();
 
                 final String preparedStatementInterceptor = "com.navercorp.pinpoint.bootstrap.plugin.jdbc.interceptor.PreparedStatementExecuteQueryInterceptor";
-                InstrumentUtils.findMethod(target, "execute")
-                        .addScopedInterceptor(preparedStatementInterceptor, va(maxBindValueSize), MYSQL_SCOPE);
-                InstrumentUtils.findMethod(target, "executeQuery")
-                        .addScopedInterceptor(preparedStatementInterceptor, va(maxBindValueSize), MYSQL_SCOPE);
-                InstrumentUtils.findMethod(target, "executeUpdate")
-                        .addScopedInterceptor(preparedStatementInterceptor, va(maxBindValueSize), MYSQL_SCOPE);
+                InstrumentMethod executeMethod = target.getDeclaredMethod("execute");
+                if (executeMethod != null) {
+                    executeMethod.addScopedInterceptor(preparedStatementInterceptor, va(maxBindValueSize), MYSQL_SCOPE);
+                }
+                InstrumentMethod executeQueryMethod = target.getDeclaredMethod("executeQuery");
+                if (executeQueryMethod != null) {
+                    executeQueryMethod.addScopedInterceptor(preparedStatementInterceptor, va(maxBindValueSize), MYSQL_SCOPE);
+                }
+                InstrumentMethod executeUpdateMethod = target.getDeclaredMethod("executeUpdate");
+                if (executeUpdateMethod != null) {
+                    executeUpdateMethod.addScopedInterceptor(preparedStatementInterceptor, va(maxBindValueSize), MYSQL_SCOPE);
+                }
 
                 if (config.isTraceSqlBindValue()) {
                     final PreparedStatementBindingMethodFilter excludes = PreparedStatementBindingMethodFilter.excludes("setRowId", "setNClob", "setSQLXML");


### PR DESCRIPTION
MySQL java connector's PreparedStatement execute methods move around a lot by versions and may produce unnecessary NotFoundInstrumentException logs.

For example, MySQL java connector 6.x have both PreparedStatement and ServerPreparedStatement classes, with the execute methods in PreparedStatement.
MySQL java connector 8.0.11+ only have ServerPreparedStatement class, with the execute methods in it.
To cover both cases, execute method interceptors need to be added to both of these classes, which will result in NotFoundInstrumentException log when running MySQL java connector 6.x.