### PR TITLE
Fixes integration test for mariadb 1.6.0 to 1.8.0

### DIFF
--- a/agent-it/src/test/java/com/navercorp/pinpoint/plugin/jdbc/mariadb/MariaDB_1_6_x_to_1_8_0_IT.java
+++ b/agent-it/src/test/java/com/navercorp/pinpoint/plugin/jdbc/mariadb/MariaDB_1_6_x_to_1_8_0_IT.java
@@ -52,7 +52,7 @@ import static com.navercorp.pinpoint.bootstrap.plugin.test.Expectations.sql;
 @RunWith(PinpointPluginTestSuite.class)
 @PinpointAgent(AgentPath.PATH)
 @JvmVersion(7) // 1.6.2+ works with Java 6, but since the IT includes 1.6.0 and 1.6.1 just run on Java 7
-@Dependency({ "org.mariadb.jdbc:mariadb-java-client:[1.6.0,2.0.min)", "ch.vorburger.mariaDB4j:mariaDB4j:2.2.2" })
+@Dependency({ "org.mariadb.jdbc:mariadb-java-client:[1.6.0,1.8.0)", "ch.vorburger.mariaDB4j:mariaDB4j:2.2.2" })
 public class MariaDB_1_6_x_to_1_8_0_IT extends MariaDB_IT_Base {
 
     // see CallableParameterMetaData#queryMetaInfos


### PR DESCRIPTION
Wrong dependency version range specified.