### PR TITLE
backport log4j2 plugin to 1.8.x

### DIFF
--- a/agent-it/pom.xml
+++ b/agent-it/pom.xml
@@ -403,6 +403,19 @@
             <version>4.1.28.Final</version>
             <scope>test</scope>
         </dependency>
+        <!-- log4j2 -->
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>2.0</version>
+            <scope>test</scope>
+        </dependency>
 
     </dependencies>
 

--- a/agent-it/src/test/java/com/navercorp/pinpoint/plugin/log4j2/Log4j2ForAsyncLoggerIT.java
+++ b/agent-it/src/test/java/com/navercorp/pinpoint/plugin/log4j2/Log4j2ForAsyncLoggerIT.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2018 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.plugin.log4j2;
+
+import com.navercorp.pinpoint.plugin.AgentPath;
+import com.navercorp.pinpoint.test.plugin.*;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.ThreadContext;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(PinpointPluginTestSuite.class)
+@PinpointAgent(AgentPath.PATH)
+@PinpointConfig("pinpoint-spring-bean-test.config")
+@JvmArgument("-Dlog4j2.contextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector")
+@JvmVersion(7)
+@Dependency({"org.apache.logging.log4j:log4j-core:[2.0,)", "com.lmax:disruptor:[3.4.2]"})
+public class Log4j2ForAsyncLoggerIT {
+
+    @Test
+    public void test() {
+        Logger logger = LogManager.getLogger();
+        logger.error("for log4j2 plugin async logger test");
+
+        Assert.assertNotNull(ThreadContext.get("PtxId"));
+        Assert.assertNotNull(ThreadContext.get("PspanId"));
+    }
+}

--- a/agent-it/src/test/java/com/navercorp/pinpoint/plugin/log4j2/Log4j2IT.java
+++ b/agent-it/src/test/java/com/navercorp/pinpoint/plugin/log4j2/Log4j2IT.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2018 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.plugin.log4j2;
+
+import com.navercorp.pinpoint.plugin.AgentPath;
+import com.navercorp.pinpoint.test.plugin.*;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.ThreadContext;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(PinpointPluginTestSuite.class)
+@PinpointAgent(AgentPath.PATH)
+@PinpointConfig("pinpoint-spring-bean-test.config")
+@JvmVersion(7)
+@Dependency({"org.apache.logging.log4j:log4j-core:[2.0,)"})
+public class Log4j2IT {
+
+    @Test
+    public void test() {
+        Logger logger = LogManager.getLogger();
+        logger.error("for log4j2 plugin test");
+
+        Assert.assertNotNull(ThreadContext.get("PtxId"));
+        Assert.assertNotNull(ThreadContext.get("PspanId"));
+    }
+}

--- a/agent-it/src/test/resources/pinpoint-grpc-plugin-test.config
+++ b/agent-it/src/test/resources/pinpoint-grpc-plugin-test.config
@@ -345,6 +345,11 @@ profiler.spring.beans.mark.error=false
 profiler.log4j.logging.transactioninfo=false
 
 ###########################################################
+# log4j2
+###########################################################
+profiler.log4j2.logging.transactioninfo=false
+
+###########################################################
 # logback
 ###########################################################
 profiler.logback.logging.transactioninfo=false

--- a/agent-it/src/test/resources/pinpoint-spring-bean-test.config
+++ b/agent-it/src/test/resources/pinpoint-spring-bean-test.config
@@ -348,6 +348,11 @@ profiler.spring.beans.mark.error=false
 profiler.log4j.logging.transactioninfo=true
 
 ###########################################################
+# log4j2
+###########################################################
+profiler.log4j2.logging.transactioninfo=true
+
+###########################################################
 # logback
 ###########################################################
 profiler.logback.logging.transactioninfo=true

--- a/agent/src/main/resources-local/pinpoint.config
+++ b/agent/src/main/resources-local/pinpoint.config
@@ -776,6 +776,11 @@ profiler.spring.async.executor.class.names=
 profiler.log4j.logging.transactioninfo=false
 
 ###########################################################
