### PR TITLE
[#noissue] Fix: Make the links visible when it's bi-directional between nodes in visjs

### DIFF
--- a/web/src/main/webapp/v2/src/app/core/components/server-map/class/server-map-diagram-with-visjs.class.ts
+++ b/web/src/main/webapp/v2/src/app/core/components/server-map/class/server-map-diagram-with-visjs.class.ts
@@ -65,6 +65,10 @@ export class ServerMapDiagramWithVisjs extends ServerMapDiagram {
                     size: 18,
                     background: ServerMapTheme.general.link.normal.textBox.fill,
                 },
+                smooth: {
+                    type: 'curvedCW',
+                    roundness: 0.1
+                }
             } as EdgeOptions,
             groups: {
                 main: {


### PR DESCRIPTION
- There's no other way to make it work other than setting it curved