### PR TITLE
[#5891] fix DubboConsumerIT NullPointerException

### DIFF
--- a/agent-it/src/test/java/com/navercorp/pinpoint/plugin/dubbo/consumer/DubboConsumerIT.java
+++ b/agent-it/src/test/java/com/navercorp/pinpoint/plugin/dubbo/consumer/DubboConsumerIT.java
@@ -64,6 +64,7 @@ public class DubboConsumerIT {
     @Test
     public void testConsumer() throws NoSuchMethodException {
         abstractClusterInvoker = new MockInvoker<Demo>(Demo.class, url);
+        when(rpcInvocation.getInvoker()).thenReturn(abstractClusterInvoker);
         try {
             abstractClusterInvoker.invoke(rpcInvocation);
         } catch (RpcException e) {
@@ -79,6 +80,7 @@ public class DubboConsumerIT {
     @Test
     public void testConsumerMonitor() {
         abstractClusterInvoker = mock(AbstractInvoker.class);
+        when(rpcInvocation.getInvoker()).thenReturn(abstractClusterInvoker);
         when(abstractClusterInvoker.getInterface()).thenReturn(MonitorService.class);
         try {
             abstractClusterInvoker.invoke(rpcInvocation);


### PR DESCRIPTION
After adding `when(rpcInvocation.getInvoker()).thenReturn(abstractClusterInvoker);`, NullPointerException disappeared 

![image](https://user-images.githubusercontent.com/10413284/63251667-c4927800-c2a0-11e9-87b1-c30140761b2a.png)
