### PR TITLE
expose spanId and applicationName to log.page.url for customization

### DIFF
--- a/web/src/main/java/com/navercorp/pinpoint/web/controller/BusinessTransactionController.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/controller/BusinessTransactionController.java
@@ -107,7 +107,7 @@ public class BusinessTransactionController {
         ApplicationMap map = filteredMapService.selectApplicationMap(transactionId, viewVersion);
         RecordSet recordSet = this.transactionInfoService.createRecordSet(callTreeIterator, focusTimestamp, agentId, spanId);
 
-        TransactionInfoViewModel result = new TransactionInfoViewModel(transactionId, map.getNodes(), map.getLinks(), recordSet, spanResult.getTraceState(), logLinkEnable, logButtonName, logPageUrl, disableButtonMessage);
+        TransactionInfoViewModel result = new TransactionInfoViewModel(transactionId, spanId, map.getNodes(), map.getLinks(), recordSet, spanResult.getTraceState(), logLinkEnable, logButtonName, logPageUrl, disableButtonMessage);
         return result;
     }
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/view/TransactionInfoViewModel.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/view/TransactionInfoViewModel.java
@@ -42,6 +42,7 @@ import org.apache.commons.lang3.StringUtils;
 public class TransactionInfoViewModel {
 
     private TransactionId transactionId;
+    private long spanId;
     private Collection<Node> nodes;
     private Collection<Link> links;
     private RecordSet recordSet;
@@ -51,8 +52,9 @@ public class TransactionInfoViewModel {
     private String logPageUrl;
     private String disableButtonMessage;
 
-    public TransactionInfoViewModel(TransactionId transactionId, Collection<Node> nodes, Collection<Link> links, RecordSet recordSet, TraceState.State state, boolean logLinkEnable, String logButtonName, String logPageUrl, String disableButtonMessage) {
+    public TransactionInfoViewModel(TransactionId transactionId, long spanId, Collection<Node> nodes, Collection<Link> links, RecordSet recordSet, TraceState.State state, boolean logLinkEnable, String logButtonName, String logPageUrl, String disableButtonMessage) {
         this.transactionId = transactionId;
+        this.spanId = spanId;
         this.nodes = nodes;
         this.links = links;
         this.recordSet = recordSet;
@@ -71,6 +73,11 @@ public class TransactionInfoViewModel {
     @JsonProperty("transactionId")
     public String getTransactionId() {
         return TransactionIdUtils.formatString(transactionId);
+    }
+
+    @JsonProperty("spanId")
+    public long getSpanId() {
+        return spanId;
     }
 
     @JsonProperty("agentId")
@@ -118,6 +125,8 @@ public class TransactionInfoViewModel {
         if (StringUtils.isNotEmpty(logPageUrl)) {
             StringBuilder sb = new StringBuilder();
             sb.append("transactionId=").append(getTransactionId());
+            sb.append("&spanId=").append(spanId);
+            sb.append("&applicationName=").append(getApplicationId());
             sb.append("&time=").append(recordSet.getStartTime());
             return logPageUrl + "?" + sb.toString();
         }


### PR DESCRIPTION
Now the spanId and applicationName are not exposed to the log.page.url. For the customization implementation for [log controller](https://github.com/naver/pinpoint/blob/master/doc/per-request_feature_guide.md#3-expose-log-in-pinpoint-web).   The @RequestParam("spanId") would always be null.