### PR TITLE
[#5411] support option for tracing embedded library

### DIFF
--- a/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/context/Trace.java
+++ b/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/context/Trace.java
@@ -56,4 +56,6 @@ public interface Trace extends StackOperation {
     TraceScope getScope(String name);
 
     TraceScope addScope(String name);
+
+    TraceScope removeScope(String name);
 }

--- a/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/AsyncChildTrace.java
+++ b/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/AsyncChildTrace.java
@@ -299,6 +299,14 @@ public class AsyncChildTrace implements Trace {
     }
 
     @Override
+    public TraceScope removeScope(String name) {
+        if (scopePool == null) {
+            return null;
+        }
+        return scopePool.remove(name);
+    }
+
+    @Override
     public String toString() {
         return "AsyncChildTrace{" +
                 "traceRoot=" + getTraceRoot() +

--- a/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/AsyncTrace.java
+++ b/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/AsyncTrace.java
@@ -145,6 +145,11 @@ public class AsyncTrace implements Trace {
     }
 
     @Override
+    public TraceScope removeScope(String name) {
+        return trace.removeScope(name);
+    }
+
+    @Override
     public String toString() {
         return "AsyncTrace{" +
                 "traceRoot=" + traceRoot +

--- a/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/DefaultTrace.java
+++ b/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/DefaultTrace.java
@@ -314,6 +314,14 @@ public final class DefaultTrace implements Trace {
     }
 
     @Override
+    public TraceScope removeScope(String name) {
+        if (scopePool == null) {
+            return null;
+        }
+        return scopePool.remove(name);
+    }
+
+    @Override
     public String toString() {
         return "DefaultTrace{" +
                 ", traceRoot=" + getTraceRoot() +

--- a/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/DisableTrace.java
+++ b/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/DisableTrace.java
@@ -142,4 +142,9 @@ public class DisableTrace implements Trace {
     public TraceScope addScope(String name) {
         return scopePool.add(name);
     }
+
+    @Override
+    public TraceScope removeScope(String name) {
+        return scopePool.remove(name);
+    }
 }

--- a/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/scope/DefaultTraceScopePool.java
+++ b/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/scope/DefaultTraceScopePool.java
@@ -42,6 +42,14 @@ public class DefaultTraceScopePool {
         return oldScope;
     }
 
+    public TraceScope remove(String name) {
+        if (name == null) {
+            throw new IllegalArgumentException("name must not be null");
+        }
+
+        return list.remove(name);
+    }
+
     public void clear() {
         list.clear();
     }


### PR DESCRIPTION
Working with scope works... But.

### Need to consider when altering trace with Scope

Must consider.
Shouldn't the applied range be inside a Span?
In this case, isn't applied range a Trace?

### Besides the applied range
A small thing. But the naming is a little awkward. (in the case of `isActive` function)

It can be used as below,
When A library embeds B library. ( = B inside A)

A plugin
```java
currentTrace.addScope(HttpClient4Constants.HTTP_CLIENT4_SCOPE);
currentTrace.getScope(HttpClient4Constants.HTTP_CLIENT4_SCOPE).tryEnter();
logger.info("add scope NOT to trace embedded library");
```

B plugin
```java
TraceScope traceScope = trace.getScope(HttpClient4Constants.HTTP_CLIENT4_SCOPE);
        if(traceScope != null && traceScope.isActive()){
            logger.info("Do NOT trace embedded library");
            return;
        }
```

What do you think?
