### PR TITLE
[#noissue] Fix log message of interceptor-registry

### DIFF
--- a/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/interceptor/registry/DefaultInterceptorRegistryAdaptor.java
+++ b/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/interceptor/registry/DefaultInterceptorRegistryAdaptor.java
@@ -36,10 +36,10 @@ public final class DefaultInterceptorRegistryAdaptor implements InterceptorRegis
         if (interceptor == null) {
             return -1;
         }
-        
+
         final int newId = nextId();
         if (newId >= registrySize) {
-            throw new IndexOutOfBoundsException("size=" + index.length() + " id=" + id);
+            throw new IndexOutOfBoundsException("Interceptor registry size exceeded. Check the \"profiler.interceptorregistry.size\" setting. size=" + index.length() + " id=" + id);
         }
         index.set(newId, interceptor);
         return newId;


### PR DESCRIPTION
Fix a log message that occurs when the maximum size of the Interceptor Registry is reached.
~~~
Interceptor registry size exceeded. Check the "profiler.interceptorregistry.size" setting. size=8192 id=8731 
~~~