### PR TITLE
add a transactionId header to the response for Jetty&Tomcat

### DIFF
--- a/agent/src/main/resources/profiles/local/pinpoint-env.config
+++ b/agent/src/main/resources/profiles/local/pinpoint-env.config
@@ -265,6 +265,10 @@ profiler.jetty.tracerequestparam=true
 #profiler.jetty.realipheader=X-Real-IP
 # optional parameter, If the header value is ${profiler.jetty.realipemptyvalue}, Ignore header value.
 #profiler.jetty.realipemptyvalue=unknown
+# add trace id header to response
+#profiler.jetty.response-trace-header=false
+# trace id header name for response
+#profiler.jetty.response-trace-header-name=X-PP-Trace-Id
 
 ###########################################################
 # DUBBO                                                   #

--- a/agent/src/main/resources/profiles/local/pinpoint-env.config
+++ b/agent/src/main/resources/profiles/local/pinpoint-env.config
@@ -241,6 +241,10 @@ profiler.tomcat.tracerequestparam=true
 #profiler.tomcat.realipheader=X-Real-IP
 # optional parameter, If the header value is ${profiler.tomcat.realipemptyvalue}, Ignore header value.
 #profiler.tomcat.realipemptyvalue=unknown
+# add trace id header to response
+#profiler.tomcat.response-trace-header=false
+# trace id header name for response
+#profiler.tomcat.response-trace-header-name=X-PP-Trace-Id
 
 
 ###########################################################

--- a/agent/src/main/resources/profiles/release/pinpoint-env.config
+++ b/agent/src/main/resources/profiles/release/pinpoint-env.config
@@ -265,6 +265,10 @@ profiler.jetty.tracerequestparam=true
 #profiler.jetty.realipheader=X-Real-IP
 # optional parameter, If the header value is ${profiler.jetty.realipemptyvalue}, Ignore header value.
 #profiler.jetty.realipemptyvalue=unknown
+# add trace id header to response
+#profiler.jetty.response-trace-header=false
+# trace id header name for response
+#profiler.jetty.response-trace-header-name=X-PP-Trace-Id
 
 ###########################################################
 # DUBBO                                                   #

--- a/agent/src/main/resources/profiles/release/pinpoint-env.config
+++ b/agent/src/main/resources/profiles/release/pinpoint-env.config
@@ -241,6 +241,10 @@ profiler.tomcat.tracerequestparam=true
 #profiler.tomcat.realipheader=X-Real-IP
 # optional parameter, If the header value is ${profiler.tomcat.realipemptyvalue}, Ignore header value.
 #profiler.tomcat.realipemptyvalue=unknown
+# add trace id header to response
+#profiler.tomcat.response-trace-header=false
+# trace id header name for response
+#profiler.tomcat.response-trace-header-name=X-PP-Trace-Id
 
 
 ###########################################################

