### PR TITLE
[#noissue] Patch log4j2 testcase

### DIFF
--- a/agent-it/src/test/java/com/navercorp/pinpoint/plugin/log4j2/Log4j2ForAsyncLoggerIT.java
+++ b/agent-it/src/test/java/com/navercorp/pinpoint/plugin/log4j2/Log4j2ForAsyncLoggerIT.java
@@ -29,7 +29,7 @@ import org.junit.runner.RunWith;
 @PinpointConfig("pinpoint-spring-bean-test.config")
 @JvmArgument("-Dlog4j2.contextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector")
 @JvmVersion(7)
-@Dependency({"org.apache.logging.log4j:log4j-core:[2.0,)", "com.lmax:disruptor:[3.4.2]"})
+@Dependency({"org.apache.logging.log4j:log4j-core:[2.0,2.13)", "com.lmax:disruptor:[3.4.2]"})
 public class Log4j2ForAsyncLoggerIT {
 
     @Test

--- a/agent-it8/src/test/java/com/navercorp/pinpoint/plugin/log4j2/Log4j2ForAsyncLoggerIT.java
+++ b/agent-it8/src/test/java/com/navercorp/pinpoint/plugin/log4j2/Log4j2ForAsyncLoggerIT.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2018 NAVER Corp.
+ * Copyright 2019 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,7 +16,12 @@
 package com.navercorp.pinpoint.plugin.log4j2;
 
 import com.navercorp.pinpoint.plugin.AgentPath;
-import com.navercorp.pinpoint.test.plugin.*;
+import com.navercorp.pinpoint.test.plugin.Dependency;
+import com.navercorp.pinpoint.test.plugin.JvmArgument;
+import com.navercorp.pinpoint.test.plugin.JvmVersion;
+import com.navercorp.pinpoint.test.plugin.PinpointAgent;
+import com.navercorp.pinpoint.test.plugin.PinpointConfig;
+import com.navercorp.pinpoint.test.plugin.PinpointPluginTestSuite;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.ThreadContext;
@@ -27,14 +32,15 @@ import org.junit.runner.RunWith;
 @RunWith(PinpointPluginTestSuite.class)
 @PinpointAgent(AgentPath.PATH)
 @PinpointConfig("pinpoint-spring-bean-test.config")
-@JvmVersion(7)
-@Dependency({"org.apache.logging.log4j:log4j-core:[2.0,2.13)"})
-public class Log4j2IT {
+@JvmArgument("-Dlog4j2.contextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector")
+@JvmVersion(8)
+@Dependency({"org.apache.logging.log4j:log4j-core:[2.13,)", "com.lmax:disruptor:[3.4.2]"})
+public class Log4j2ForAsyncLoggerIT {
 
     @Test
     public void test() {
         Logger logger = LogManager.getLogger();
-        logger.error("for log4j2 plugin test");
+        logger.error("for log4j2 plugin async logger test");
 
         Assert.assertNotNull(ThreadContext.get("PtxId"));
         Assert.assertNotNull(ThreadContext.get("PspanId"));

--- a/agent-it8/src/test/java/com/navercorp/pinpoint/plugin/log4j2/Log4j2IT.java
+++ b/agent-it8/src/test/java/com/navercorp/pinpoint/plugin/log4j2/Log4j2IT.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2018 NAVER Corp.
+ * Copyright 2019 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,7 +16,11 @@
 package com.navercorp.pinpoint.plugin.log4j2;
 
 import com.navercorp.pinpoint.plugin.AgentPath;
-import com.navercorp.pinpoint.test.plugin.*;
+import com.navercorp.pinpoint.test.plugin.Dependency;
+import com.navercorp.pinpoint.test.plugin.JvmVersion;
+import com.navercorp.pinpoint.test.plugin.PinpointAgent;
+import com.navercorp.pinpoint.test.plugin.PinpointConfig;
+import com.navercorp.pinpoint.test.plugin.PinpointPluginTestSuite;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.ThreadContext;
@@ -27,8 +31,8 @@ import org.junit.runner.RunWith;
 @RunWith(PinpointPluginTestSuite.class)
 @PinpointAgent(AgentPath.PATH)
 @PinpointConfig("pinpoint-spring-bean-test.config")
-@JvmVersion(7)
-@Dependency({"org.apache.logging.log4j:log4j-core:[2.0,2.13)"})
+@JvmVersion(8)
+@Dependency({"org.apache.logging.log4j:log4j-core:[2.13,)"})
 public class Log4j2IT {
 
     @Test

--- a/agent-it8/src/test/resources/pinpoint-spring-bean-test.config
+++ b/agent-it8/src/test/resources/pinpoint-spring-bean-test.config
@@ -1,0 +1,371 @@
+#
+# Pinpoint agent configuration
+#
+
+###########################################################
+# Collector server                                        # 
+###########################################################
+profiler.collector.ip=127.0.0.1
+
+# placeHolder support "${key}"
+profiler.collector.span.ip=${profiler.collector.ip}
+profiler.collector.span.port=9996
+
+# placeHolder support "${key}"
+profiler.collector.stat.ip=${profiler.collector.ip}
+profiler.collector.stat.port=9995
+
+# placeHolder support "${key}"
+profiler.collector.tcp.ip=${profiler.collector.ip}
+profiler.collector.tcp.port=9994
+
+
+###########################################################
+# Profiler Global Configuration                           # 
+###########################################################
+profiler.enable=true
+
+profiler.jvm.collect.interval=1000
+
+profiler.sampling.enable=true
+
+# Set sampling rate. If you set it to 10, 1 out of 10 transaction will be sampled.
+profiler.sampling.rate=1
+
+profiler.io.buffering.enable=true
+profiler.io.buffering.buffersize=20
+
+profiler.spandatasender.write.queue.size=5120
+#profiler.spandatasender.socket.sendbuffersize=1048576
+#profiler.spandatasender.socket.timeout=3000
+profiler.spandatasender.chunk.size=16384
+# Should keep in mind
+# 1. Loadbancing : TCP transport load balancing is per connection.(UDP transport loadbalancing is per packet)
+# 2. In unexpected situations, UDP has its own protection feature (like packet loss etc.), but tcp does not have such a feature. (We will add protection later)
+profiler.spandatasender.transport.type=UDP
+
+profiler.statdatasender.write.queue.size=5120
+#profiler.statdatasender.socket.sendbuffersize=1048576
+#profiler.statdatasender.socket.timeout=3000
+profiler.statdatasender.chunk.size=16384
+# Should keep in mind
+# 1. Loadbancing : TCP transport load balancing is per connection.(UDP transport loadbalancing is per packet)
+# 2. In unexpected situations, UDP has its own protection feature (like packet loss etc.), but tcp does not have such a feature. (We will add protection later)
+profiler.statdatasender.transport.type=UDP
+
+profiler.agentInfo.send.retry.interval=300000
+
+#  Allows TCP data command
+profiler.tcpdatasender.command.accept.enable=true
+
+# Allow bytecode framework
+profiler.instrument.asm=true
+
+###########################################################
+# application type                                        # 
+###########################################################
+#profiler.applicationservertype=TOMCAT
+#profiler.applicationservertype=BLOC
+
+profiler.plugin.disable=
+
+###########################################################
+# user defined classes                                    # 
+###########################################################
+profiler.include=
+
+###########################################################
+# TOMCAT                                                  #
+###########################################################
+profiler.tomcat.enable=true
+# Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
+profiler.tomcat.bootstrap.main=org.apache.catalina.startup.Bootstrap
+# Hide pinpoint headers.
+profiler.tomcat.hidepinpointheader=true
+# URLs to exclude from tracing
+profiler.tomcat.excludeurl=/aa/test.html, /bb/exclude.html
+profiler.tomcat.tracerequestparam=true
+
+# original IP address header
+# https://en.wikipedia.org/wiki/X-Forwarded-For
+#profiler.tomcat.realipheader=X-Forwarded-For
+# nginx real ip header
+#profiler.tomcat.realipheader=X-Real-IP
+# optional parameter, If the header value is ${profiler.tomcat.realipemptyvalue}, Ignore header value.
+#profiler.tomcat.realipemptyvalue=unknown
+
+
+###########################################################
+# JETTY                                                   #
+###########################################################
+profiler.jetty.enable=true
+# Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
+profiler.jetty.bootstrap.main=org.eclipse.jetty.start.Main
+# URLs to exclude from tracing
+profiler.jetty.excludeurl=
+
+
+###########################################################
+# DUBBO                                                   #
+###########################################################
+profiler.dubbo.enable=true
+# Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
+profiler.dubbo.bootstrap.main=com.alibaba.dubbo.container.Main
+
+
+###########################################################
+# JBOSS                                                   #
+###########################################################
+profiler.jboss.enable=true
+# Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
+profiler.jboss.bootstrap.main=org.jboss.modules.Main
+# Hide pinpoint headers.
+profiler.jboss.hidepinpointheader=true
+# URLs to exclude from tracing
+profiler.jboss.excludeurl=
+# HTTP Request methods to exclude from tracing
+#profiler.jboss.excludemethod=
+profiler.jboss.tracerequestparam=true
+
+# original IP address header
+# https://en.wikipedia.org/wiki/X-Forwarded-For
+#profiler.jboss.realipheader=X-Forwarded-For
+# nginx real ip header
+#profiler.jboss.realipheader=X-Real-IP
+# optional parameter, If the header value is ${profiler.jboss.realipemptyvalue}, Ignore header value.
+#profiler.jboss.realipemptyvalue=unknown
+
+
+###########################################################
+# SPRING BOOT                                             #
+###########################################################
+profiler.springboot.enable=true
+# Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
+profiler.springboot.bootstrap.main=org.springframework.boot.loader.JarLauncher, org.springframework.boot.loader.WarLauncher, org.springframework.boot.loader.PropertiesLauncher
+
+###########################################################
+# JDBC                                                    # 
+###########################################################
+profiler.jdbc=true
+profiler.jdbc.sqlcachesize=1024
+profiler.jdbc.maxsqlbindvaluesize=1024
+
+#
+# MYSQL
+#
+profiler.jdbc.mysql=true
+profiler.jdbc.mysql.setautocommit=true
+profiler.jdbc.mysql.commit=true
+profiler.jdbc.mysql.rollback=true
+
+#
+# MSSQL Jtds
+#
+profiler.jdbc.jtds=true
+profiler.jdbc.jtds.setautocommit=true
+profiler.jdbc.jtds.commit=true
+profiler.jdbc.jtds.rollback=true
+
+#
+# Oracle
+#
+profiler.jdbc.oracle=true
+profiler.jdbc.oracle.setautocommit=true
+profiler.jdbc.oracle.commit=true
+profiler.jdbc.oracle.rollback=true
+
+#
+# CUBRID
+#
+profiler.jdbc.cubrid=true
+profiler.jdbc.cubrid.setautocommit=true
+profiler.jdbc.cubrid.commit=true
+profiler.jdbc.cubrid.rollback=true
+
+#
+# DBCP
+#
+profiler.jdbc.dbcp=true
+profiler.jdbc.dbcp.connectionclose=true
+
+#
+# DBCP2
+#
+profiler.jdbc.dbcp2=true
+profiler.jdbc.dbcp2.connectionclose=true
+
+#
+# HIKARICP
+#
+profiler.jdbc.hikaricp=true
+profiler.jdbc.hikaricp.connectionclose=true
+
+###########################################################
+# Apache HTTP Client  4.x                                 #
+###########################################################
+profiler.apache.httpclient4=true
+profiler.apache.httpclient4.cookie=true
+
+# When cookies should be dumped. It could be ALWAYS or EXCEPTION.
+profiler.apache.httpclient4.cookie.dumptype=ALWAYS
+profiler.apache.httpclient4.cookie.sampling.rate=1
+
+# Dump entities of POST or PUT request. limited to entities which is HttpEntity.isRepeatable() == true.
+profiler.apache.httpclient4.entity=true
+
+# When entities should be dumped. ALWAYS or EXCEPTION.
+profiler.apache.httpclient4.entity.dumptype=ALWAYS
+profiler.apache.httpclient4.entity.sampling.rate=1
+
+profiler.apache.nio.httpclient4=true
+
+
+###########################################################
+# JDK HTTPURLConnection                                   #
+###########################################################
+profiler.jdk.httpurlconnection=true
+
+
+###########################################################
+# Ning Async HTTP Client                                  # 
+###########################################################
+profiler.ning.asynchttpclient=true
+profiler.ning.asynchttpclient.cookie=true
+profiler.ning.asynchttpclient.cookie.dumptype=ALWAYS
+profiler.ning.asynchttpclient.cookie.dumpsize=1024
+profiler.ning.asynchttpclient.cookie.sampling.rate=1
+profiler.ning.asynchttpclient.entity=true
+profiler.ning.asynchttpclient.entity.dumptype=ALWAYS
+profiler.ning.asynchttpclient.entity.dumpsize=1024
+profiler.ning.asynchttpclient.entity.sampling.rate=1
+profiler.ning.asynchttpclient.param=true
+profiler.ning.asynchttpclient.param.dumptype=ALWAYS
+profiler.ning.asynchttpclient.param.dumpsize=1024
+profiler.ning.asynchttpclient.param.sampling.rate=1
+
+
+###########################################################
+# Arcus                                                   # 
+###########################################################
+profiler.arcus=true
+profiler.arcus.keytrace=true
+
+
+###########################################################
+# Memcached                                               # 
+###########################################################
+profiler.memcached=true
+profiler.memcached.keytrace=true
+
+
+###########################################################
+# ibatis                                                  # 
+###########################################################
+profiler.orm.ibatis=true
+
+
+###########################################################
+# mybatis                                                 # 
+###########################################################
+profiler.orm.mybatis=true
+
+
+###########################################################
+# spring-beans 
+###########################################################
+# Profile spring-beans
+profiler.spring.beans=true
+
+# filters
+#    filter
+#    filter OR filters
+# filter
+#    value
+#    value AND filter
+# value
+#    token
+#    token OR token
+# token
+#    profiler.spring.beans.n.scope= [component-scan | post-processor] default is component-scan.
+#    profiler.spring.beans.n.base-packages= [package name, ...]
+#    profiler.spring.beans.n.name.pattern= [regex pattern, regex:regex pattern, antstyle:antstyle pattern, ...]
+#    profiler.spring.beans.n.class.pattern= [regex pattern, regex:regex pattern, antstyle:antstyle pattern, ...]
+#    profiler.spring.beans.n.annotation= [annotation name, ...]
+#
+# Scope:
+# component-scan: <context:component-scan ... /> or @ComponentScan
+# post-processor: BeanPostProcessor - Slow!!!
+#
+# ANT Style pattern rules:
+# ? - matches on character
+# * - matches zero or more characters
+# ** - matches zero or more 'directories' in a path
+
+# Examples:
+# profiler.spring.beans.1.scope=component-scan
+# profiler.spring.beans.1.base-packages=com.foo, com.bar
+# profiler.spring.beans.1.name.pattern=.*Foo, regex:.*Bar, antstyle:*Controller
+# profiler.spring.beans.1.class.pattern=
+# profiler.spring.beans.1.annotation=org.springframework.stereotype.Controller,org.springframework.stereotype.Service,org.springframework.stereotype.Repository
+#
+# profiler.spring.beans.2.scope=post-processor
+# profiler.spring.beans.2.base-packages=com.foo
+# profiler.spring.beans.2.name.pattern=
+# profiler.spring.beans.2.class.pattern=antstyle:com.foo.repository.*Repository, antstyle:com.foo.Service.Main*
+# profiler.spring.beans.2.annotation=
+
+profiler.spring.beans.1.scope=post-processor
+profiler.spring.beans.1.base-packages=com.navercorp.test.pinpoint
+profiler.spring.beans.1.name.pattern=ma.*, outer
+
+profiler.spring.beans.2.scope=post-processor
+profiler.spring.beans.2.base-packages=com.navercorp.test.pinpoint
+profiler.spring.beans.2.class.pattern=.*Morae
+
+profiler.spring.beans.3.scope=post-processor
+profiler.spring.beans.3.base-packages=com.navercorp.test.pinpoint
+profiler.spring.beans.3.annotation=org.springframework.stereotype.Component
+
+profiler.spring.beans.mark.error=false
+
+###########################################################
+# log4j
+###########################################################
+profiler.log4j.logging.transactioninfo=true
+
+###########################################################
+# log4j2
+###########################################################
+profiler.log4j2.logging.transactioninfo=true
+
+###########################################################
+# logback
+###########################################################
+profiler.logback.logging.transactioninfo=true
+
+###########################################################
+# gson
+###########################################################
+profiler.json.gson=true
+
+###########################################################
+# jackson
+###########################################################
+profiler.json.jackson=true
+
+###########################################################
+# json-lib
+###########################################################
+profiler.json.jsonlib=true
+
+###########################################################
+# RestTemplate
+###########################################################
+profiler.resttemplate=false
+
+###########################################################
+# Netty
+###########################################################
+# recommend netty plugin disable, when using VERTX.
+profiler.netty=false
+profiler.netty.http=false


### PR DESCRIPTION
Log4j 2.13.0 is the latest release of Log4j. As of Log4j 2.13.0 Log4j 2 requires Java 8 or greater at runtime.