+# log4j2 (guide url : https://github.com/naver/pinpoint/blob/master/doc/per-request_feature_guide.md)
+###########################################################
+profiler.log4j2.logging.transactioninfo=false
+
+###########################################################
 # logback (guide url : https://github.com/naver/pinpoint/blob/master/doc/per-request_feature_guide.md)
 ###########################################################
 profiler.logback.logging.transactioninfo=false

--- a/agent/src/main/resources-release/pinpoint.config
+++ b/agent/src/main/resources-release/pinpoint.config
@@ -767,6 +767,11 @@ profiler.spring.async.executor.class.names=
 profiler.log4j.logging.transactioninfo=false
 
 ###########################################################
+# log4j2 (guide url : https://github.com/naver/pinpoint/blob/master/doc/per-request_feature_guide.md)
+###########################################################
+profiler.log4j2.logging.transactioninfo=false
+
+###########################################################
 # logback (guide url : https://github.com/naver/pinpoint/blob/master/doc/per-request_feature_guide.md)
 ###########################################################
 profiler.logback.logging.transactioninfo=false

--- a/doc/per-request_feature_guide.md
+++ b/doc/per-request_feature_guide.md
@@ -130,27 +130,26 @@ ex) pinpoint.config when using log4j
 # log4j
 ###########################################################
 profiler.log4j.logging.transactioninfo=true
+```
 
+ex) pinpoint.config when using log4j2
+```
 ###########################################################
-# logback
+# log4j2 
 ###########################################################
-profiler.logback.logging.transactioninfo=false
+profiler.log4j2.logging.transactioninfo=true
+
 ```
 
 ex) pinpoint.config when using logback
 ```
-###########################################################
-# log4j
-###########################################################
-profiler.log4j.logging.transactioninfo=false
-
 ###########################################################
 # logback
 ###########################################################
 profiler.logback.logging.transactioninfo=true
 ```
 
-**2-2 log4j, logback configuration**
+**2-2 log4j, log4j2, logback configuration**
 
 Change the log message format to print the transactionId, and spanId saved in MDC.
 
@@ -169,6 +168,23 @@ After
           <param name = "ConversionPattern" value= "%d{yyyy-MM-dd HH:mm:ss} [%-5p](%-30c{1}) [TxId : %X{PtxId} , SpanId : %X{PspanId}] %m%n" />
         </layout >
 </appender >
+```
+
+ex) log4j2 - log4j2.xml
+```xml
+Before
+<appender>
+     <console name="STDOUT" target="SYSTEM_OUT">
+          <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss} [%-5p](%-30c{1}) %m%n""/>
+     </console>
+<appender>
+
+After
+<appender>
+     <console name="STDOUT" target="SYSTEM_OUT">
+          <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss} [%-5p](%-30c{1}) [TxId : %X{PtxId} , SpanId : %X{PspanId}] %m%n""/>
+     </console>
+<appender>
 ```
 
 ex) logback : logback.xml
@@ -401,27 +417,26 @@ ex) Pinpoint.config  - log4j 를 사용할 경우
 # log4j
 ###########################################################
 profiler.log4j.logging.transactioninfo=true
+```
 
+ex) Pinpoint.config  - log4j2 를 사용할 경우
+```
 ###########################################################
-# logback
+# log4j2 
 ###########################################################
-profiler.logback.logging.transactioninfo=false
+profiler.log4j2.logging.transactioninfo=true
+
 ```
 
 ex) Pinpoint.config  - logback 를 사용할 경우
 ```
-###########################################################
-# log4j
-###########################################################
-profiler.log4j.logging.transactioninfo=false
-
 ###########################################################
 # logback
 ###########################################################
 profiler.logback.logging.transactioninfo=true
 ```
 
-**2-2 log4j, logback 설정 파일 설정**
+**2-2 log4j, log4j2, logback 설정 파일 설정**
 
 logging 설정 파일의 log message pattern 설정에 Pinpoint에서 MDC에 저장한 transactionId, spanId값이 출력될수 있도록 설정을 추가하자.
 
@@ -440,6 +455,23 @@ ex) log4j - log4j.xml
           <param name = "ConversionPattern" value= "%d{yyyy-MM-dd HH:mm:ss} [%-5p](%-30c{1}) [TxId : %X{PtxId} , SpanId : %X{PspanId}] %m%n" />
         </layout >
 </appender >
+```
+
+ex) log4j2 - log4j2.xml
+```xml
+변경 전
+<appender>
+     <console name="STDOUT" target="SYSTEM_OUT">
+          <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss} [%-5p](%-30c{1}) %m%n""/>
+     </console>
+<appender>
+
+변경 후
+<appender>
+     <console name="STDOUT" target="SYSTEM_OUT">
+          <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss} [%-5p](%-30c{1}) [TxId : %X{PtxId} , SpanId : %X{PspanId}] %m%n""/>
+     </console>
+<appender>
 ```
 
 ex) logback - logback.xml

