### PR TITLE
Adds support for mariadb-connector-j 2.4.x

### DIFF
--- a/agent-it/src/test/java/com/navercorp/pinpoint/plugin/jdbc/mariadb/MariaDB_2_0_1_to_2_4_0_IT.java
+++ b/agent-it/src/test/java/com/navercorp/pinpoint/plugin/jdbc/mariadb/MariaDB_2_0_1_to_2_4_0_IT.java
@@ -40,8 +40,8 @@ import static com.navercorp.pinpoint.bootstrap.plugin.test.Expectations.sql;
 @RunWith(PinpointPluginTestSuite.class)
 @PinpointAgent(AgentPath.PATH)
 @JvmVersion(8) // 2.x+ requires Java 8
-@Dependency({ "org.mariadb.jdbc:mariadb-java-client:[2.0.1,)", "ch.vorburger.mariaDB4j:mariaDB4j:2.2.2" })
-public class MariaDB_2_x_IT extends MariaDB_IT_Base {
+@Dependency({ "org.mariadb.jdbc:mariadb-java-client:[2.0.1,2.4.min)", "ch.vorburger.mariaDB4j:mariaDB4j:2.2.2" })
+public class MariaDB_2_0_1_to_2_4_0_IT extends MariaDB_IT_Base {
 
     // see CallableParameterMetaData#queryMetaInfos
     private  static final String CALLABLE_QUERY_META_INFOS_QUERY = "select param_list, returns, db, type from mysql.proc where name=? and db=DATABASE()";

--- a/plugins/mariadb-jdbc/src/main/java/com/navercorp/pinpoint/plugin/jdbc/mariadb/MariaDBPlugin.java
+++ b/plugins/mariadb-jdbc/src/main/java/com/navercorp/pinpoint/plugin/jdbc/mariadb/MariaDBPlugin.java
@@ -91,8 +91,6 @@ public class MariaDBPlugin implements ProfilerPlugin, TransformTemplateAware {
     }
 
     private void addConnectionTransformer() {
-
-
         transformTemplate.transform("org.mariadb.jdbc.MariaDbConnection", MariaDbConnectionTransform.class);
     }
 
@@ -194,6 +192,9 @@ public class MariaDBPlugin implements ProfilerPlugin, TransformTemplateAware {
         // 1.6.x
         transformTemplate.transform("org.mariadb.jdbc.MariaDbPreparedStatementServer", PreparedStatementTransform.class);
         transformTemplate.transform("org.mariadb.jdbc.MariaDbPreparedStatementClient", PreparedStatementTransform.class);
+        // 2.4.x
+        transformTemplate.transform("org.mariadb.jdbc.ServerSidePreparedStatement", PreparedStatementTransform.class);
+        transformTemplate.transform("org.mariadb.jdbc.ClientSidePreparedStatement", PreparedStatementTransform.class);
 
     }
 
@@ -226,7 +227,6 @@ public class MariaDBPlugin implements ProfilerPlugin, TransformTemplateAware {
     };
 
     private void addPreparedStatementBindVariableTransformer() {
-
         transformTemplate.transform("org.mariadb.jdbc.AbstractMariaDbPrepareStatement", PreparedStatementBindVariableTransformer.class);
         // Class renamed in 1.5.6 - https://github.com/MariaDB/mariadb-connector-j/commit/16c8313960cf4fbc6b2b83136504d1ba9e662919
         transformTemplate.transform("org.mariadb.jdbc.AbstractPrepareStatement", PreparedStatementBindVariableTransformer.class);
@@ -299,8 +299,6 @@ public class MariaDBPlugin implements ProfilerPlugin, TransformTemplateAware {
     };
 
     private void addCallableStatementTransformer() {
-
-
         transformTemplate.transform("org.mariadb.jdbc.AbstractCallableProcedureStatement", CallableStatementTransformer.class);
         transformTemplate.transform("org.mariadb.jdbc.AbstractCallableFunctionStatement", CallableStatementTransformer.class);
         // 1.6.x


### PR DESCRIPTION
Mariadb-connector-j 2.4.0 has been released and with it, class names have been changed.
```
org.mariadb.jdbc.MariaDbPreparedStatementServer -> org.mariadb.jdbc.ServerSidePreparedStatement
org.mariadb.jdbc.MariaDbPreparedStatementClient -> org.mariadb.jdbc.ClientSidePreparedStatement
```