### PR TITLE
Adds a workaround for scanning classes in nested jars

### DIFF
--- a/profiler/src/main/java/com/navercorp/pinpoint/profiler/instrument/classloading/JarProfilerPluginClassInjector.java
+++ b/profiler/src/main/java/com/navercorp/pinpoint/profiler/instrument/classloading/JarProfilerPluginClassInjector.java
@@ -71,6 +71,7 @@ public class JarProfilerPluginClassInjector implements ClassInjector {
         }
     }
 
+    @Override
     public InputStream getResourceAsStream(ClassLoader targetClassLoader, String internalName) {
         try {
             if (bootstrapCore.isBootstrapPackageByInternalName(internalName)) {

--- a/profiler/src/main/java/com/navercorp/pinpoint/profiler/instrument/scanner/ClassScannerFactory.java
+++ b/profiler/src/main/java/com/navercorp/pinpoint/profiler/instrument/scanner/ClassScannerFactory.java
@@ -25,6 +25,10 @@ import java.security.ProtectionDomain;
  * @author Woonduk Kang(emeroad)
  */
 public class ClassScannerFactory {
+
+    private static final String FORCE_CLASS_LOADER_SCANNER_PROPERTY_KEY = "pinpoint.force.classloader.scanner";
+    private static final boolean FORCE_CLASS_LOADER_SCANNER = forceClassLoaderScanner();
+
     // jboss vfs support
     private static final String[] FILE_PROTOCOLS = {"file", "vfs"};
     private static final String[] JAR_EXTENSIONS = {".jar", ".war", ".ear"};
@@ -40,9 +44,16 @@ public class ClassScannerFactory {
             return scanner;
         }
 
+        // workaround for scanning for classes in nested jars - see newURLScanner(URL) below.
+        if (FORCE_CLASS_LOADER_SCANNER || isNestedJar(codeLocation.getPath())) {
+            ClassLoader protectionDomainClassLoader = protectionDomain.getClassLoader();
+            if (protectionDomainClassLoader != null) {
+                return new ClassLoaderScanner(protectionDomainClassLoader);
+            }
+        }
+
         throw new IllegalArgumentException("unknown scanner type classLoader:" + classLoader + " protectionDomain:" + protectionDomain);
     }
-
 
     public static Scanner newScanner(ProtectionDomain protectionDomain) {
         final URL codeLocation = CodeSourceUtils.getCodeLocation(protectionDomain);
@@ -70,9 +81,13 @@ public class ClassScannerFactory {
                 return new DirectoryScanner(path);
             }
         }
+        // TODO consider a scanner for nested jars
+        // Though the workaround above should work for current use cases, adding a scanner for nested jars would
+        // be the "correct" way of handling Spring Boot or One-jar executable jars. However, there doesn't seem
+        // to be a way to efficiently handle them.
+        // Spring Boot loader's JarFile and JarFileEntries implementations look like a great reference for this.
         return null;
     }
-
 
     static boolean isJarExtension(String path) {
         if (path == null) {
@@ -95,5 +110,20 @@ public class ClassScannerFactory {
         return false;
     }
 
+    static boolean isNestedJar(String path) {
+        if (path == null) {
+            return false;
+        }
+        final String separator = "!/";
+        if (!path.endsWith(separator)) {
+            return false;
+        }
+        String subPath = path.substring(0, path.lastIndexOf(separator));
+        return subPath.contains(separator);
+    }
 
+    private static boolean forceClassLoaderScanner() {
+        String forceClassLoaderScanner = System.getProperty(FORCE_CLASS_LOADER_SCANNER_PROPERTY_KEY);
+        return Boolean.parseBoolean(forceClassLoaderScanner);
+    }
 }

--- a/profiler/src/test/java/com/navercorp/pinpoint/profiler/instrument/scanner/ClassScannerFactoryTest.java
+++ b/profiler/src/test/java/com/navercorp/pinpoint/profiler/instrument/scanner/ClassScannerFactoryTest.java
@@ -96,4 +96,16 @@ public class ClassScannerFactoryTest {
 
         Assert.assertFalse(ClassScannerFactory.isJarExtension(".zip"));
     }
+
+    @Test
+    public void isNestedJar() {
+        Assert.assertTrue(ClassScannerFactory.isNestedJar("file:/path/to/some.jar!/nested/another.jar!/"));
+
+        Assert.assertFalse(ClassScannerFactory.isNestedJar(null));
+        Assert.assertFalse(ClassScannerFactory.isNestedJar(""));
+        Assert.assertFalse(ClassScannerFactory.isNestedJar("/path/to/some.jar"));
+        Assert.assertFalse(ClassScannerFactory.isNestedJar("/path/to/some.jar!/"));
+        Assert.assertFalse(ClassScannerFactory.isNestedJar("file:/path/to/some.jar"));
+        Assert.assertFalse(ClassScannerFactory.isNestedJar("file:/path/to/some.jar!/"));
+    }
 }


### PR DESCRIPTION
When a plugin calls `Instrumentor.exist(...)` API from inside `TransformerCallback.doInTransform(...)` implementation, the agent creates a scanner to search for the given resource from the same place where the class, which the **Instrumentor** was created for, resides in.
Currently, such scanners are only created when the class resides in a single jar, or a directory.
As such, when the API is invoked inside a transformer callback for a class inside a nested jar (for example, Spring Boot or One-Jar executable jars), the agent throws an **IllegalArgumentException**.

This PR adds a workaround so that in cases for nested jars, a scanner is created to simply search for the resource from the class loader that loaded the initiating class.
This should work as the class loader must have been able to handle nested jars in order to find the initiating class in the first place.