--- a/plugins/log4j2/.gitignore
+++ b/plugins/log4j2/.gitignore
@@ -1,0 +1,5 @@
+/target/
+/.settings/
+/.classpath
+/.project
+/*.iml

--- a/plugins/log4j2/pom.xml
+++ b/plugins/log4j2/pom.xml
@@ -1,0 +1,28 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.navercorp.pinpoint</groupId>
+        <artifactId>pinpoint</artifactId>
+        <relativePath>../..</relativePath>
+        <version>1.8.5-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>pinpoint-log4j2-plugin</artifactId>
+    <name>pinpoint-log4j2-plugin</name>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.navercorp.pinpoint</groupId>
+            <artifactId>pinpoint-bootstrap-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.1</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/plugins/log4j2/src/main/java/com/navercorp/pinpoint/plugin/log4j2/Log4j2Config.java
+++ b/plugins/log4j2/src/main/java/com/navercorp/pinpoint/plugin/log4j2/Log4j2Config.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.plugin.log4j2;
+
+import com.navercorp.pinpoint.bootstrap.config.ProfilerConfig;
+
+/**
+ * @author https://github.com/licoco/pinpoint
+ */
+public class Log4j2Config {
+    public static final String LOG4J2_LOGGING_TRANSACTION_INFO = "profiler.log4j2.logging.transactioninfo";
+    public static final String REUSABLELOGEVENTFACTORY_SCOPE = "reusableLogEventFactoryScope";
+
+    private final boolean log4j2LoggingTransactionInfo;
+
+
+    public Log4j2Config(ProfilerConfig config) {
+        this.log4j2LoggingTransactionInfo = config.readBoolean(LOG4J2_LOGGING_TRANSACTION_INFO, false);
+    }
+
+    public boolean isLog4j2LoggingTransactionInfo() {
+        return log4j2LoggingTransactionInfo;
+    }
+
+    @Override
+    public String toString() {
+        return "Log4j2Config [ log4j2LoggingTransactionInfo=" + log4j2LoggingTransactionInfo + "]";
+    }
+
+}

