### PR TITLE
integration support with external log system for pinpoint web 

### DIFF
--- a/doc/per-request_feature_guide.md
+++ b/doc/per-request_feature_guide.md
@@ -247,6 +247,22 @@ log.enable= true
 log.page.url=XXXX.pinpoint
 log.button.name= log
 ```
+The log page url would be /XXXX.pinpoint?transactionId=XXX&spanId=xxx&applicationName=xxx&time=xxx .
+If you want to integrate with external log system, you may add the following configuration and configure Nginx to relocate to the system url.
+```properties
+# enable log button regardless of the data.
+log.transaction.info.always.logged = true
+# open the log.page.url in a new page.
+log.page.new.window = true
+```
+
+```
+	location = /XXXX.pinpoint {
+	    # change the url as necessary
+		return 301 https://elk.example.com/query?app=$arg_applicationname&txId=$arg_transactionid&spanid=$arg_spanid&ts=$arg_time;
+	}
+```
+
 
 **step 3**
 Pinpoint 1.5.0 or later, we improve button to decided enable/disable depending on whether or not being logged.

--- a/web/src/main/java/com/navercorp/pinpoint/web/controller/BusinessTransactionController.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/controller/BusinessTransactionController.java
@@ -63,6 +63,12 @@ public class BusinessTransactionController {
     @Autowired
     private FilteredMapService filteredMapService;
 
+    @Value("#{pinpointWebProps['log.transaction.info.always.logged'] ?: false}")
+    private boolean logTransactionInfoAlwaysLogged;
+
+    @Value("#{pinpointWebProps['log.page.new.window'] ?: false}")
+    private boolean logPageNewWindow;
+
     @Value("#{pinpointWebProps['log.enable'] ?: false}")
     private boolean logLinkEnable;
 
@@ -107,7 +113,11 @@ public class BusinessTransactionController {
         ApplicationMap map = filteredMapService.selectApplicationMap(transactionId, viewVersion);
         RecordSet recordSet = this.transactionInfoService.createRecordSet(callTreeIterator, focusTimestamp, agentId, spanId);
 
-        TransactionInfoViewModel result = new TransactionInfoViewModel(transactionId, map.getNodes(), map.getLinks(), recordSet, spanResult.getTraceState(), logLinkEnable, logButtonName, logPageUrl, disableButtonMessage);
+        TransactionInfoViewModel result = new TransactionInfoViewModel(transactionId, spanId, map.getNodes(), map.getLinks(), recordSet, spanResult.getTraceState(), logLinkEnable, logButtonName, logPageUrl, disableButtonMessage, logPageNewWindow);
+        if (logTransactionInfoAlwaysLogged) {
+            recordSet.setLoggingTransactionInfo(true);
+        }
+
         return result;
     }
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/view/TransactionInfoViewModel.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/view/TransactionInfoViewModel.java
@@ -42,6 +42,7 @@ import org.apache.commons.lang3.StringUtils;
 public class TransactionInfoViewModel {
 
     private TransactionId transactionId;
+    private long spanId;
     private Collection<Node> nodes;
     private Collection<Link> links;
     private RecordSet recordSet;
@@ -50,9 +51,11 @@ public class TransactionInfoViewModel {
     private String logButtonName;
     private String logPageUrl;
     private String disableButtonMessage;
+    private boolean logPageNewWindow;
 
-    public TransactionInfoViewModel(TransactionId transactionId, Collection<Node> nodes, Collection<Link> links, RecordSet recordSet, TraceState.State state, boolean logLinkEnable, String logButtonName, String logPageUrl, String disableButtonMessage) {
+    public TransactionInfoViewModel(TransactionId transactionId, long spanId, Collection<Node> nodes, Collection<Link> links, RecordSet recordSet, TraceState.State state, boolean logLinkEnable, String logButtonName, String logPageUrl, String disableButtonMessage, boolean logPageNewWindow) {
         this.transactionId = transactionId;
+        this.spanId = spanId;
         this.nodes = nodes;
         this.links = links;
         this.recordSet = recordSet;
@@ -61,6 +64,7 @@ public class TransactionInfoViewModel {
         this.logButtonName = logButtonName;
         this.logPageUrl = logPageUrl;
         this.disableButtonMessage = disableButtonMessage;
+        this.logPageNewWindow = logPageNewWindow;
     }
 
     @JsonProperty("applicationName")
@@ -71,6 +75,16 @@ public class TransactionInfoViewModel {
     @JsonProperty("transactionId")
     public String getTransactionId() {
         return TransactionIdUtils.formatString(transactionId);
+    }
+
+    @JsonProperty("spanId")
+    public long getSpanId() {
+        return spanId;
+    }
+
+    @JsonProperty("logPageNewWindow")
+    public boolean isLogPageNewWindow() {
+        return logPageNewWindow;
     }
 
     @JsonProperty("agentId")
@@ -118,6 +132,8 @@ public class TransactionInfoViewModel {
         if (StringUtils.isNotEmpty(logPageUrl)) {
             StringBuilder sb = new StringBuilder();
             sb.append("transactionId=").append(getTransactionId());
+            sb.append("&spanId=").append(spanId);
+            sb.append("&applicationName=").append(getApplicationId());
             sb.append("&time=").append(recordSet.getStartTime());
             return logPageUrl + "?" + sb.toString();
         }

--- a/web/src/main/resources/pinpoint-web.properties
+++ b/web/src/main/resources/pinpoint-web.properties
@@ -26,7 +26,11 @@ admin.password=admin
 
 #log site link (guide url : https://github.com/naver/pinpoint/blob/master/doc/per-request_feature_guide.md)
 #log.enable=false
+# link url would be ${log.page.url}?transactionId=XXX&spanId=xxx&applicationName=xxx&time=xxx
 #log.page.url=
+#log.page.new.window=false
+#log.transaction.info.always.logged=true
+#log.button.disable.message=
 #log.button.name=
 
 # Configuration

--- a/web/src/main/webapp/pages/transactionDetail/transaction-detail.controller.js
+++ b/web/src/main/webapp/pages/transactionDetail/transaction-detail.controller.js
@@ -63,6 +63,7 @@
 	        function parseTransactionDetail(result) {
 	            $scope.transactionDetail = result;
 	            $scope.logLinkEnable = result.logLinkEnable || false;
+	            $scope.logPageNewWindow = result.logPageNewWindow || false;
 	            $scope.loggingTransactionInfo = result.loggingTransactionInfo || false;
 	            $scope.logButtonName = result.logButtonName || "";
 	            $scope.logPageUrl = result.logPageUrl || "";

--- a/web/src/main/webapp/pages/transactionDetail/transactionDetail.html
+++ b/web/src/main/webapp/pages/transactionDetail/transactionDetail.html
@@ -65,7 +65,8 @@
     <li><a href="#Timeline" data-toggle="tab">Timeline</a></li>
     <li><a href ng-click="openTransactionView($event);">Mixed View</a></li>
     <li ng-show="logLinkEnable">
-   		<a href ng-click="viewLog(logPageUrl)" style="{{loggingTransactionInfo ? '' : 'color:#BBBABA'}};curspr: pointer;">{{logButtonName}}</a>
+        <a ng-if="logPageNewWindow" href="{{logPageUrl}}" target="_blank">{{logButtonName}}</a>
+   		<a ng-if="!logPageNewWindow" href ng-click="viewLog(logPageUrl)" style="{{loggingTransactionInfo ? '' : 'color:#BBBABA'}};curspr: pointer;">{{logButtonName}}</a>
     </li>
 	<li style="padding-left:10px;padding-top:1px;" class="_searchForm">
 		<select class="form-control" style="width:100px" ng-model="searchColumn" ng-change="selectSearchColumn()">

--- a/web/src/main/webapp/v2/src/app/shared/services/transaction-detail-data.service.ts
+++ b/web/src/main/webapp/v2/src/app/shared/services/transaction-detail-data.service.ts
@@ -9,6 +9,7 @@ export interface ITransactionDetailPartInfo {
     logPageUrl: string;
     logButtonName: string;
     logLinkEnable: boolean;
+    logPageNewWindow: boolean;
     disableButtonMessage: string;
     loggingTransactionInfo: boolean;
 }
@@ -37,6 +38,7 @@ export class TransactionDetailDataService {
                     this.partInfo.next({
                         logButtonName: transactionInfo.logButtonName,
                         logLinkEnable: transactionInfo.logLinkEnable,
+                        logPageNewWindow: transactionInfo.logPageNewWindow,
                         logPageUrl: transactionInfo.logPageUrl,
                         loggingTransactionInfo: transactionInfo.loggingTransactionInfo,
                         disableButtonMessage: transactionInfo.disableButtonMessage,


### PR DESCRIPTION
* expose applicationName & spanId to log.page.url
* add config log.transaction.info.always.logged config to enable log button regardless of the data.
* add config log.page.new.window to open the log.page.url in a new window.

Info:
The full URL of the log page would be ${log.page.url}?transactionId=XXX&spanId=xxx&applicationName=xxx&time=xxx. If your external log system, i.e. ELK use different query parameter, you could rewrite the url via nginx location.

> log.page.url=XXXX.pinpoint

```
	location = /XXXX.pinpoint {
		return 301 https://elk.example.com/query?app=$arg_applicationname&txId=$arg_transactionid&spanid=$arg_spanid&ts=$arg_time;
	}
```

