### PR TITLE
Fixes apache dubbo plugin sniffer version

### DIFF
--- a/plugins/apache-dubbo/pom.xml
+++ b/plugins/apache-dubbo/pom.xml
@@ -14,7 +14,7 @@
     <properties>
         <jdk.version>1.6</jdk.version>
         <jdk.home>${env.JAVA_8_HOME}</jdk.home>
-        <sniffer.artifactid>java18</sniffer.artifactid>
+        <sniffer.artifactid>java16</sniffer.artifactid>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
Apache Dubbo 2.6.x can run on java 6 and 7, only Apache Dubbo 2.7+ requires java 8

related to #5697