--- a/plugins/log4j2/src/main/java/com/navercorp/pinpoint/plugin/log4j2/Log4j2Plugin.java
+++ b/plugins/log4j2/src/main/java/com/navercorp/pinpoint/plugin/log4j2/Log4j2Plugin.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2019 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.plugin.log4j2;
+
+import com.navercorp.pinpoint.bootstrap.instrument.InstrumentClass;
+import com.navercorp.pinpoint.bootstrap.instrument.InstrumentException;
+import com.navercorp.pinpoint.bootstrap.instrument.InstrumentMethod;
+import com.navercorp.pinpoint.bootstrap.instrument.Instrumentor;
+import com.navercorp.pinpoint.bootstrap.instrument.transformer.TransformCallback;
+import com.navercorp.pinpoint.bootstrap.instrument.transformer.TransformTemplate;
+import com.navercorp.pinpoint.bootstrap.instrument.transformer.TransformTemplateAware;
+import com.navercorp.pinpoint.bootstrap.interceptor.scope.ExecutionPolicy;
+import com.navercorp.pinpoint.bootstrap.logging.PLogger;
+import com.navercorp.pinpoint.bootstrap.logging.PLoggerFactory;
+import com.navercorp.pinpoint.bootstrap.plugin.ProfilerPlugin;
+import com.navercorp.pinpoint.bootstrap.plugin.ProfilerPluginSetupContext;
+import com.navercorp.pinpoint.plugin.log4j2.interceptor.LogEventFactoryInterceptor;
+
+import java.security.ProtectionDomain;
+
+/**
+ * @author https://github.com/licoco/pinpoint
+ */
+public class Log4j2Plugin implements ProfilerPlugin, TransformTemplateAware {
+
+    private final PLogger logger = PLoggerFactory.getLogger(getClass());
+
+    private static final String INTERCEPTOR_CLASS = "com.navercorp.pinpoint.plugin.log4j2.interceptor.LogEventFactoryInterceptor";
+
+    private TransformTemplate transformTemplate;
+
+    @Override
+    public void setup(ProfilerPluginSetupContext context) {
+        final Log4j2Config config = new Log4j2Config(context.getConfig());
+        if (logger.isInfoEnabled()) {
+            logger.info("Log4j2Plugin config:{}", config);
+        }
+
+        if (!config.isLog4j2LoggingTransactionInfo()) {
+            logger.info("Log4j2 plugin is not executed because log4j2 transform enable config value is false.");
+            return;
+        }
+
+        //for case : use SyncAppdender, use AsyncAppender, use Mixing Synchronous and Asynchronous Loggers
+        transformTemplate.transform("org.apache.logging.log4j.core.impl.DefaultLogEventFactory", new DefaultLogEventFactoryTransform());
+        transformTemplate.transform("org.apache.logging.log4j.core.impl.ReusableLogEventFactory", new ReusableLogEventFactoryTransform());
+
+        //for case : Making All Loggers Asynchronous
+        transformTemplate.transform("org.apache.logging.log4j.core.async.RingBufferLogEventTranslator", new RingBufferLogEventTranslatorTransform());
+
+    }
+
+    public static class DefaultLogEventFactoryTransform extends LogEventFactoryTransform {
+
+        @Override
+        public byte[] doInTransform(Instrumentor instrumentor, ClassLoader loader, String className, Class<?> classBeingRedefined, ProtectionDomain protectionDomain, byte[] classfileBuffer) throws InstrumentException {
+            if (!validateThreadContextMethod(instrumentor, loader)) {
+                return null;
+            }
+
+            InstrumentClass target = instrumentor.getInstrumentClass(loader, className, classfileBuffer);
+            addInterceptor(target,"createEvent", new String[]{"java.lang.String", "org.apache.logging.log4j.Marker", "java.lang.String", "org.apache.logging.log4j.Level", "org.apache.logging.log4j.message.Message", "java.util.List", "java.lang.Throwable"}, INTERCEPTOR_CLASS);
+            addInterceptor(target,"createEvent", new String[]{"java.lang.String", "org.apache.logging.log4j.Marker", "java.lang.String", "java.lang.StackTraceElement","org.apache.logging.log4j.Level", "org.apache.logging.log4j.message.Message", "java.util.List", "java.lang.Throwable"}, INTERCEPTOR_CLASS);
+            return target.toBytecode();
+        }
+
+        private void addInterceptor(InstrumentClass target, String methodName, String[] parameterTypes, String interceptorClassName) throws InstrumentException {
+            InstrumentMethod method = target.getDeclaredMethod(methodName, parameterTypes);
+            if (method != null) {
+                method.addInterceptor(interceptorClassName);
+            }
+        }
+    }
+
+    public static class ReusableLogEventFactoryTransform extends LogEventFactoryTransform {
+
+        @Override
+        public byte[] doInTransform(Instrumentor instrumentor, ClassLoader loader, String className, Class<?> classBeingRedefined, ProtectionDomain protectionDomain, byte[] classfileBuffer) throws InstrumentException {
+            if (!validateThreadContextMethod(instrumentor, loader)) {
+                return null;
+            }
+
+            InstrumentClass target = instrumentor.getInstrumentClass(loader, className, classfileBuffer);
+            addInterceptor(target, "createEvent", new String[]{"java.lang.String", "org.apache.logging.log4j.Marker", "java.lang.String", "org.apache.logging.log4j.Level", "org.apache.logging.log4j.message.Message", "java.util.List", "java.lang.Throwable"}, INTERCEPTOR_CLASS);
+            addInterceptor(target, "createEvent", new String[]{"java.lang.String", "org.apache.logging.log4j.Marker", "java.lang.String", "java.lang.StackTraceElement", "org.apache.logging.log4j.Level", "org.apache.logging.log4j.message.Message", "java.util.List", "java.lang.Throwable"}, INTERCEPTOR_CLASS);
+            return target.toBytecode();
+        }
+
+        private void addInterceptor(InstrumentClass target, String methodName, String[] parameterTypes, String interceptorClassName) throws InstrumentException {
+            InstrumentMethod method = target.getDeclaredMethod(methodName, parameterTypes);
+            if (method != null) {
+                method.addScopedInterceptor(interceptorClassName, Log4j2Config.REUSABLELOGEVENTFACTORY_SCOPE, ExecutionPolicy.BOUNDARY);
+            }
+        }
+    }
+
+    public static class RingBufferLogEventTranslatorTransform extends LogEventFactoryTransform {
+
+        @Override
+        public byte[] doInTransform(Instrumentor instrumentor, ClassLoader loader, String className, Class<?> classBeingRedefined, ProtectionDomain protectionDomain, byte[] classfileBuffer) throws InstrumentException {
+            if (!validateThreadContextMethod(instrumentor, loader)) {
+                return null;
+            }
+
+            InstrumentClass target = instrumentor.getInstrumentClass(loader, className, classfileBuffer);
+            addInterceptor(target, "translateTo", new String[]{"org.apache.logging.log4j.core.async.RingBufferLogEvent", "long"}, INTERCEPTOR_CLASS);
+            return target.toBytecode();
+        }
+
+        private void addInterceptor(InstrumentClass target, String methodName, String[] parameterTypes, String interceptorClassName) throws InstrumentException {
+            InstrumentMethod method = target.getDeclaredMethod(methodName, parameterTypes);
+            if (method != null) {
+                method.addInterceptor(interceptorClassName);
+            }
+        }
+    }
+
+    static abstract class LogEventFactoryTransform implements TransformCallback {
+
+        private final PLogger logger = PLoggerFactory.getLogger(this.getClass());
+
+        boolean validateThreadContextMethod(Instrumentor instrumentor, ClassLoader loader) {
+            InstrumentClass mdcClass = instrumentor.getInstrumentClass(loader, "org.apache.logging.log4j.ThreadContext", null);
+
+            if (mdcClass == null) {
+                logger.warn("Can not modify. Because org.apache.logging.log4j.ThreadContext does not exist.");
+                return false;
+            }
+
+            if (!mdcClass.hasMethod("put", "java.lang.String", "java.lang.String")) {
+                logger.warn("Can not modify. Because put method does not exist at org.apache.logging.log4j.ThreadContext class.");
+                return false;
+            }
+            if (!mdcClass.hasMethod("remove", "java.lang.String")) {
+                logger.warn("Can not modify. Because remove method does not exist at org.apache.logging.log4j.ThreadContext class.");
+                return false;
+            }
+
+            return true;
+        }
+    }
+
+    @Override
+    public void setTransformTemplate(TransformTemplate transformTemplate) {
+        this.transformTemplate = transformTemplate;
+    }
+}

