### PR TITLE
[#noissue] Improve rejected execution messages of ThreadPoolExecutor

### DIFF
--- a/collector/src/main/java/com/navercorp/pinpoint/collector/monitor/LoggingRejectedExecutionHandler.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/monitor/LoggingRejectedExecutionHandler.java
@@ -28,9 +28,7 @@ import java.util.concurrent.atomic.AtomicLong;
  * @author Woonduk Kang(emeroad)
  */
 public class LoggingRejectedExecutionHandler implements RejectedExecutionHandler {
-
     private final AtomicLong rejectedCount = new AtomicLong(0);
-
     private final Logger logger;
     private final int logRate;
 
@@ -45,7 +43,8 @@ public class LoggingRejectedExecutionHandler implements RejectedExecutionHandler
     public void rejectedExecution(Runnable r, ThreadPoolExecutor executor) {
         final long error = rejectedCount.incrementAndGet();
         if ((error % logRate) == 0) {
-            logger.warn("RejectedExecutionCount={}", error);
+            final int maxPoolSize = executor != null ? executor.getMaximumPoolSize() : -1;
+            logger.warn("The executor uses finite bounds for both maximum threads and work queue capacity, and is saturated. Check the maxPoolSize, queueCapacity, and HBase options in the configuration. maxPoolSize={}, rejectedCount={}", maxPoolSize, error);
         }
     }
 }

--- a/collector/src/test/java/com/navercorp/pinpoint/collector/monitor/LoggingRejectedExecutionHandlerTest.java
+++ b/collector/src/test/java/com/navercorp/pinpoint/collector/monitor/LoggingRejectedExecutionHandlerTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2019 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.collector.monitor;
+
+import org.junit.Test;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+public class LoggingRejectedExecutionHandlerTest {
+
+    @Test
+    public void rejectedExecution() throws Exception{
+        LoggingRejectedExecutionHandler handler = new LoggingRejectedExecutionHandler("testExecutor", 10);
+
+        ThreadPoolExecutor executor = (ThreadPoolExecutor) Executors.newFixedThreadPool(10);
+        Runnable runnable = new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    TimeUnit.MILLISECONDS.sleep(10);
+                } catch (InterruptedException e) {
+                }
+            }
+        };
+
+        for (int i = 0; i < 100; i++) {
+            executor.execute(runnable);
+            handler.rejectedExecution(runnable, executor);
+            TimeUnit.MILLISECONDS.sleep(100);
+        }
+    }
+}


### PR DESCRIPTION
## Improve rejected execution messages of ThreadPoolExecutor

AS-IS
~~~
RejectedExecutionCount=1000
~~~

TO-BE
~~~
The executor uses finite bounds for both maximum threads and work queue capacity, and is saturated. Check the maxPoolSize, queueCapacity, and HBase options in the configuration. maxPoolSize=10, rejectedCount=70
~~~