### PR TITLE
add log4j2 support for 1.8.x

### DIFF
--- a/agent-it/pom.xml
+++ b/agent-it/pom.xml
@@ -403,6 +403,19 @@
             <version>4.1.28.Final</version>
             <scope>test</scope>
         </dependency>
+        <!-- log4j2 -->
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>2.0</version>
+            <scope>test</scope>
+        </dependency>
 
     </dependencies>
 

--- a/agent-it/src/test/java/com/navercorp/pinpoint/plugin/log4j2/Log4j2IT.java
+++ b/agent-it/src/test/java/com/navercorp/pinpoint/plugin/log4j2/Log4j2IT.java
@@ -30,7 +30,7 @@ import org.junit.runner.RunWith;
 @RunWith(PinpointPluginTestSuite.class)
 @PinpointAgent(AgentPath.PATH)
 @PinpointConfig("pinpoint-spring-bean-test.config")
-@Dependency({"org.apache.logging.log4j:log4j-core:[2.0][2.1][2.2][2.3][2.4]"})
+@Dependency({"org.apache.logging.log4j:log4j-core:[2.0,2.11]"})
 public class Log4j2IT {
 
     @Test

--- a/agent-it/src/test/java/com/navercorp/pinpoint/plugin/log4j2/Log4j2IT.java
+++ b/agent-it/src/test/java/com/navercorp/pinpoint/plugin/log4j2/Log4j2IT.java
@@ -30,7 +30,7 @@ import org.junit.runner.RunWith;
 @RunWith(PinpointPluginTestSuite.class)
 @PinpointAgent(AgentPath.PATH)
 @PinpointConfig("pinpoint-spring-bean-test.config")
-@Dependency({"org.apache.logging.log4j:log4j-core:[2.0,2.11]"})
+@Dependency({"org.apache.logging.log4j:log4j-core:[2.0,)"})
 public class Log4j2IT {
 
     @Test

--- a/agent-it/src/test/java/com/navercorp/pinpoint/plugin/log4j2/Log4j2IT.java
+++ b/agent-it/src/test/java/com/navercorp/pinpoint/plugin/log4j2/Log4j2IT.java
@@ -20,25 +20,25 @@ import com.navercorp.pinpoint.test.plugin.Dependency;
 import com.navercorp.pinpoint.test.plugin.PinpointAgent;
 import com.navercorp.pinpoint.test.plugin.PinpointConfig;
 import com.navercorp.pinpoint.test.plugin.PinpointPluginTestSuite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.slf4j.MDC;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.ThreadContext;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 @RunWith(PinpointPluginTestSuite.class)
 @PinpointAgent(AgentPath.PATH)
-@Dependency({"org.apache.logging.log4j:log4j-core:[2.0,)"})
 @PinpointConfig("pinpoint-spring-bean-test.config")
+@Dependency({"org.apache.logging.log4j:log4j-core:[2.0][2.1][2.2][2.3][2.4]"})
 public class Log4j2IT {
 
     @Test
     public void test() {
-        Logger logger = LoggerFactory.getLogger(getClass());
-        logger.error("log4j2");
+        Logger logger = LogManager.getLogger();
+        logger.error("for log4j2 plugin test");
 
-        Assert.assertNotNull(MDC.get("PtxId"));
-        Assert.assertNotNull(MDC.get("PspanId"));
+        Assert.assertNotNull(ThreadContext.get("PtxId"));
+        Assert.assertNotNull(ThreadContext.get("PspanId"));
     }
 }

--- a/agent-it/src/test/java/com/navercorp/pinpoint/plugin/log4j2/Log4j2IT.java
+++ b/agent-it/src/test/java/com/navercorp/pinpoint/plugin/log4j2/Log4j2IT.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2018 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.plugin.log4j2;
+
+import com.navercorp.pinpoint.plugin.AgentPath;
+import com.navercorp.pinpoint.test.plugin.Dependency;
+import com.navercorp.pinpoint.test.plugin.PinpointAgent;
+import com.navercorp.pinpoint.test.plugin.PinpointConfig;
+import com.navercorp.pinpoint.test.plugin.PinpointPluginTestSuite;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(PinpointPluginTestSuite.class)
+@PinpointAgent(AgentPath.PATH)
+@Dependency({"org.apache.logging.log4j:log4j-core:[2.0,)"})
+@PinpointConfig("pinpoint-spring-bean-test.config")
+public class Log4j2IT {
+
+    @Test
+    public void test() {
+        Logger logger = LoggerFactory.getLogger(getClass());
+        logger.error("log4j2");
+
+        Assert.assertNotNull(MDC.get("PtxId"));
+        Assert.assertNotNull(MDC.get("PspanId"));
+    }
+}

--- a/agent-it/src/test/resources/pinpoint-grpc-plugin-test.config
+++ b/agent-it/src/test/resources/pinpoint-grpc-plugin-test.config
@@ -345,6 +345,11 @@ profiler.spring.beans.mark.error=false
 profiler.log4j.logging.transactioninfo=false
 
 ###########################################################
+# log4j2
+###########################################################
+profiler.log4j2.logging.transactioninfo=false
+
+###########################################################
 # logback
 ###########################################################
 profiler.logback.logging.transactioninfo=false

--- a/agent-it/src/test/resources/pinpoint-spring-bean-test.config
+++ b/agent-it/src/test/resources/pinpoint-spring-bean-test.config
@@ -348,6 +348,11 @@ profiler.spring.beans.mark.error=false
 profiler.log4j.logging.transactioninfo=true
 
 ###########################################################
+# log4j2
+###########################################################
+profiler.log4j2.logging.transactioninfo=true
+
+###########################################################
 # logback
 ###########################################################
 profiler.logback.logging.transactioninfo=true

--- a/agent-it/src/test/resources/pinpoint-spring-bean-test.config
+++ b/agent-it/src/test/resources/pinpoint-spring-bean-test.config
@@ -351,6 +351,7 @@ profiler.log4j.logging.transactioninfo=true
 # log4j2
 ###########################################################
 profiler.log4j2.logging.transactioninfo=true
+profiler.log4j2.logging.extended.logger.implementation=org.apache.logging.log4j.core.Logger,org.apache.logging.log4j.simple.SimpleLogger
 
 ###########################################################
 # logback

--- a/agent/src/main/resources-local/pinpoint.config
+++ b/agent/src/main/resources-local/pinpoint.config
@@ -775,6 +775,12 @@ profiler.spring.async.executor.class.names=
 ###########################################################
 profiler.log4j.logging.transactioninfo=false
 
+
+###########################################################
+# log4j2 (guide url : https://github.com/naver/pinpoint/blob/master/doc/per-request_feature_guide.md)
+###########################################################
+profiler.log4j2.logging.transactioninfo=false
+
 ###########################################################
 # logback (guide url : https://github.com/naver/pinpoint/blob/master/doc/per-request_feature_guide.md)
 ###########################################################

--- a/agent/src/main/resources-release/pinpoint.config
+++ b/agent/src/main/resources-release/pinpoint.config
@@ -767,6 +767,11 @@ profiler.spring.async.executor.class.names=
 profiler.log4j.logging.transactioninfo=false
 
 ###########################################################
+# log4j2 (guide url : https://github.com/naver/pinpoint/blob/master/doc/per-request_feature_guide.md)
+###########################################################
+profiler.log4j2.logging.transactioninfo=false
+
+###########################################################
 # logback (guide url : https://github.com/naver/pinpoint/blob/master/doc/per-request_feature_guide.md)
 ###########################################################
 profiler.logback.logging.transactioninfo=false

--- a/plugins/log4j2/pom.xml
+++ b/plugins/log4j2/pom.xml
@@ -5,7 +5,7 @@
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint</artifactId>
         <relativePath>../..</relativePath>
-        <version>1.8.4</version>
+        <version>1.8.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>pinpoint-log4j2-plugin</artifactId>

--- a/plugins/log4j2/pom.xml
+++ b/plugins/log4j2/pom.xml
@@ -1,0 +1,34 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.navercorp.pinpoint</groupId>
+        <artifactId>pinpoint</artifactId>
+        <relativePath>../..</relativePath>
+        <version>1.8.4</version>
+    </parent>
+
+    <artifactId>pinpoint-log4j2-plugin</artifactId>
+    <name>pinpoint-log4j2-plugin</name>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.navercorp.pinpoint</groupId>
+            <artifactId>pinpoint-bootstrap-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>2.0</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/plugins/log4j2/src/main/java/com/navercorp/pinpoint/plugin/log4j2/Log4j2Config.java
+++ b/plugins/log4j2/src/main/java/com/navercorp/pinpoint/plugin/log4j2/Log4j2Config.java
@@ -10,30 +10,30 @@ public class Log4j2Config {
 
     static final String LOG4J2_LOGGING_TRANSACTION_INFO = "profiler.log4j2.logging.transactioninfo";
 
-    private static final String ASYNC_LOGGER_TRANSFORM_CLASS = "profiler.log4j2.async.logging.transform.class";
+    private static final String EXTENDED_LOGGER_IMPLEMENTATION_CLASS = "profiler.log4j2.logging.extended.logger.implementation";
 
     private final boolean log4j2LoggingTransactionInfo;
 
-    private final String asyncLoggerTransformClass;
+    private final String extendedLoggerImplementationClass;
 
     Log4j2Config(ProfilerConfig config) {
         this.log4j2LoggingTransactionInfo = config.readBoolean(LOG4J2_LOGGING_TRANSACTION_INFO, false);
-        this.asyncLoggerTransformClass = config.readString(ASYNC_LOGGER_TRANSFORM_CLASS, "org.apache.logging.log4j.core.async.AsyncLogger");
+        this.extendedLoggerImplementationClass = config.readString(EXTENDED_LOGGER_IMPLEMENTATION_CLASS, "org.apache.logging.log4j.core.Logger");
     }
 
     boolean isLog4j2LoggingTransactionInfo() {
         return log4j2LoggingTransactionInfo;
     }
 
-    String getAsyncLoggerTransformClass() {
-        return asyncLoggerTransformClass;
+    String getExtendedLoggerImplementationClass() {
+        return extendedLoggerImplementationClass;
     }
 
     @Override
     public String toString() {
         return "Log4j2Config{" +
                 "log4j2LoggingTransactionInfo=" + log4j2LoggingTransactionInfo +
-                ", asyncLoggerTransformClass='" + asyncLoggerTransformClass + '\'' +
+                ", extendedLoggerImplementationClass='" + extendedLoggerImplementationClass + '\'' +
                 '}';
     }
 }

--- a/plugins/log4j2/src/main/java/com/navercorp/pinpoint/plugin/log4j2/Log4j2Config.java
+++ b/plugins/log4j2/src/main/java/com/navercorp/pinpoint/plugin/log4j2/Log4j2Config.java
@@ -1,0 +1,28 @@
+package com.navercorp.pinpoint.plugin.log4j2;
+
+import com.navercorp.pinpoint.bootstrap.config.ProfilerConfig;
+
+/**
+ * @author licoco
+ * @author King Jin
+ */
+public class Log4j2Config {
+
+    static final String LOG4J2_LOGGING_TRANSACTION_INFO = "profiler.log4j2.logging.transactioninfo";
+
+    private final boolean log4j2LoggingTransactionInfo;
+
+    Log4j2Config(ProfilerConfig config) {
+        this.log4j2LoggingTransactionInfo = config.readBoolean(LOG4J2_LOGGING_TRANSACTION_INFO, false);
+    }
+
+    boolean isLog4j2LoggingTransactionInfo() {
+        return log4j2LoggingTransactionInfo;
+    }
+
+    @Override
+    public String toString() {
+        return "Log4jConfig [ log4j2LoggingTransactionInfo=" + log4j2LoggingTransactionInfo + "]";
+    }
+
+}

--- a/plugins/log4j2/src/main/java/com/navercorp/pinpoint/plugin/log4j2/Log4j2Config.java
+++ b/plugins/log4j2/src/main/java/com/navercorp/pinpoint/plugin/log4j2/Log4j2Config.java
@@ -10,19 +10,30 @@ public class Log4j2Config {
 
     static final String LOG4J2_LOGGING_TRANSACTION_INFO = "profiler.log4j2.logging.transactioninfo";
 
+    private static final String ASYNC_LOGGER_TRANSFORM_CLASS = "profiler.log4j2.async.logging.transform.class";
+
     private final boolean log4j2LoggingTransactionInfo;
+
+    private final String asyncLoggerTransformClass;
 
     Log4j2Config(ProfilerConfig config) {
         this.log4j2LoggingTransactionInfo = config.readBoolean(LOG4J2_LOGGING_TRANSACTION_INFO, false);
+        this.asyncLoggerTransformClass = config.readString(ASYNC_LOGGER_TRANSFORM_CLASS, "org.apache.logging.log4j.core.async.AsyncLogger");
     }
 
     boolean isLog4j2LoggingTransactionInfo() {
         return log4j2LoggingTransactionInfo;
     }
 
-    @Override
-    public String toString() {
-        return "Log4jConfig [ log4j2LoggingTransactionInfo=" + log4j2LoggingTransactionInfo + "]";
+    String getAsyncLoggerTransformClass() {
+        return asyncLoggerTransformClass;
     }
 
+    @Override
+    public String toString() {
+        return "Log4j2Config{" +
+                "log4j2LoggingTransactionInfo=" + log4j2LoggingTransactionInfo +
+                ", asyncLoggerTransformClass='" + asyncLoggerTransformClass + '\'' +
+                '}';
+    }
 }

--- a/plugins/log4j2/src/main/java/com/navercorp/pinpoint/plugin/log4j2/Log4j2Plugin.java
+++ b/plugins/log4j2/src/main/java/com/navercorp/pinpoint/plugin/log4j2/Log4j2Plugin.java
@@ -26,11 +26,13 @@ public class Log4j2Plugin implements ProfilerPlugin, TransformTemplateAware {
 
     private TransformTemplate transformTemplate;
 
+    private Log4j2Config config;
+
 
     @Override
     public void setup(ProfilerPluginSetupContext context) {
 
-        final Log4j2Config config = new Log4j2Config(context.getConfig());
+        config = new Log4j2Config(context.getConfig());
         if (logger.isInfoEnabled()) {
             logger.info("Log4j2Plugin config:{}", config);
         }
@@ -112,7 +114,10 @@ public class Log4j2Plugin implements ProfilerPlugin, TransformTemplateAware {
     }
 
     private void transformAsyncLogger() {
-        final String clazz = "org.apache.logging.log4j.core.async.AsyncLogger";
+        final String clazz = config.getAsyncLoggerTransformClass();
+        if (clazz == null || clazz.isEmpty()) {
+            return;
+        }
         transformTemplate.transform(clazz, new TransformCallback() {
 
             @Override

--- a/plugins/log4j2/src/main/java/com/navercorp/pinpoint/plugin/log4j2/Log4j2Plugin.java
+++ b/plugins/log4j2/src/main/java/com/navercorp/pinpoint/plugin/log4j2/Log4j2Plugin.java
@@ -1,0 +1,134 @@
+package com.navercorp.pinpoint.plugin.log4j2;
+
+import com.navercorp.pinpoint.bootstrap.instrument.InstrumentClass;
+import com.navercorp.pinpoint.bootstrap.instrument.InstrumentException;
+import com.navercorp.pinpoint.bootstrap.instrument.InstrumentMethod;
+import com.navercorp.pinpoint.bootstrap.instrument.Instrumentor;
+import com.navercorp.pinpoint.bootstrap.instrument.transformer.TransformCallback;
+import com.navercorp.pinpoint.bootstrap.instrument.transformer.TransformTemplate;
+import com.navercorp.pinpoint.bootstrap.instrument.transformer.TransformTemplateAware;
+import com.navercorp.pinpoint.bootstrap.logging.PLogger;
+import com.navercorp.pinpoint.bootstrap.logging.PLoggerFactory;
+import com.navercorp.pinpoint.bootstrap.plugin.ProfilerPlugin;
+import com.navercorp.pinpoint.bootstrap.plugin.ProfilerPluginSetupContext;
+import com.navercorp.pinpoint.bootstrap.plugin.util.InstrumentUtils;
+import com.navercorp.pinpoint.plugin.log4j2.interceptor.LoggingEventOfLog4j2Interceptor;
+
+import java.security.ProtectionDomain;
+
+/**
+ * @author licoco
+ * @author King Jin
+ */
+public class Log4j2Plugin implements ProfilerPlugin, TransformTemplateAware {
+
+    private final PLogger logger = PLoggerFactory.getLogger(getClass());
+
+    private TransformTemplate transformTemplate;
+
+
+    @Override
+    public void setup(ProfilerPluginSetupContext context) {
+
+        final Log4j2Config config = new Log4j2Config(context.getConfig());
+        if (logger.isInfoEnabled()) {
+            logger.info("Log4j2Plugin config:{}", config);
+        }
+        if (!config.isLog4j2LoggingTransactionInfo()) {
+            logger.info("Log4j2 plugin is not executed because log4j2 transform enable config value is false.");
+            return;
+        }
+
+        transformLogEvent();
+    }
+
+    private void transformLogEvent() {
+        transformTemplate.transform("org.apache.logging.log4j.core.impl.Log4jLogEvent", new TransformCallback() {
+
+            @Override
+            public byte[] doInTransform(Instrumentor instrumentor, ClassLoader loader, String className, Class<?>
+                    classBeingRedefined, ProtectionDomain protectionDomain, byte[] classfileBuffer) throws InstrumentException {
+
+                InstrumentClass mdcClass = instrumentor.getInstrumentClass(loader, "org.apache.logging.log4j.ThreadContext", null);
+                if (mdcClass == null) {
+                    logger.warn("Can not modify. Because org.apache.logging.log4j.ThreadContext does not exist.");
+                    return null;
+                }
+                if (!mdcClass.hasMethod("put", "java.lang.String", "java.lang.String")) {
+                    logger.warn("Can not modify. Because put method does not exist at org.apache.logging.log4j.ThreadContext class.");
+                    return null;
+                }
+                if (!mdcClass.hasMethod("remove", "java.lang.String")) {
+                    logger.warn("Can not modify. Because remove method does not exist at org.apache.logging.log4j.ThreadContext class.");
+                    return null;
+                }
+
+
+                InstrumentClass target = instrumentor.getInstrumentClass(loader, className, classfileBuffer);
+                final String interceptorClassName = LoggingEventOfLog4j2Interceptor.class.getName();
+
+                addInterceptor(target, new String[0], interceptorClassName);
+                addInterceptor(target, new String[]{"long"}, interceptorClassName);
+                addInterceptor(target, new String[]{"java.lang.String", "org.apache.logging.log4j.Marker", "java.lang.String", "org.apache.logging.log4j.Level", "org.apache.logging.log4j.message.Message",
+                        "java.lang.Throwable"}, interceptorClassName);
+                addInterceptor(target, new String[]{"java.lang.String", "org.apache.logging.log4j.Marker", "java.lang.String", "org.apache.logging.log4j.Level", "org.apache.logging.log4j.message.Message",
+                        "java.util.List", "java.lang.Throwable"}, interceptorClassName);
+                addInterceptor(target, new String[]{"java.lang.String", "org.apache.logging.log4j.Marker", "java.lang.String", "org.apache.logging.log4j.Level", "org.apache.logging.log4j.message.Message",
+                        "java.lang.Throwable", "java.util.Map", "org.apache.logging.log4j.ThreadContext$ContextStack", "java.lang.String", "java.lang.StackTraceElement", "long"}, interceptorClassName);
+
+                int majorVersion = 0;
+                int minorVersion = 0;
+                int patchVersion = 0;
+                boolean gotCheckError = false;
+                try {
+                    String versionCheckClass = "org.apache.logging.log4j.core.LogEvent";
+                    Class<?> transformClazz = Class.forName(versionCheckClass, false, loader);
+                    String implementationVersion = transformClazz.getPackage().getImplementationVersion();
+                    String[] versionsString = implementationVersion.split("\\.");
+                    majorVersion = Integer.parseInt(versionsString[0]);
+                    minorVersion = Integer.parseInt(versionsString[1]);
+                    final int maxVersionLength = 3;
+                    patchVersion = versionsString.length >= maxVersionLength ? Integer.parseInt(versionsString[2]) : 0;
+                } catch (ClassNotFoundException e) {
+                    gotCheckError = true;
+                } catch (NumberFormatException e) {
+                    gotCheckError = true;
+                }
+
+                final int majorVersionConstraint = 2;
+                if (majorVersion != majorVersionConstraint) {
+                    gotCheckError = true;
+                }
+                if (gotCheckError) {
+                    return target.toBytecode();
+                }
+                /*
+                  for log4j2 >=2.12.1 Constructor
+                 */
+                int minorVersionCheck = 12;
+                int patchVersionCheck = 1;
+                boolean extraConstructor = (minorVersion == minorVersionCheck && patchVersion >= patchVersionCheck) || (minorVersion > minorVersionCheck);
+                if (extraConstructor) {
+                    addInterceptor(target, new String[]{"java.lang.String", "org.apache.logging.log4j.Marker", "java.lang.String",
+                            "java.lang.StackTraceElement", "org.apache.logging.log4j.Level", "org.apache.logging.log4j.message.Message", "java.util.List", "java.lang.Throwable"}, interceptorClassName);
+                }
+
+                return target.toBytecode();
+            }
+
+            private void addInterceptor(InstrumentClass target, String[] parameterTypes, String interceptorClassName) throws InstrumentException {
+                InstrumentMethod constructor = InstrumentUtils.findConstructor(target, parameterTypes);
+                if (constructor != null) {
+                    constructor.addInterceptor(interceptorClassName);
+                }
+            }
+
+        });
+    }
+
+    @Override
+    public void setTransformTemplate(TransformTemplate transformTemplate) {
+        this.transformTemplate = transformTemplate;
+    }
+
+}

--- a/plugins/log4j2/src/main/java/com/navercorp/pinpoint/plugin/log4j2/interceptor/LoggingEventOfLog4j2Interceptor.java
+++ b/plugins/log4j2/src/main/java/com/navercorp/pinpoint/plugin/log4j2/interceptor/LoggingEventOfLog4j2Interceptor.java
@@ -1,0 +1,40 @@
+package com.navercorp.pinpoint.plugin.log4j2.interceptor;
+
+import com.navercorp.pinpoint.bootstrap.context.Trace;
+import com.navercorp.pinpoint.bootstrap.context.TraceContext;
+import com.navercorp.pinpoint.bootstrap.interceptor.AroundInterceptor0;
+import org.apache.logging.log4j.ThreadContext;
+
+/**
+ * @author licoco
+ * @author King Jin
+ */
+public class LoggingEventOfLog4j2Interceptor implements AroundInterceptor0 {
+
+    public static final String TRANSACTION_ID = "PtxId";
+
+    private static final String SPAN_ID = "PspanId";
+
+    private final TraceContext traceContext;
+
+    public LoggingEventOfLog4j2Interceptor(TraceContext traceContext) {
+        this.traceContext = traceContext;
+    }
+
+    @Override
+    public void before(Object target) {
+        Trace trace = traceContext.currentTraceObject();
+        if (trace == null) {
+            ThreadContext.remove(TRANSACTION_ID);
+            ThreadContext.remove(SPAN_ID);
+        } else {
+            ThreadContext.put(TRANSACTION_ID, trace.getTraceId().getTransactionId());
+            ThreadContext.put(SPAN_ID, String.valueOf(trace.getTraceId().getSpanId()));
+        }
+    }
+
+    @Override
+    public void after(Object target, Object result, Throwable throwable) {
+
+    }
+}

--- a/plugins/log4j2/src/main/resources/META-INF/services/com.navercorp.pinpoint.bootstrap.plugin.ProfilerPlugin
+++ b/plugins/log4j2/src/main/resources/META-INF/services/com.navercorp.pinpoint.bootstrap.plugin.ProfilerPlugin
@@ -1,0 +1,1 @@
+com.navercorp.pinpoint.plugin.log4j2.Log4j2Plugin

--- a/plugins/log4j2/src/test/java/com/navercorp/pinpoint/plugin/log4j2/Log4j2PluginTest.java
+++ b/plugins/log4j2/src/test/java/com/navercorp/pinpoint/plugin/log4j2/Log4j2PluginTest.java
@@ -1,0 +1,104 @@
+package com.navercorp.pinpoint.plugin.log4j2;
+
+import com.navercorp.pinpoint.bootstrap.config.DefaultProfilerConfig;
+import com.navercorp.pinpoint.bootstrap.config.ProfilerConfig;
+import com.navercorp.pinpoint.bootstrap.context.Trace;
+import com.navercorp.pinpoint.bootstrap.context.TraceContext;
+import com.navercorp.pinpoint.bootstrap.context.TraceId;
+import com.navercorp.pinpoint.bootstrap.instrument.InstrumentContext;
+import com.navercorp.pinpoint.bootstrap.instrument.transformer.TransformTemplate;
+import com.navercorp.pinpoint.bootstrap.plugin.ProfilerPluginSetupContext;
+import com.navercorp.pinpoint.common.util.StringUtils;
+import com.navercorp.pinpoint.plugin.log4j2.interceptor.LoggingEventOfLog4j2Interceptor;
+
+import org.apache.logging.log4j.ThreadContext;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author licoco
+ * @author King Jin
+ */
+public class Log4j2PluginTest {
+
+    private Log4j2Plugin plugin = new Log4j2Plugin();
+
+    @Test
+    public void setTransformTemplate() {
+        InstrumentContext instrumentContext = mock(InstrumentContext.class);
+        plugin.setTransformTemplate(new TransformTemplate(instrumentContext));
+    }
+
+    @Test
+    public void testLoggingEventOfLog4j2Interceptor() {
+        TraceContext traceContext = mock(TraceContext.class);
+        LoggingEventOfLog4j2Interceptor interceptor = new LoggingEventOfLog4j2Interceptor(traceContext);
+        interceptor.before(null);
+        interceptor.after(null, null, null);
+        Assert.assertNull(ThreadContext.get(LoggingEventOfLog4j2Interceptor.TRANSACTION_ID));
+    }
+
+    @Test
+    public void testLoggingEventOfLog4j2Interceptor2() {
+        TraceContext traceContext = spy(TraceContext.class);
+        Trace trace = mock(Trace.class);
+        TraceId traceId = spy(TraceId.class);
+        String txId = "api_gw01^1565160016090^9878229";
+        when(traceContext.currentTraceObject()).thenReturn(trace);
+        when(traceContext.currentRawTraceObject()).thenReturn(trace);
+        when(traceContext.currentRawTraceObject().getTraceId()).thenReturn(traceId);
+        when(traceContext.currentRawTraceObject().getTraceId().getTransactionId()).thenReturn(txId);
+        when(traceContext.currentRawTraceObject().getTraceId().getSpanId()).thenReturn(9878229L);
+
+        LoggingEventOfLog4j2Interceptor interceptor = spy(new LoggingEventOfLog4j2Interceptor(traceContext));
+        interceptor.before(null);
+        interceptor.after(null, null, null);
+        Assert.assertEquals(txId, ThreadContext.get(LoggingEventOfLog4j2Interceptor.TRANSACTION_ID));
+    }
+
+    @Test
+    public void testLog4j2Config() {
+        ProfilerConfig profilerConfig = mock(ProfilerConfig.class);
+        Log4j2Config log4j2Config = new Log4j2Config(profilerConfig);
+        Assert.assertTrue(!StringUtils.isEmpty(log4j2Config.toString()));
+        Assert.assertTrue(!log4j2Config.isLog4j2LoggingTransactionInfo());
+    }
+
+    @Test
+    public void testSetup() {
+
+        ProfilerPluginSetupContext profilerPluginSetupContext = spy(ProfilerPluginSetupContext.class);
+        DefaultProfilerConfig profilerConfig = spy(new DefaultProfilerConfig());
+        when(profilerPluginSetupContext.getConfig()).thenReturn(profilerConfig);
+        when(profilerConfig.readBoolean(Log4j2Config.LOG4J2_LOGGING_TRANSACTION_INFO, false)).thenReturn(true);
+
+        Log4j2Config log4j2Config = spy(new Log4j2Config(profilerConfig));
+        when(log4j2Config.isLog4j2LoggingTransactionInfo()).thenReturn(true);
+
+        InstrumentContext instrumentContext = mock(InstrumentContext.class);
+        plugin.setTransformTemplate(new TransformTemplate(instrumentContext));
+        plugin.setup(profilerPluginSetupContext);
+    }
+
+
+    @Test
+    public void testSetup2() {
+
+        ProfilerPluginSetupContext profilerPluginSetupContext = spy(ProfilerPluginSetupContext.class);
+        DefaultProfilerConfig profilerConfig = spy(new DefaultProfilerConfig());
+        when(profilerPluginSetupContext.getConfig()).thenReturn(profilerConfig);
+        when(profilerConfig.readBoolean(Log4j2Config.LOG4J2_LOGGING_TRANSACTION_INFO, false)).thenReturn(false);
+
+        Log4j2Config log4j2Config = spy(new Log4j2Config(profilerConfig));
+        when(log4j2Config.isLog4j2LoggingTransactionInfo()).thenReturn(true);
+
+        InstrumentContext instrumentContext = mock(InstrumentContext.class);
+        plugin.setTransformTemplate(new TransformTemplate(instrumentContext));
+        plugin.setup(profilerPluginSetupContext);
+    }
+
+}

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -65,6 +65,7 @@
         <module>mybatis</module>
         <module>okhttp</module>
         <module>log4j</module>
+        <module>log4j2</module>
         <module>logback</module>
         <module>dubbo</module>
         <module>cassandra</module>
@@ -265,6 +266,11 @@
         <dependency>
             <groupId>com.navercorp.pinpoint</groupId>
             <artifactId>pinpoint-log4j-plugin</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.navercorp.pinpoint</groupId>
+            <artifactId>pinpoint-log4j2-plugin</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>


### PR DESCRIPTION
Continuation work from https://github.com/naver/pinpoint/pull/5405.
1.1  all constructors are extracted via the script https://gist.github.com/yjqg6666/ded14b895a815e514d699920e3ca9076.
versions 2.0~2.12.1 are checked.
1.2. add a version test for new constructor(s).