--- a/plugins/log4j2/src/main/java/com/navercorp/pinpoint/plugin/log4j2/interceptor/LogEventFactoryInterceptor.java
+++ b/plugins/log4j2/src/main/java/com/navercorp/pinpoint/plugin/log4j2/interceptor/LogEventFactoryInterceptor.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2019 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.plugin.log4j2.interceptor;
+
+import com.navercorp.pinpoint.bootstrap.context.Trace;
+import com.navercorp.pinpoint.bootstrap.context.TraceContext;
+import com.navercorp.pinpoint.bootstrap.interceptor.AroundInterceptor0;
+import org.apache.logging.log4j.ThreadContext;
+
+/**
+ * @author minwoo.jung
+ * @author licoco
+ */
+public class LogEventFactoryInterceptor implements AroundInterceptor0 {
+
+    private static final String TRANSACTION_ID = "PtxId";
+    private static final String SPAN_ID = "PspanId";
+    private final TraceContext traceContext;
+
+    public LogEventFactoryInterceptor(TraceContext traceContext) {
+        this.traceContext = traceContext;
+    }
+
+    @Override
+    public void before(Object target) {
+        Trace trace = traceContext.currentTraceObject();
+
+        if (trace == null) {
+            ThreadContext.remove(TRANSACTION_ID);
+            ThreadContext.remove(SPAN_ID);
+            return;
+        } else {
+            ThreadContext.put(TRANSACTION_ID, trace.getTraceId().getTransactionId());
+            ThreadContext.put(SPAN_ID, String.valueOf(trace.getTraceId().getSpanId()));
+        }
+    }
+
+    @Override
+    public void after(Object target, Object result, Throwable throwable) {
+
+    }
+}

