### PR TITLE
Fixes running container agents not showing up in Inspector View agent list

### DIFF
--- a/web/src/main/java/com/navercorp/pinpoint/web/controller/AgentInfoController.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/controller/AgentInfoController.java
@@ -94,13 +94,20 @@ public class AgentInfoController {
             @RequestParam("from") long from,
             @RequestParam("to") long to) {
         ApplicationAgentsList.Filter containerFilter = agentInfo -> {
-            if (agentInfo.isContainer()) {
-                AgentStatus agentStatus = agentInfo.getStatus();
-                if (agentStatus == null || agentStatus.getEventTimestamp() < from) {
-                    return ApplicationAgentsList.Filter.REJECT;
-                }
+            if (!agentInfo.isContainer()) {
+                return ApplicationAgentsList.Filter.ACCEPT;
             }
-            return ApplicationAgentsList.Filter.ACCEPT;
+            AgentStatus agentStatus = agentInfo.getStatus();
+            if (agentStatus == null) {
+                return ApplicationAgentsList.Filter.REJECT;
+            }
+            if (agentStatus.getState() == AgentLifeCycleState.RUNNING) {
+                return ApplicationAgentsList.Filter.ACCEPT;
+            }
+            if (agentStatus.getEventTimestamp() >= from) {
+                return ApplicationAgentsList.Filter.ACCEPT;
+            }
+            return ApplicationAgentsList.Filter.REJECT;
         };
         long timestamp = to;
         return this.agentInfoService.getApplicationAgentsList(ApplicationAgentsList.GroupBy.HOST_NAME, containerFilter, applicationName, timestamp);
@@ -113,13 +120,17 @@ public class AgentInfoController {
             @RequestParam("application") String applicationName,
             @RequestParam("timestamp") long timestamp) {
         ApplicationAgentsList.Filter runningContainerFilter = agentInfo -> {
-            if (agentInfo.isContainer()) {
-                AgentStatus agentStatus = agentInfo.getStatus();
-                if (agentStatus == null || agentStatus.getState() != AgentLifeCycleState.RUNNING) {
-                    return ApplicationAgentsList.Filter.REJECT;
-                }
+            if (!agentInfo.isContainer()) {
+                return ApplicationAgentsList.Filter.ACCEPT;
             }
-            return ApplicationAgentsList.Filter.ACCEPT;
+            AgentStatus agentStatus = agentInfo.getStatus();
+            if (agentStatus == null) {
+                return ApplicationAgentsList.Filter.REJECT;
+            }
+            if (agentStatus.getState() == AgentLifeCycleState.RUNNING) {
+                return ApplicationAgentsList.Filter.ACCEPT;
+            }
+            return ApplicationAgentsList.Filter.REJECT;
         };
         return this.agentInfoService.getApplicationAgentsList(ApplicationAgentsList.GroupBy.HOST_NAME, runningContainerFilter, applicationName, timestamp);
     }


### PR DESCRIPTION
Currently, running container agents are filtered from the agent list in Inspector View if the search period is set to be in between agent ping times.
This fixes so that container agents are not filtered even if there were no ping events during the search period if their status is running.

resolves #5445 