--- a/plugins/jetty/src/main/java/com/navercorp/pinpoint/plugin/jetty/JettyConfiguration.java
+++ b/plugins/jetty/src/main/java/com/navercorp/pinpoint/plugin/jetty/JettyConfiguration.java
@@ -32,6 +32,9 @@ public class JettyConfiguration {
     private final List<String> bootstrapMains;
     private final Filter<String> excludeUrlFilter;
     private final boolean hidePinpointHeader;
+    private final boolean responseTraceIdHeader;
+    private final String responseTraceIdHeaderName;
+    private final boolean encodeTraceIdHeader;
     private final String realIpHeader;
     private final String realIpEmptyValue;
     private final boolean traceRequestParam;
@@ -52,6 +55,9 @@ public class JettyConfiguration {
             hidePinpointHeader = config.readBoolean("profiler.jetty.hidepinpointheader", true);
         }
         this.hidePinpointHeader = hidePinpointHeader;
+        this.responseTraceIdHeader = config.readBoolean("profiler.jetty.response-trace-header", false);
+        this.responseTraceIdHeaderName = config.readString("profiler.jetty.response-trace-header-name", "X-Trace-Id");
+        this.encodeTraceIdHeader = config.readBoolean("profiler.jetty.encode-trace-header", true);
         final String excludeProfileMethod = config.readString("profiler.jetty.excludemethod", "");
         if (!excludeProfileMethod.isEmpty()) {
             this.excludeProfileMethodFilter = new ExcludeMethodFilter(excludeProfileMethod);
@@ -79,6 +85,18 @@ public class JettyConfiguration {
         return hidePinpointHeader;
     }
 
+    public boolean isResponseTraceIdHeader() {
+        return responseTraceIdHeader;
+    }
+
+    public String getResponseTraceIdHeaderName() {
+        return responseTraceIdHeaderName;
+    }
+
+    public boolean isEncodeTraceIdHeader() {
+        return encodeTraceIdHeader;
+    }
+
     public String getRealIpHeader() {
         return realIpHeader;
     }
@@ -102,6 +120,9 @@ public class JettyConfiguration {
         sb.append(", bootstrapMains=").append(bootstrapMains);
         sb.append(", excludeUrlFilter=").append(excludeUrlFilter);
         sb.append(", hidePinpointHeader=").append(hidePinpointHeader);
+        sb.append(", responseTraceIdHeader=").append(responseTraceIdHeader);
+        sb.append(", responseTraceIdHeaderName=").append(responseTraceIdHeaderName);
+        sb.append(", encodeTraceIdHeader=").append(encodeTraceIdHeader);
         sb.append(", realIpHeader='").append(realIpHeader).append('\'');
         sb.append(", realIpEmptyValue='").append(realIpEmptyValue).append('\'');
         sb.append(", traceRequestParam=").append(traceRequestParam);

--- a/plugins/tomcat/src/main/java/com/navercorp/pinpoint/plugin/tomcat/TomcatConfig.java
+++ b/plugins/tomcat/src/main/java/com/navercorp/pinpoint/plugin/tomcat/TomcatConfig.java
@@ -33,6 +33,9 @@ public class TomcatConfig {
     private final boolean enable;
     private final List<String> bootstrapMains;
     private final boolean hidePinpointHeader;
+    private final boolean responseTraceIdHeader;
+    private final String responseTraceIdHeaderName;
+    private final boolean encodeTraceIdHeader;
 
     private final boolean traceRequestParam;
     private final Filter<String> excludeUrlFilter;
@@ -49,6 +52,9 @@ public class TomcatConfig {
         this.enable = config.readBoolean("profiler.tomcat.enable", true);
         this.bootstrapMains = config.readList("profiler.tomcat.bootstrap.main");
         this.hidePinpointHeader = config.readBoolean("profiler.tomcat.hidepinpointheader", true);
+        this.responseTraceIdHeader = config.readBoolean("profiler.tomcat.response-trace-header", false);
+        this.responseTraceIdHeaderName = config.readString("profiler.tomcat.response-trace-header-name", "X-Trace-Id");
+        this.encodeTraceIdHeader = config.readBoolean("profiler.tomcat.encode-trace-header", true);
 
         // runtime
         this.traceRequestParam = config.readBoolean("profiler.tomcat.tracerequestparam", true);
@@ -81,6 +87,18 @@ public class TomcatConfig {
         return hidePinpointHeader;
     }
 
+    public boolean isResponseTraceIdHeader() {
+        return responseTraceIdHeader;
+    }
+
+    public String getResponseTraceIdHeaderName() {
+        return responseTraceIdHeaderName;
+    }
+
+    public boolean isEncodeTraceIdHeader() {
+        return encodeTraceIdHeader;
+    }
+
     public boolean isTraceRequestParam() {
         return traceRequestParam;
     }
@@ -107,6 +125,9 @@ public class TomcatConfig {
         sb.append("enable=").append(enable);
         sb.append(", bootstrapMains=").append(bootstrapMains);
         sb.append(", hidePinpointHeader=").append(hidePinpointHeader);
+        sb.append(", responseTraceIdHeader=").append(responseTraceIdHeader);
+        sb.append(", responseTraceIdHeaderName=").append(responseTraceIdHeaderName);
+        sb.append(", encodeTraceIdHeader=").append(encodeTraceIdHeader);
         sb.append(", traceRequestParam=").append(traceRequestParam);
         sb.append(", excludeUrlFilter=").append(excludeUrlFilter);
         sb.append(", realIpHeader='").append(realIpHeader).append('\'');


### PR DESCRIPTION
1. default to off, no header added to the response.
2. header name can be configured.
3. header value i.e. transactionId is url-encoded by default.

More convenient to check the current specific transaction. 
Enable to trace the transaction for the apps/devices.

To view the transaction, you may check #4790 if you are use V1 UI and
if you are use V2 UI, you may check via the url https://youdomain/v2/transactionDetail/{txId}/0/{agentId}/-1. 
If your txId is jt4zp-10.20.3.4^1581804767659^1, then the agentId is jt4zp-10.20.3.4.