--- a/plugins/log4j2/src/main/resources/META-INF/services/com.navercorp.pinpoint.bootstrap.plugin.ProfilerPlugin
+++ b/plugins/log4j2/src/main/resources/META-INF/services/com.navercorp.pinpoint.bootstrap.plugin.ProfilerPlugin
@@ -1,0 +1,1 @@
+com.navercorp.pinpoint.plugin.log4j2.Log4j2Plugin

--- a/plugins/log4j2/src/test/java/com/navercorp/pinpoint/plugin/log4j2/Log4j2ConfigTest.java
+++ b/plugins/log4j2/src/test/java/com/navercorp/pinpoint/plugin/log4j2/Log4j2ConfigTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.plugin.log4j2;
+
+import com.navercorp.pinpoint.bootstrap.config.ProfilerConfig;
+import com.navercorp.pinpoint.common.util.StringUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+
+/**
+ * @author minwoo.jung
+ */
+public class Log4j2ConfigTest {
+
+    @Test
+    public void testLog4j2Config() {
+        ProfilerConfig profilerConfig = mock(ProfilerConfig.class);
+        Log4j2Config log4j2Config = new Log4j2Config(profilerConfig);
+        Assert.assertTrue(!StringUtils.isEmpty(log4j2Config.toString()));
+        Assert.assertTrue(!log4j2Config.isLog4j2LoggingTransactionInfo());
+    }
+
+}

--- a/plugins/log4j2/src/test/java/com/navercorp/pinpoint/plugin/log4j2/Log4j2PluginTest.java
+++ b/plugins/log4j2/src/test/java/com/navercorp/pinpoint/plugin/log4j2/Log4j2PluginTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2019 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.plugin.log4j2;
+
+import com.navercorp.pinpoint.bootstrap.config.DefaultProfilerConfig;
+import com.navercorp.pinpoint.bootstrap.instrument.InstrumentContext;
+import com.navercorp.pinpoint.bootstrap.instrument.transformer.TransformTemplate;
+import com.navercorp.pinpoint.bootstrap.plugin.ProfilerPluginSetupContext;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author https://github.com/licoco/pinpoint
+ */
+public class Log4j2PluginTest {
+
+
+    private static final String LOG4J2_LOGGING_TRANSACTION_INFO = "profiler.log4j2.logging.transactioninfo";
+
+    private Log4j2Plugin plugin = new Log4j2Plugin();
+
+    @Test
+    public void setTransformTemplate() {
+        InstrumentContext instrumentContext = mock(InstrumentContext.class);
+        plugin.setTransformTemplate(new TransformTemplate(instrumentContext));
+    }
+
+    @Test
+    public void testSetup() {
+        ProfilerPluginSetupContext profilerPluginSetupContext = spy(ProfilerPluginSetupContext.class);
+        DefaultProfilerConfig profilerConfig = spy(new DefaultProfilerConfig());
+        when(profilerPluginSetupContext.getConfig()).thenReturn(profilerConfig);
+        when(profilerConfig.readBoolean(LOG4J2_LOGGING_TRANSACTION_INFO, false)).thenReturn(true);
+        Log4j2Config log4j2Config = spy(new Log4j2Config(profilerConfig));
+        when(log4j2Config.isLog4j2LoggingTransactionInfo()).thenReturn(true);
+
+        InstrumentContext instrumentContext = mock(InstrumentContext.class);
+        plugin.setTransformTemplate(new TransformTemplate(instrumentContext));
+        plugin.setup(profilerPluginSetupContext);
+    }
+
+
+    @Test
+    public void testSetup2() {
+        ProfilerPluginSetupContext profilerPluginSetupContext = spy(ProfilerPluginSetupContext.class);
+        DefaultProfilerConfig profilerConfig = spy(new DefaultProfilerConfig());
+        when(profilerPluginSetupContext.getConfig()).thenReturn(profilerConfig);
+        when(profilerConfig.readBoolean(LOG4J2_LOGGING_TRANSACTION_INFO, false)).thenReturn(false);
+        Log4j2Config log4j2Config = spy(new Log4j2Config(profilerConfig));
+        when(log4j2Config.isLog4j2LoggingTransactionInfo()).thenReturn(true);
+
+        InstrumentContext instrumentContext = mock(InstrumentContext.class);
+        plugin.setTransformTemplate(new TransformTemplate(instrumentContext));
+        plugin.setup(profilerPluginSetupContext);
+    }
+
+}

