### PR TITLE
[#5785] Improve memory usage in 'transactionmetadata' rest api

### DIFF
--- a/web/src/main/java/com/navercorp/pinpoint/web/vo/SpanHint.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/vo/SpanHint.java
@@ -37,7 +37,7 @@ public final class SpanHint {
     public SpanHint(long collectorAcceptorTime, int responseTime) {
         Assert.isTrue(collectorAcceptorTime > 0, "collectorAcceptorTime must be 'collectorAcceptorTime > 0'");
         this.collectorAcceptorTime = collectorAcceptorTime;
-        Assert.isTrue(responseTime > 0, "responseTime must be 'responseTime > 0'");
+        Assert.isTrue(responseTime >= 0, "responseTime must be 'responseTime >= 0'");
         this.responseTime = responseTime;
 
         this.isSet = true;


### PR DESCRIPTION
allow for 0 response time