### PR TITLE
[#noissue] Initialize the chart once when switching the tab on the transaction view page

### DIFF
--- a/web/src/main/webapp/v2/src/app/core/components/inspector-chart/inspector-chart-container.component.ts
+++ b/web/src/main/webapp/v2/src/app/core/components/inspector-chart/inspector-chart-container.component.ts
@@ -240,6 +240,9 @@ export class InspectorChartContainerComponent implements OnInit, OnDestroy {
                     }
                 }
             },
+            resize: {
+                auto: false
+            },
             tooltip: {
                 linked: true,
                 format: {

--- a/web/src/main/webapp/v2/src/app/core/components/inspector-chart/transaction-view-chart-container.component.ts
+++ b/web/src/main/webapp/v2/src/app/core/components/inspector-chart/transaction-view-chart-container.component.ts
@@ -1,11 +1,11 @@
-import { Component, OnInit, Input, OnDestroy } from '@angular/core';
+import { Component, OnInit, Input, OnDestroy, ViewChild } from '@angular/core';
 import { Subject, forkJoin, combineLatest, of } from 'rxjs';
 import { TranslateService } from '@ngx-translate/core';
 import { PrimitiveArray, Data } from 'billboard.js';
 import * as moment from 'moment-timezone';
 
 import { ChartType, InspectorChartContainerFactory, IInspectorChartContainer } from './inspector-chart-container-factory';
-import { IChartConfig } from './inspector-chart.component';
+import { IChartConfig, InspectorChartComponent } from './inspector-chart.component';
 import { StoreHelperService, NewUrlStateNotificationService } from 'app/shared/services';
 import { InspectorChartDataService, IInspectorChartData } from './inspector-chart-data.service';
 import { UrlPathId } from 'app/shared/models';
@@ -24,6 +24,7 @@ export enum Layer {
     styleUrls: ['./transaction-view-chart-container.component.css']
 })
 export class TransactionViewChartContainerComponent implements OnInit, OnDestroy {
+    @ViewChild(InspectorChartComponent) component: InspectorChartComponent;
     @Input()
     set chartType(chartType: ChartType) {
         this._chartType = chartType;
@@ -98,6 +99,10 @@ export class TransactionViewChartContainerComponent implements OnInit, OnDestroy
 
     onRendered(): void {
         this.activeLayer = Layer.CHART;
+    }
+
+    onBackToTheView(): void {
+        this.component.resize();
     }
 
     private setChartVisibility(showChart: boolean): void {
@@ -194,6 +199,9 @@ export class TransactionViewChartContainerComponent implements OnInit, OnDestroy
                         r: 3
                     }
                 }
+            },
+            resize: {
+                auto: false
             },
             tooltip: {
                 linked: true,

--- a/web/src/main/webapp/v2/src/app/core/components/transaction-view-top-contents/transaction-view-top-contents-container.component.html
+++ b/web/src/main/webapp/v2/src/app/core/components/transaction-view-top-contents/transaction-view-top-contents-container.component.html
@@ -1,7 +1,9 @@
 <div class="l-transaction-view-top">
     <div class="l-left-section">
         <ul class="font-opensans l-tab-menu-list">
-            <li *ngFor="let tab of tabList" class="l-tab-menu-list-item" [class.active]="tab.isActive"><a (click)="onTabClick(tab.id)">{{tab.displayText}}</a></li>
+            <li *ngFor="let tab of tabList" class="l-tab-menu-list-item" [class.active]="tab.id === activeTab">
+                <a (click)="onTabClick(tab.id)">{{tab.display}}</a>
+            </li>
         </ul>
         <ng-container #chartContainer></ng-container>
     </div>

--- a/web/src/main/webapp/v2/src/app/core/components/transaction-view-top-contents/transaction-view-top-contents-container.component.ts
+++ b/web/src/main/webapp/v2/src/app/core/components/transaction-view-top-contents/transaction-view-top-contents-container.component.ts
@@ -13,8 +13,10 @@ export class TransactionViewTopContentsContainerComponent implements OnInit, OnD
     @HostBinding('class') hostClass = 'l-transaction-view-top-contents';
     @ViewChild('chartContainer', { read: ViewContainerRef }) chartContainer: ViewContainerRef;
 
-    tabList: any[];
-    private aliveComponentRef: ComponentRef<any>;
+    private componentRefMap = new Map<string, ComponentRef<TransactionViewChartContainerComponent>>();
+
+    tabList: {id: string, display: string}[];
+    activeTab = 'heap';
 
     constructor(
         private componentFactoryResolver: ComponentFactoryResolver,
@@ -23,38 +25,35 @@ export class TransactionViewTopContentsContainerComponent implements OnInit, OnD
 
     ngOnInit() {
         this.initTabList();
-        this.loadComponent(this.tabList.find((tab) => tab.isActive).id);
+        this.loadComponent(this.activeTab);
     }
 
     ngOnDestroy() {
-        this.aliveComponentRef.destroy();
+        this.chartContainer.get(0).destroy();
     }
 
-    onTabClick(tabName: string): void {
-        this.setActiveTab(tabName);
-        this.clearContainer();
-        this.loadComponent(tabName);
-    }
+    onTabClick(tab: string): void {
+        if (tab === this.activeTab) {
+            return;
+        }
 
-    private clearContainer(): void {
-        this.chartContainer.clear();
+        this.activeTab = tab;
+        this.chartContainer.detach(0);
+        this.loadComponent(tab);
     }
 
     private initTabList(): void {
         this.tabList = [{
             id: 'heap',
-            displayText: 'Heap',
-            isActive: true
+            display: 'Heap',
         },
         {
             id: 'nonHeap',
-            displayText: 'Non Heap',
-            isActive: false
+            display: 'Non Heap',
         },
         {
             id: 'cpu',
-            displayText: 'CPU Load',
-            isActive: false
+            display: 'CPU Load',
         }];
     }
 
@@ -71,13 +70,18 @@ export class TransactionViewTopContentsContainerComponent implements OnInit, OnD
 
     private loadComponent(key: string): void {
         this.analyticsService.trackEvent((TRACKED_EVENT_LIST as any)[`CLICK_${key}`]);
-        const componentFactory = this.componentFactoryResolver.resolveComponentFactory(TransactionViewChartContainerComponent);
 
-        this.aliveComponentRef = this.chartContainer.createComponent(componentFactory);
-        this.aliveComponentRef.instance.chartType = this.matchChartType(key);
-    }
+        const componentRef = this.componentRefMap.get(key);
 
-    private setActiveTab(tabName: string): void {
-        this.tabList.forEach((tab) => tab.isActive = tabName === tab.id);
+        if (componentRef) {
+            this.chartContainer.insert(componentRef.hostView);
+            componentRef.instance.onBackToTheView();
+        } else {
+            const componentFactory = this.componentFactoryResolver.resolveComponentFactory(TransactionViewChartContainerComponent);
+            const component = this.chartContainer.createComponent(componentFactory);
+
+            this.componentRefMap.set(key, component);
+            component.instance.chartType = this.matchChartType(key);
+        }
     }
 }


### PR DESCRIPTION
- Detach and insert the chart instead of removing it in switching the tab