### PR TITLE
Increasing length limit in variables agentId and applicationName

### DIFF
--- a/bootstrap/src/main/java/com/navercorp/pinpoint/bootstrap/IdValidator.java
+++ b/bootstrap/src/main/java/com/navercorp/pinpoint/bootstrap/IdValidator.java
@@ -30,7 +30,7 @@ public class IdValidator {
     private final BootLogger logger = BootLogger.getLogger(IdValidator.class.getName());
 
     private final Properties property;
-    private static final int MAX_ID_LENGTH = 24;
+    private static final int MAX_ID_LENGTH = 100;
 
     public IdValidator() {
         this(System.getProperties());

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/util/RowKeyUtils.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/util/RowKeyUtils.java
@@ -35,7 +35,7 @@ public final class RowKeyUtils {
         if (fixedBytes == null) {
             throw new NullPointerException("fixedBytes must not null");
         }
-        if (fixedBytes.length > maxFixedLength) {
+        if (fixedBytes.length > 100) {
             throw new IndexOutOfBoundsException("fixedBytes.length too big. length:" + fixedBytes.length);
         }
         byte[] rowKey = new byte[maxFixedLength + LONG_BYTE_LENGTH];

--- a/commons/src/main/java/com/navercorp/pinpoint/common/PinpointConstants.java
+++ b/commons/src/main/java/com/navercorp/pinpoint/common/PinpointConstants.java
@@ -21,8 +21,8 @@ package com.navercorp.pinpoint.common;
  */
 public final class PinpointConstants {
 
-    public static final int APPLICATION_NAME_MAX_LEN = 24;
+    public static final int APPLICATION_NAME_MAX_LEN = 100;
 
-    public static final int AGENT_NAME_MAX_LEN = 24;
+    public static final int AGENT_NAME_MAX_LEN = 100;
 
 }


### PR DESCRIPTION
Added the ability to specify in -Dpinpoint.agentId and -Dpinpoint.applicationName =
names are more than 24 characters.
Now this limit is limited to 100 characters.