### PR TITLE
Added RetryingMessageListenerAdapter to KafkaPlugin

### DIFF
--- a/plugins/kafka/src/main/java/com/navercorp/pinpoint/plugin/kafka/KafkaPlugin.java
+++ b/plugins/kafka/src/main/java/com/navercorp/pinpoint/plugin/kafka/KafkaPlugin.java
@@ -45,7 +45,9 @@ import java.util.List;
 
 import static com.navercorp.pinpoint.common.util.VarArgs.va;
 
-
+/**
+ * @author Harris Gwag (gwagdalf)
+ */
 public class KafkaPlugin implements ProfilerPlugin, TransformTemplateAware {
 
     private final PLogger logger = PLoggerFactory.getLogger(this.getClass());

--- a/plugins/kafka/src/main/java/com/navercorp/pinpoint/plugin/kafka/KafkaPlugin.java
+++ b/plugins/kafka/src/main/java/com/navercorp/pinpoint/plugin/kafka/KafkaPlugin.java
@@ -68,10 +68,11 @@ public class KafkaPlugin implements ProfilerPlugin, TransformTemplateAware {
             transformTemplate.transform("org.apache.kafka.clients.consumer.ConsumerRecord", ConsumerRecordTransform.class);
 
             if (config.isSpringConsumerEnable()) {
-                transformTemplate.transform("org.springframework.kafka.listener.adapter.RecordMessagingMessageListenerAdapterTransform", RecordMessagingMessageListenerAdapterTransform.class);
-
+                transformTemplate.transform("org.springframework.kafka.listener.adapter.RecordMessagingMessageListenerAdapter", AcknowledgingConsumerAwareMessageListenerTransform.class);
                 transformTemplate.transform("org.springframework.kafka.listener.adapter.BatchMessagingMessageListenerAdapter", BatchMessagingMessageListenerAdapterTransform.class);
 
+                // Spring Cloud Starter Stream Kafka 2.2.x is supported
+                transformTemplate.transform("org.springframework.kafka.listener.adapter.RetryingMessageListenerAdapter", AcknowledgingConsumerAwareMessageListenerTransform.class);
             }
 
             if (StringUtils.hasText(config.getKafkaEntryPoint())) {
@@ -168,7 +169,7 @@ public class KafkaPlugin implements ProfilerPlugin, TransformTemplateAware {
 
     }
 
-    public static class RecordMessagingMessageListenerAdapterTransform implements TransformCallback {
+    public static class AcknowledgingConsumerAwareMessageListenerTransform implements TransformCallback {
 
         @Override
         public byte[] doInTransform(Instrumentor instrumentor, ClassLoader classLoader, String className, Class<?> classBeingRedefined, ProtectionDomain protectionDomain, byte[] classfileBuffer) throws InstrumentException {


### PR DESCRIPTION
Added & modified 3 lines in KafkaPlugin class.

1. Added RetryingMessageListenerAdapter.

2. Bug fixed RecordMessagingMessageListenerAdapterTransform -> RecordMessagingMessageListenerAdapter. Corrected the class name instead of callback name.

3. Method name changed RecordMessagingMessageListenerAdapterTransform -> AcknowledgingConsumerAwareMessageListenerTransform

I tested it in my development environment, but I honestly don't know how to test it.
Please give me feedback if you need anything
