### PR TITLE
[#4558] Add gRPC StatusError of Collector

### DIFF
--- a/collector/src/main/java/com/navercorp/pinpoint/collector/receiver/grpc/service/SpanService.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/receiver/grpc/service/SpanService.java
@@ -20,6 +20,8 @@ import com.google.protobuf.Empty;
 import com.google.protobuf.GeneratedMessageV3;
 import com.navercorp.pinpoint.collector.receiver.DispatchHandler;
 import com.navercorp.pinpoint.grpc.MessageFormatUtils;
+import com.navercorp.pinpoint.grpc.StatusError;
+import com.navercorp.pinpoint.grpc.StatusErrors;
 import com.navercorp.pinpoint.grpc.trace.PSpan;
 import com.navercorp.pinpoint.grpc.trace.PSpanChunk;
 import com.navercorp.pinpoint.grpc.trace.PSpanMessage;
@@ -77,7 +79,12 @@ public class SpanService extends SpanGrpc.SpanImplBase {
 
             @Override
             public void onError(Throwable throwable) {
-                logger.warn("Error sendSpan stream", throwable);
+                final StatusError statusError = StatusErrors.throwable(throwable);
+                if (statusError.isSimpleError()) {
+                    logger.info("Failed to span stream, cause={}", statusError.getMessage());
+                } else {
+                    logger.warn("Failed to span stream, cause={}", statusError.getMessage(), statusError.getThrowable());
+                }
             }
 
             @Override

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/receiver/grpc/service/StatService.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/receiver/grpc/service/StatService.java
@@ -20,6 +20,8 @@ import com.google.protobuf.Empty;
 import com.google.protobuf.GeneratedMessageV3;
 import com.navercorp.pinpoint.collector.receiver.DispatchHandler;
 import com.navercorp.pinpoint.grpc.MessageFormatUtils;
+import com.navercorp.pinpoint.grpc.StatusError;
+import com.navercorp.pinpoint.grpc.StatusErrors;
 import com.navercorp.pinpoint.grpc.trace.PAgentStat;
 import com.navercorp.pinpoint.grpc.trace.PAgentStatBatch;
 import com.navercorp.pinpoint.grpc.trace.PStatMessage;
@@ -79,7 +81,12 @@ public class StatService extends StatGrpc.StatImplBase {
 
             @Override
             public void onError(Throwable throwable) {
-                logger.warn("Error sendAgentStat stream", throwable);
+                final StatusError statusError = StatusErrors.throwable(throwable);
+                if (statusError.isSimpleError()) {
+                    logger.info("Failed to stat stream, cause={}", statusError.getMessage());
+                } else {
+                    logger.warn("Failed to stat stream, cause={}", statusError.getMessage(), statusError.getThrowable());
+                }
             }
 
             @Override

--- a/grpc/src/main/java/com/navercorp/pinpoint/grpc/StatusErrors.java
+++ b/grpc/src/main/java/com/navercorp/pinpoint/grpc/StatusErrors.java
@@ -24,6 +24,8 @@ import io.grpc.StatusRuntimeException;
  */
 public class StatusErrors {
     private static final String CONNECTION_REFUSED_MESSAGE = "Connection refused: no further information";
+    private static final String CANCELLED_BEFORE_RECEIVING_HALF_CLOSE = "CANCELLED: cancelled before receiving half close";
+
 
     public static StatusError throwable(final Throwable t) {
         if (t instanceof StatusRuntimeException) {
@@ -33,6 +35,10 @@ public class StatusErrors {
                 if (causeMessage != null) {
                     final String message = exception.getStatus().getDescription() + ": " + causeMessage;
                     return new SimpleStatusError(message, t);
+                }
+            } else if(exception.getStatus().getCode() == Status.CANCELLED.getCode()) {
+                if (exception.getMessage() != null && exception.getMessage().startsWith(CANCELLED_BEFORE_RECEIVING_HALF_CLOSE)) {
+                    return new SimpleStatusError(CANCELLED_BEFORE_RECEIVING_HALF_CLOSE, t);
                 }
             }
         }


### PR DESCRIPTION
#4558 

~~~
io.grpc.StatusRuntimeException: CANCELLED: cancelled before receiving half close
	at io.grpc.Status.asRuntimeException(Status.java:517)
	at io.grpc.stub.ServerCalls$StreamingServerCallHandler$StreamingServerCallListener.onCancel(ServerCalls.java:272)
	at io.grpc.PartialForwardingServerCallListener.onCancel(PartialForwardingServerCallListener.java:40)
	at io.grpc.ForwardingServerCallListener.onCancel(ForwardingServerCallListener.java:23)
	at io.grpc.ForwardingServerCallListener$SimpleForwardingServerCallListener.onCancel(ForwardingServerCallListener.java:40)
	at io.grpc.Contexts$ContextualizedServerCallListener.onCancel(Contexts.java:96)
	at io.grpc.PartialForwardingServerCallListener.onCancel(PartialForwardingServerCallListener.java:40)
	at io.grpc.ForwardingServerCallListener.onCancel(ForwardingServerCallListener.java:23)
	at io.grpc.ForwardingServerCallListener$SimpleForwardingServerCallListener.onCancel(ForwardingServerCallListener.java:40)
	at io.grpc.Contexts$ContextualizedServerCallListener.onCancel(Contexts.java:96)
	at io.grpc.internal.ServerCallImpl$ServerStreamListenerImpl.closed(ServerCallImpl.java:293)
	at io.grpc.internal.ServerImpl$JumpToApplicationThreadServerStreamListener$1Closed.runInContext(ServerImpl.java:738)
	at io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37)
	at io.grpc.internal.SerializingExecutor.run(SerializingExecutor.java:123)
	at com.navercorp.pinpoint.collector.monitor.MonitoredRunnableDecorator$InstrumentedRunnable.run(MonitoredRunnableDecorator.java:113)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:834)
~~~