--- a/plugins/log4j2/src/test/java/com/navercorp/pinpoint/plugin/log4j2/interceptor/LogEventFactoryInterceptorTest.java
+++ b/plugins/log4j2/src/test/java/com/navercorp/pinpoint/plugin/log4j2/interceptor/LogEventFactoryInterceptorTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2019 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.plugin.log4j2.interceptor;
+
+import com.navercorp.pinpoint.bootstrap.context.Trace;
+import com.navercorp.pinpoint.bootstrap.context.TraceContext;
+import com.navercorp.pinpoint.bootstrap.context.TraceId;
+import org.apache.logging.log4j.ThreadContext;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author minwoo.jung
+ */
+public class LogEventFactoryInterceptorTest {
+
+    private static final String TRANSACTION_ID = "PtxId";
+
+    @Test
+    public void interceptorTest() {
+        TraceContext traceContext = mock(TraceContext.class);
+        LogEventFactoryInterceptor interceptor = new LogEventFactoryInterceptor(traceContext);
+        interceptor.before(null);
+        interceptor.after(null, null, null);
+        Assert.assertNull(ThreadContext.get(TRANSACTION_ID));
+    }
+
+    @Test
+    public void interceptorTest2() {
+        TraceContext traceContext = spy(TraceContext.class);
+        Trace trace = mock(Trace.class);
+        TraceId traceId = spy(TraceId.class);
+        when(traceContext.currentTraceObject()).thenReturn(trace);
+        when(traceContext.currentRawTraceObject()).thenReturn(trace);
+        when(traceContext.currentRawTraceObject().getTraceId()).thenReturn(traceId);
+        when(traceContext.currentRawTraceObject().getTraceId().getTransactionId()).thenReturn("aaa");
+        when(traceContext.currentRawTraceObject().getTraceId().getSpanId()).thenReturn(112343l);
+        LogEventFactoryInterceptor interceptor = spy(new LogEventFactoryInterceptor(traceContext));
+        interceptor.before(null);
+        interceptor.after(null, null, null);
+        Assert.assertNotNull(ThreadContext.get(TRANSACTION_ID));
+    }
+}

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -87,6 +87,7 @@
         <module>fastjson</module>
         <module>druid</module>
         <module>hbase</module>
+        <module>log4j2</module>
         <module>openwhisk</module>
         <module>node-js</module>
     </modules>
@@ -265,6 +266,11 @@
         <dependency>
             <groupId>com.navercorp.pinpoint</groupId>
             <artifactId>pinpoint-log4j-plugin</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.navercorp.pinpoint</groupId>
+            <artifactId>pinpoint-log4j2-plugin</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>


### PR DESCRIPTION
Cherry-picked from the following commits and adapt for pinpoint 1.8.x:

25cf954cc [#5971] fix test code fail
249c5dd03 [#5971] [#5989] add IT for log4j2 async logger
47b75b104 [#5971] add target profiling class when use "Making All
Loggers Asynchronous" function
4e8e81fe7 [#5971] add guide for log4j2 in per request logging doc
f50f73e13 [#5971] add guide for log4j2 in per request logging doc
fb886ae78 [#5971] update agent-it for log4j2
c004a616b [#5971] Log4j2 plugin
a46775750 [#5971] support log4j2