### PR TITLE
[#5384] Cleanup  code related to cluster

### DIFF
--- a/collector/src/main/java/com/navercorp/pinpoint/collector/cluster/route/AbstractRouteHandler.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/cluster/route/AbstractRouteHandler.java
@@ -25,6 +25,8 @@ import org.slf4j.LoggerFactory;
 import com.navercorp.pinpoint.collector.cluster.ClusterPointLocator;
 import com.navercorp.pinpoint.collector.cluster.TargetClusterPoint;
 import com.navercorp.pinpoint.thrift.dto.command.TCommandTransfer;
+import com.navercorp.pinpoint.thrift.dto.command.TCommandTransferResponse;
+import com.navercorp.pinpoint.thrift.dto.command.TRouteResult;
 
 /**
  * @author koo.taejin
@@ -72,6 +74,24 @@ public abstract class AbstractRouteHandler<T extends RouteEvent> implements Rout
         }
 
         return null;
+    }
+
+    protected TCommandTransferResponse createResponse(TRouteResult result) {
+        return createResponse(result, new byte[0]);
+    }
+
+    protected TCommandTransferResponse createResponse(TRouteResult result, byte[] payload) {
+        TCommandTransferResponse response = new TCommandTransferResponse();
+        response.setRouteResult(result);
+        response.setPayload(payload);
+        return response;
+    }
+
+    protected TCommandTransferResponse createResponse(TRouteResult result, String message) {
+        TCommandTransferResponse response = new TCommandTransferResponse();
+        response.setRouteResult(result);
+        response.setMessage(message);
+        return response;
     }
 
 }

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/cluster/route/DefaultRouteHandler.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/cluster/route/DefaultRouteHandler.java
@@ -23,6 +23,7 @@ import com.navercorp.pinpoint.rpc.Future;
 import com.navercorp.pinpoint.rpc.ResponseMessage;
 import com.navercorp.pinpoint.thrift.dto.command.TCommandTransferResponse;
 import com.navercorp.pinpoint.thrift.dto.command.TRouteResult;
+
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.thrift.TBase;
 
@@ -97,17 +98,6 @@ public class DefaultRouteHandler extends AbstractRouteHandler<RequestEvent> {
         }
 
         return createResponse(TRouteResult.OK, responsePayload);
-    }
-
-    private TCommandTransferResponse createResponse(TRouteResult result) {
-        return createResponse(result, new byte[0]);
-    }
-
-    private TCommandTransferResponse createResponse(TRouteResult result, byte[] payload) {
-        TCommandTransferResponse response = new TCommandTransferResponse();
-        response.setRouteResult(result);
-        response.setPayload(payload);
-        return response;
     }
 
 }

--- a/grpc/src/main/thrift/Command.thrift
+++ b/grpc/src/main/thrift/Command.thrift
@@ -130,6 +130,8 @@ enum TRouteResult {
     NOT_ACCEPTABLE = 240,
     NOT_SUPPORTED_SERVICE = 241,
 
+    STREAM_CREATE_ERROR = 250,
+
     UNKNOWN = -1
 }
 

--- a/rpc/src/main/java/com/navercorp/pinpoint/rpc/PinpointSocket.java
+++ b/rpc/src/main/java/com/navercorp/pinpoint/rpc/PinpointSocket.java
@@ -22,6 +22,7 @@ import com.navercorp.pinpoint.rpc.stream.ClientStreamChannel;
 import com.navercorp.pinpoint.rpc.stream.ClientStreamChannelContext;
 import com.navercorp.pinpoint.rpc.stream.ClientStreamChannelMessageListener;
 import com.navercorp.pinpoint.rpc.stream.StreamChannelStateChangeEventHandler;
+import com.navercorp.pinpoint.rpc.stream.StreamException;
 
 import java.net.SocketAddress;
 
@@ -36,8 +37,8 @@ public interface PinpointSocket {
 
     void response(int requestId, byte[] payload);
 
-    ClientStreamChannelContext openStream(byte[] payload, ClientStreamChannelMessageListener messageListener);
-    ClientStreamChannelContext openStream(byte[] payload, ClientStreamChannelMessageListener messageListener, StreamChannelStateChangeEventHandler<ClientStreamChannel> stateChangeListener);
+    ClientStreamChannelContext openStream(byte[] payload, ClientStreamChannelMessageListener messageListener)  throws StreamException;
+    ClientStreamChannelContext openStream(byte[] payload, ClientStreamChannelMessageListener messageListener, StreamChannelStateChangeEventHandler<ClientStreamChannel> stateChangeListener)  throws StreamException;
 
     SocketAddress getRemoteAddress();
 

--- a/rpc/src/main/java/com/navercorp/pinpoint/rpc/client/DefaultPinpointClient.java
+++ b/rpc/src/main/java/com/navercorp/pinpoint/rpc/client/DefaultPinpointClient.java
@@ -28,6 +28,8 @@ import com.navercorp.pinpoint.rpc.stream.ClientStreamChannelContext;
 import com.navercorp.pinpoint.rpc.stream.ClientStreamChannelMessageListener;
 import com.navercorp.pinpoint.rpc.stream.StreamChannelContext;
 import com.navercorp.pinpoint.rpc.stream.StreamChannelStateChangeEventHandler;
+import com.navercorp.pinpoint.rpc.stream.StreamException;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -131,12 +133,12 @@ public class DefaultPinpointClient implements PinpointClient {
     }
 
     @Override
-    public ClientStreamChannelContext openStream(byte[] payload, ClientStreamChannelMessageListener messageListener) {
+    public ClientStreamChannelContext openStream(byte[] payload, ClientStreamChannelMessageListener messageListener) throws StreamException {
         return openStream(payload, messageListener, null);
     }
 
     @Override
-    public ClientStreamChannelContext openStream(byte[] payload, ClientStreamChannelMessageListener messageListener, StreamChannelStateChangeEventHandler<ClientStreamChannel> stateChangeListener) {
+    public ClientStreamChannelContext openStream(byte[] payload, ClientStreamChannelMessageListener messageListener, StreamChannelStateChangeEventHandler<ClientStreamChannel> stateChangeListener) throws StreamException {
         // StreamChannel must be changed into interface in order to throw the StreamChannel that returns failure.
         // fow now throw just exception
         ensureOpen();

--- a/rpc/src/main/java/com/navercorp/pinpoint/rpc/client/DefaultPinpointClientHandler.java
+++ b/rpc/src/main/java/com/navercorp/pinpoint/rpc/client/DefaultPinpointClientHandler.java
@@ -330,12 +330,12 @@ public class DefaultPinpointClientHandler extends SimpleChannelHandler implement
     }
 
     @Override
-    public ClientStreamChannelContext openStream(byte[] payload, ClientStreamChannelMessageListener messageListener) {
+    public ClientStreamChannelContext openStream(byte[] payload, ClientStreamChannelMessageListener messageListener) throws StreamException {
         return openStream(payload, messageListener, null);
     }
 
     @Override
-    public ClientStreamChannelContext openStream(byte[] payload, ClientStreamChannelMessageListener messageListener, StreamChannelStateChangeEventHandler<ClientStreamChannel> stateChangeListener) {
+    public ClientStreamChannelContext openStream(byte[] payload, ClientStreamChannelMessageListener messageListener, StreamChannelStateChangeEventHandler<ClientStreamChannel> stateChangeListener) throws StreamException {
         ensureOpen();
 
         PinpointClientHandlerContext context = getChannelContext(channel);

--- a/rpc/src/main/java/com/navercorp/pinpoint/rpc/client/PinpointClientHandler.java
+++ b/rpc/src/main/java/com/navercorp/pinpoint/rpc/client/PinpointClientHandler.java
@@ -48,8 +48,8 @@ public interface PinpointClientHandler {
 
     void response(int requestId, byte[] payload);
 
-    ClientStreamChannelContext openStream(byte[] payload, ClientStreamChannelMessageListener messageListener);
-    ClientStreamChannelContext openStream(byte[] payload, ClientStreamChannelMessageListener messageListener, StreamChannelStateChangeEventHandler<ClientStreamChannel> stateChangeListener);
+    ClientStreamChannelContext openStream(byte[] payload, ClientStreamChannelMessageListener messageListener) throws StreamException;
+    ClientStreamChannelContext openStream(byte[] payload, ClientStreamChannelMessageListener messageListener, StreamChannelStateChangeEventHandler<ClientStreamChannel> stateChangeListener) throws StreamException;
 
     StreamChannelContext findStreamChannel(int streamChannelId);
     

--- a/rpc/src/main/java/com/navercorp/pinpoint/rpc/client/PinpointClientHandlerContext.java
+++ b/rpc/src/main/java/com/navercorp/pinpoint/rpc/client/PinpointClientHandlerContext.java
@@ -43,11 +43,11 @@ public class PinpointClientHandlerContext {
         return channel;
     }
 
-    public ClientStreamChannelContext openStream(byte[] payload, ClientStreamChannelMessageListener messageListener) {
+    public ClientStreamChannelContext openStream(byte[] payload, ClientStreamChannelMessageListener messageListener) throws StreamException {
         return openStream(payload, messageListener, null);
     }
 
-    public ClientStreamChannelContext openStream(byte[] payload, ClientStreamChannelMessageListener messageListener, StreamChannelStateChangeEventHandler<ClientStreamChannel> stateChangeListener) {
+    public ClientStreamChannelContext openStream(byte[] payload, ClientStreamChannelMessageListener messageListener, StreamChannelStateChangeEventHandler<ClientStreamChannel> stateChangeListener) throws StreamException {
         return streamChannelManager.openStream(payload, messageListener, stateChangeListener);
     }
 

--- a/rpc/src/main/java/com/navercorp/pinpoint/rpc/server/DefaultPinpointServer.java
+++ b/rpc/src/main/java/com/navercorp/pinpoint/rpc/server/DefaultPinpointServer.java
@@ -50,6 +50,7 @@ import com.navercorp.pinpoint.rpc.stream.ClientStreamChannelMessageListener;
 import com.navercorp.pinpoint.rpc.stream.StreamChannelContext;
 import com.navercorp.pinpoint.rpc.stream.StreamChannelManager;
 import com.navercorp.pinpoint.rpc.stream.StreamChannelStateChangeEventHandler;
+import com.navercorp.pinpoint.rpc.stream.StreamException;
 import com.navercorp.pinpoint.rpc.util.ClassUtils;
 import com.navercorp.pinpoint.rpc.util.ControlMessageEncodingUtils;
 import com.navercorp.pinpoint.rpc.util.IDGenerator;
@@ -240,12 +241,12 @@ public class DefaultPinpointServer implements PinpointServer {
     }
 
     @Override
-    public ClientStreamChannelContext openStream(byte[] payload, ClientStreamChannelMessageListener messageListener) {
+    public ClientStreamChannelContext openStream(byte[] payload, ClientStreamChannelMessageListener messageListener) throws StreamException {
         return openStream(payload, messageListener, null);
     }
 
     @Override
-    public ClientStreamChannelContext openStream(byte[] payload, ClientStreamChannelMessageListener messageListener, StreamChannelStateChangeEventHandler<ClientStreamChannel> stateChangeListener) {
+    public ClientStreamChannelContext openStream(byte[] payload, ClientStreamChannelMessageListener messageListener, StreamChannelStateChangeEventHandler<ClientStreamChannel> stateChangeListener) throws StreamException {
         logger.info("{} createStream() started.", objectUniqName);
 
         ClientStreamChannelContext streamChannel = streamChannelManager.openStream(payload, messageListener, stateChangeListener);

--- a/rpc/src/main/java/com/navercorp/pinpoint/rpc/stream/ClientStreamChannelContext.java
+++ b/rpc/src/main/java/com/navercorp/pinpoint/rpc/stream/ClientStreamChannelContext.java
@@ -17,9 +17,6 @@
 package com.navercorp.pinpoint.rpc.stream;
 
 import com.navercorp.pinpoint.common.util.Assert;
-import com.navercorp.pinpoint.rpc.packet.stream.StreamCreateFailPacket;
-
-import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * @author koo.taejin
@@ -28,15 +25,10 @@ public class ClientStreamChannelContext extends StreamChannelContext {
 
     private final ClientStreamChannel clientStreamChannel;
     private final ClientStreamChannelMessageListener clientStreamChannelMessageListener;
-    private final AtomicReference<StreamCreateFailPacket> createFailPacketReference;
 
     public ClientStreamChannelContext(ClientStreamChannel clientStreamChannel, ClientStreamChannelMessageListener clientStreamChannelMessageListener) {
-        Assert.requireNonNull(clientStreamChannel, "clientStreamChannel must not be null");
-        Assert.requireNonNull(clientStreamChannelMessageListener, "clientStreamChannelMessageListener must not be null");
-
-        this.clientStreamChannel = clientStreamChannel;
-        this.clientStreamChannelMessageListener = clientStreamChannelMessageListener;
-        this.createFailPacketReference = new AtomicReference<StreamCreateFailPacket>();
+        this.clientStreamChannel = Assert.requireNonNull(clientStreamChannel, "clientStreamChannel must not be null");
+        this.clientStreamChannelMessageListener = Assert.requireNonNull(clientStreamChannelMessageListener, "clientStreamChannelMessageListener must not be null");
     }
 
     @Override
@@ -46,14 +38,6 @@ public class ClientStreamChannelContext extends StreamChannelContext {
 
     public ClientStreamChannelMessageListener getClientStreamChannelMessageListener() {
         return clientStreamChannelMessageListener;
-    }
-
-    public StreamCreateFailPacket getCreateFailPacket() {
-        return createFailPacketReference.get();
-    }
-
-    public boolean setCreateFailPacket(StreamCreateFailPacket createFailPacket) {
-        return this.createFailPacketReference.compareAndSet(null, createFailPacket);
     }
 
 }

--- a/rpc/src/main/java/com/navercorp/pinpoint/rpc/stream/StreamException.java
+++ b/rpc/src/main/java/com/navercorp/pinpoint/rpc/stream/StreamException.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.rpc.stream;
+
+import com.navercorp.pinpoint.common.util.Assert;
+import com.navercorp.pinpoint.rpc.packet.stream.StreamCode;
+
+/**
+ * @author Taejin Koo
+ */
+public class StreamException extends Exception {
+
+    private final StreamCode streamCode;
+
+    public StreamException(StreamCode streamCode) {
+        super(streamCode.name());
+        this.streamCode = Assert.requireNonNull(streamCode, "streamCode must not be null");
+    }
+
+    public StreamCode getStreamCode() {
+        return streamCode;
+    }
+
+}

--- a/rpc/src/test/java/com/navercorp/pinpoint/rpc/stream/StreamChannelManagerTest.java
+++ b/rpc/src/test/java/com/navercorp/pinpoint/rpc/stream/StreamChannelManagerTest.java
@@ -45,7 +45,7 @@ public class StreamChannelManagerTest {
 
     // Client to Server Stream
     @Test
-    public void streamSuccessTest1() throws IOException, InterruptedException {
+    public void streamSuccessTest1() throws IOException, InterruptedException, StreamException {
         SimpleStreamBO bo = new SimpleStreamBO();
 
         TestPinpointServerAcceptor testPinpointServerAcceptor = new TestPinpointServerAcceptor(testServerMessageListenerFactory, new ServerListener(bo));
@@ -76,7 +76,7 @@ public class StreamChannelManagerTest {
 
     // Client to Server Stream
     @Test
-    public void streamSuccessTest2() throws IOException, InterruptedException {
+    public void streamSuccessTest2() throws IOException, InterruptedException, StreamException {
         SimpleStreamBO bo = new SimpleStreamBO();
 
         TestPinpointServerAcceptor testPinpointServerAcceptor = new TestPinpointServerAcceptor(testServerMessageListenerFactory, new ServerListener(bo));
@@ -119,7 +119,7 @@ public class StreamChannelManagerTest {
     }
 
     @Test
-    public void streamSuccessTest3() throws IOException, InterruptedException {
+    public void streamSuccessTest3() throws IOException, InterruptedException, StreamException {
         TestPinpointServerAcceptor testPinpointServerAcceptor = new TestPinpointServerAcceptor(testServerMessageListenerFactory);
         int bindPort = testPinpointServerAcceptor.bind();
 
@@ -158,8 +158,8 @@ public class StreamChannelManagerTest {
         }
     }
 
-    @Test
-    public void streamClosedTest1() throws IOException, InterruptedException {
+    @Test(expected = StreamException.class)
+    public void streamClosedTest1() throws IOException, InterruptedException, StreamException {
         TestPinpointServerAcceptor testPinpointServerAcceptor = new TestPinpointServerAcceptor(testServerMessageListenerFactory);
         int bindPort = testPinpointServerAcceptor.bind();
 
@@ -169,13 +169,7 @@ public class StreamChannelManagerTest {
 
             RecordedStreamChannelMessageListener clientListener = new RecordedStreamChannelMessageListener(4);
 
-            ClientStreamChannelContext clientContext = testPinpointClient.openStream(new byte[0], clientListener);
-            StreamCreateFailPacket createFailPacket = clientContext.getCreateFailPacket();
-            if (createFailPacket == null) {
-                Assert.fail();
-            }
-
-            clientContext.getStreamChannel().close();
+            testPinpointClient.openStream(new byte[0], clientListener);
         } finally {
             testPinpointClient.closeAll();
             testPinpointServerAcceptor.close();
@@ -183,7 +177,7 @@ public class StreamChannelManagerTest {
     }
 
     @Test
-    public void streamClosedTest2() throws IOException, InterruptedException {
+    public void streamClosedTest2() throws IOException, InterruptedException, StreamException {
         final SimpleStreamBO bo = new SimpleStreamBO();
 
         TestPinpointServerAcceptor testPinpointServerAcceptor = new TestPinpointServerAcceptor(testServerMessageListenerFactory, new ServerListener(bo));
@@ -218,7 +212,7 @@ public class StreamChannelManagerTest {
 
     // ServerStreamChannel first close.
     @Test(expected = PinpointSocketException.class)
-    public void streamClosedTest3() throws IOException, InterruptedException {
+    public void streamClosedTest3() throws IOException, InterruptedException, StreamException {
         TestPinpointServerAcceptor testPinpointServerAcceptor = new TestPinpointServerAcceptor(testServerMessageListenerFactory);
         int bindPort = testPinpointServerAcceptor.bind();
 

--- a/rpc/src/test/java/com/navercorp/pinpoint/test/client/TestPinpointClient.java
+++ b/rpc/src/test/java/com/navercorp/pinpoint/test/client/TestPinpointClient.java
@@ -26,6 +26,7 @@ import com.navercorp.pinpoint.rpc.stream.ClientStreamChannelContext;
 import com.navercorp.pinpoint.rpc.stream.ClientStreamChannelMessageListener;
 import com.navercorp.pinpoint.rpc.stream.ServerStreamChannelMessageListener;
 import com.navercorp.pinpoint.rpc.stream.StreamChannelContext;
+import com.navercorp.pinpoint.rpc.stream.StreamException;
 import com.navercorp.pinpoint.test.server.TestPinpointServerAcceptor;
 
 import java.util.Collections;
@@ -89,7 +90,7 @@ public class TestPinpointClient {
         this.pinpointClient = pinpointClientFactory.connect(host, port);
     }
 
-    public ClientStreamChannelContext openStream(byte[] payload, ClientStreamChannelMessageListener messageListener) {
+    public ClientStreamChannelContext openStream(byte[] payload, ClientStreamChannelMessageListener messageListener) throws StreamException {
         Assert.requireNonNull(pinpointClient, "pinpointClient must not be null");
         return pinpointClient.openStream(payload, messageListener);
     }

--- a/thrift/src/main/java/com/navercorp/pinpoint/thrift/dto/command/TRouteResult.java
+++ b/thrift/src/main/java/com/navercorp/pinpoint/thrift/dto/command/TRouteResult.java
@@ -23,6 +23,7 @@ public enum TRouteResult implements org.apache.thrift.TEnum {
   NOT_FOUND(230),
   NOT_ACCEPTABLE(240),
   NOT_SUPPORTED_SERVICE(241),
+  STREAM_CREATE_ERROR(250),
   UNKNOWN(-1);
 
   private final int value;
@@ -66,6 +67,8 @@ public enum TRouteResult implements org.apache.thrift.TEnum {
         return NOT_ACCEPTABLE;
       case 241:
         return NOT_SUPPORTED_SERVICE;
+      case 250:
+        return STREAM_CREATE_ERROR;
       case -1:
         return UNKNOWN;
       default:

--- a/thrift/src/main/thrift/Command.thrift
+++ b/thrift/src/main/thrift/Command.thrift
@@ -130,6 +130,8 @@ enum TRouteResult {
     NOT_ACCEPTABLE = 240,
     NOT_SUPPORTED_SERVICE = 241,
 
+    STREAM_CREATE_ERROR = 250,
+
     UNKNOWN = -1
 }
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/cluster/DefaultPinpointRouteResponse.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/cluster/DefaultPinpointRouteResponse.java
@@ -34,6 +34,7 @@ public class DefaultPinpointRouteResponse implements PinpointRouteResponse {
 
     private TRouteResult routeResult;
     private TBase response;
+    private String message;
 
     private boolean isParsed;
 
@@ -62,6 +63,7 @@ public class DefaultPinpointRouteResponse implements PinpointRouteResponse {
                 }
 
                 response = deserialize(commandDeserializerFactory, commandResponse.getPayload(), null);
+                message = commandResponse.getMessage();
             } else {
                 routeResult = TRouteResult.UNKNOWN;
                 response = object;
@@ -80,6 +82,11 @@ public class DefaultPinpointRouteResponse implements PinpointRouteResponse {
     public TBase getResponse() {
         assertParsed();
         return response;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
     }
 
     @Override

--- a/web/src/main/java/com/navercorp/pinpoint/web/cluster/FailedPinpointRouteResponse.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/cluster/FailedPinpointRouteResponse.java
@@ -24,8 +24,8 @@ import org.apache.thrift.TBase;
  */
 public class FailedPinpointRouteResponse implements PinpointRouteResponse {
 
-    private TRouteResult routeResult;
-    private TBase response;
+    private final TRouteResult routeResult;
+    private final TBase response;
 
     public FailedPinpointRouteResponse(TRouteResult routeResult, TBase response) {
         this.routeResult = routeResult;
@@ -40,6 +40,11 @@ public class FailedPinpointRouteResponse implements PinpointRouteResponse {
     @Override
     public TBase getResponse() {
         return response;
+    }
+
+    @Override
+    public String getMessage() {
+        return null;
     }
 
     @Override

--- a/web/src/main/java/com/navercorp/pinpoint/web/cluster/PinpointRouteResponse.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/cluster/PinpointRouteResponse.java
@@ -25,8 +25,9 @@ import org.apache.thrift.TBase;
 public interface PinpointRouteResponse {
 
     TRouteResult getRouteResult();
-
     TBase getResponse();
+    String getMessage();
+
     <R extends TBase> R getResponse(Class<R> clazz);
     <R extends TBase> R getResponse(Class<R> clazz, R defaultValue);
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/AgentService.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/AgentService.java
@@ -21,6 +21,7 @@ import com.navercorp.pinpoint.rpc.stream.ClientStreamChannel;
 import com.navercorp.pinpoint.rpc.stream.ClientStreamChannelContext;
 import com.navercorp.pinpoint.rpc.stream.ClientStreamChannelMessageListener;
 import com.navercorp.pinpoint.rpc.stream.StreamChannelStateChangeEventHandler;
+import com.navercorp.pinpoint.rpc.stream.StreamException;
 import com.navercorp.pinpoint.web.cluster.PinpointRouteResponse;
 import com.navercorp.pinpoint.web.vo.AgentActiveThreadCountList;
 import com.navercorp.pinpoint.web.vo.AgentInfo;
@@ -55,11 +56,11 @@ public interface AgentService {
     Map<AgentInfo, PinpointRouteResponse> invoke(List<AgentInfo> agentInfoList, byte[] payload) throws TException;
     Map<AgentInfo, PinpointRouteResponse> invoke(List<AgentInfo> agentInfoList, byte[] payload, long timeout) throws TException;
 
-    ClientStreamChannelContext openStream(AgentInfo agentInfo, TBase<?, ?> tBase, ClientStreamChannelMessageListener messageListener) throws TException;
-    ClientStreamChannelContext openStream(AgentInfo agentInfo, TBase<?, ?> tBase, ClientStreamChannelMessageListener messageListener, StreamChannelStateChangeEventHandler<ClientStreamChannel> stateChangeListener) throws TException;
+    ClientStreamChannelContext openStream(AgentInfo agentInfo, TBase<?, ?> tBase, ClientStreamChannelMessageListener messageListener) throws TException, StreamException;
+    ClientStreamChannelContext openStream(AgentInfo agentInfo, TBase<?, ?> tBase, ClientStreamChannelMessageListener messageListener, StreamChannelStateChangeEventHandler<ClientStreamChannel> stateChangeListener) throws TException, StreamException;
 
-    ClientStreamChannelContext openStream(AgentInfo agentInfo, byte[] payload, ClientStreamChannelMessageListener messageListener) throws TException;
-    ClientStreamChannelContext openStream(AgentInfo agentInfo, byte[] payload, ClientStreamChannelMessageListener messageListener, StreamChannelStateChangeEventHandler<ClientStreamChannel> stateChangeListener) throws TException;
+    ClientStreamChannelContext openStream(AgentInfo agentInfo, byte[] payload, ClientStreamChannelMessageListener messageListener) throws TException, StreamException;
+    ClientStreamChannelContext openStream(AgentInfo agentInfo, byte[] payload, ClientStreamChannelMessageListener messageListener, StreamChannelStateChangeEventHandler<ClientStreamChannel> stateChangeListener) throws TException, StreamException;
 
     AgentActiveThreadCountList getActiveThreadCount(List<AgentInfo> agentInfoList) throws TException;
     AgentActiveThreadCountList getActiveThreadCount(List<AgentInfo> agentInfoList, byte[] payload) throws TException;

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/AgentServiceImpl.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/AgentServiceImpl.java
@@ -20,10 +20,12 @@ import com.navercorp.pinpoint.io.request.Message;
 import com.navercorp.pinpoint.rpc.Future;
 import com.navercorp.pinpoint.rpc.PinpointSocket;
 import com.navercorp.pinpoint.rpc.ResponseMessage;
+import com.navercorp.pinpoint.rpc.packet.stream.StreamCode;
 import com.navercorp.pinpoint.rpc.stream.ClientStreamChannel;
 import com.navercorp.pinpoint.rpc.stream.ClientStreamChannelContext;
 import com.navercorp.pinpoint.rpc.stream.ClientStreamChannelMessageListener;
 import com.navercorp.pinpoint.rpc.stream.StreamChannelStateChangeEventHandler;
+import com.navercorp.pinpoint.rpc.stream.StreamException;
 import com.navercorp.pinpoint.rpc.util.ListUtils;
 import com.navercorp.pinpoint.thrift.dto.command.TCmdActiveThreadCount;
 import com.navercorp.pinpoint.thrift.dto.command.TCmdActiveThreadCountRes;
@@ -42,6 +44,7 @@ import com.navercorp.pinpoint.web.vo.AgentActiveThreadCount;
 import com.navercorp.pinpoint.web.vo.AgentActiveThreadCountFactory;
 import com.navercorp.pinpoint.web.vo.AgentActiveThreadCountList;
 import com.navercorp.pinpoint.web.vo.AgentInfo;
+
 import org.apache.thrift.TBase;
 import org.apache.thrift.TException;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -248,32 +251,31 @@ public class AgentServiceImpl implements AgentService {
     }
 
     @Override
-    public ClientStreamChannelContext openStream(AgentInfo agentInfo, TBase<?, ?> tBase, ClientStreamChannelMessageListener messageListener) throws TException {
+    public ClientStreamChannelContext openStream(AgentInfo agentInfo, TBase<?, ?> tBase, ClientStreamChannelMessageListener messageListener) throws TException, StreamException {
         byte[] payload = serializeRequest(tBase);
         return openStream(agentInfo, payload, messageListener, null);
     }
 
     @Override
-    public ClientStreamChannelContext openStream(AgentInfo agentInfo, byte[] payload, ClientStreamChannelMessageListener messageListener) throws TException {
+    public ClientStreamChannelContext openStream(AgentInfo agentInfo, byte[] payload, ClientStreamChannelMessageListener messageListener) throws TException, StreamException {
         return openStream(agentInfo, payload, messageListener, null);
     }
 
     @Override
-    public ClientStreamChannelContext openStream(AgentInfo agentInfo, TBase<?, ?> tBase, ClientStreamChannelMessageListener messageListener, StreamChannelStateChangeEventHandler<ClientStreamChannel> stateChangeListener) throws TException {
+    public ClientStreamChannelContext openStream(AgentInfo agentInfo, TBase<?, ?> tBase, ClientStreamChannelMessageListener messageListener, StreamChannelStateChangeEventHandler<ClientStreamChannel> stateChangeListener) throws TException, StreamException {
         byte[] payload = serializeRequest(tBase);
         return openStream(agentInfo, payload, messageListener, stateChangeListener);
     }
 
     @Override
-    public ClientStreamChannelContext openStream(AgentInfo agentInfo, byte[] payload, ClientStreamChannelMessageListener messageListener, StreamChannelStateChangeEventHandler<ClientStreamChannel> stateChangeListener) throws TException {
+    public ClientStreamChannelContext openStream(AgentInfo agentInfo, byte[] payload, ClientStreamChannelMessageListener messageListener, StreamChannelStateChangeEventHandler<ClientStreamChannel> stateChangeListener) throws TException, StreamException {
         TCommandTransfer transferObject = createCommandTransferObject(agentInfo, payload);
         PinpointSocket socket = clusterManager.getSocket(agentInfo);
-
-        if (socket != null) {
-            return socket.openStream(serializeRequest(transferObject), messageListener, stateChangeListener);
+        if (socket == null) {
+            throw new StreamException(StreamCode.CONNECTION_NOT_FOUND);
         }
 
-        return null;
+        return socket.openStream(serializeRequest(transferObject), messageListener, stateChangeListener);
     }
 
     @Override

--- a/web/src/test/java/com/navercorp/pinpoint/web/cluster/PinpointRouteResponseTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/cluster/PinpointRouteResponseTest.java
@@ -63,21 +63,23 @@ public class PinpointRouteResponseTest {
 
         Assert.assertEquals(TRouteResult.OK, response.getRouteResult());
         Assert.assertTrue(response.getResponse() instanceof TCommandEcho);
+        Assert.assertNull(response.getMessage());
     }
 
     @Test
     public void routeResponseTest3() throws Exception {
         HeaderTBaseSerializer serializer = serializerFactory.createSerializer();
 
-        byte[] responsePayload = serializer.serialize(wrapResponse(TRouteResult.OK, new byte[1]));
+        String message = "hello";
+        byte[] responsePayload = serializer.serialize(wrapResponse(TRouteResult.OK, new byte[1], message));
 
         DefaultPinpointRouteResponse response = new DefaultPinpointRouteResponse(responsePayload);
         response.parse(deserializerFactory);
 
         Assert.assertEquals(TRouteResult.OK, response.getRouteResult());
         Assert.assertNull(response.getResponse());
+        Assert.assertEquals(message, response.getMessage());
     }
-
 
     private TCommandEcho createCommandEcho(String message) {
         TCommandEcho echo = new TCommandEcho(message);
@@ -85,9 +87,17 @@ public class PinpointRouteResponseTest {
     }
 
     private TCommandTransferResponse wrapResponse(TRouteResult routeResult, byte[] payload) {
+        return wrapResponse(routeResult, payload, null);
+    }
+
+    private TCommandTransferResponse wrapResponse(TRouteResult routeResult, byte[] payload, String message) {
         TCommandTransferResponse response = new TCommandTransferResponse();
         response.setRouteResult(routeResult);
         response.setPayload(payload);
+
+        if (message != null) {
+            response.setMessage(message);
+        }
 
         return response;
     }


### PR DESCRIPTION
Delete the FailPacket field in ClientStreamChannelContext.
Through this operation, can simplifies StreamChannelContext class.