### PR TITLE
[#6084] reword the statement about profiler.sampling.rate in faq.md

### DIFF
--- a/doc/faq.md
+++ b/doc/faq.md
@@ -18,7 +18,7 @@ You can change the log level by modifying the agent's *log4j.xml* located in *PI
 
 ### Why is only the first/some of the requests traced?
 There is a sampling rate option in the agent's pinpoint.config file (profiler.sampling.rate).
-The agent's release binary has this value set to 20, which tells the agent to sample 1 trace every 20 transactions.
+Pinpoint agent samples 1 trace every N transactions if this value was set as N.
 Changing this value to 1 will allow you to trace every transaction.
 
 ### Request count in the Scatter Chart is different from the ones in Response Summary chart. Why is this?


### PR DESCRIPTION
Reword the statement about profiler.sampling.rate in faq.md. 
Pinpoint release binary has changed the `profiler.sampling.rate` to 1, but it is still 20 in the document, it might be better to change the doc to a more general statement.