### PR TITLE
[#6634] Added support for driver version 4.50

### DIFF
--- a/agent/src/main/resources/profiles/local/pinpoint-env.config
+++ b/agent/src/main/resources/profiles/local/pinpoint-env.config
@@ -578,6 +578,21 @@ profiler.jdbc.hikaricp=true
 profiler.jdbc.hikaricp.connectionclose=true
 
 #
+# INFORMIX
+# support 4.10.10.0+
+#
+# Profile INFORMIX.
+profiler.jdbc.informix=true
+# Allow profiling of setautocommit.
+profiler.jdbc.informix.setautocommit=true
+# Allow profiling of commit.
+profiler.jdbc.informix.commit=true
+# Allow profiling of rollback.
+profiler.jdbc.informix.rollback=true
+# Trace bindvalues for INFORMIX PreparedStatements (overrides profiler.jdbc.tracesqlbindvalue)
+#profiler.jdbc.informix.tracesqlbindvalue=true
+
+#
 # DRUID
 #
 profiler.jdbc.druid=true

--- a/agent/src/main/resources/profiles/release/pinpoint-env.config
+++ b/agent/src/main/resources/profiles/release/pinpoint-env.config
@@ -574,6 +574,21 @@ profiler.jdbc.dbcp2.connectionclose=false
 profiler.jdbc.hikaricp=true
 profiler.jdbc.hikaricp.connectionclose=false
 
+# 
+# INFORMIX 
+# support 4.10.10.0+ 
+# 
+# Profile INFORMIX. 
+profiler.jdbc.informix=true 
+# Allow profiling of setautocommit. 
+profiler.jdbc.informix.setautocommit=true 
+# Allow profiling of commit. 
+profiler.jdbc.informix.commit=true 
+# Allow profiling of rollback. 
+profiler.jdbc.informix.rollback=true 
+# Trace bindvalues for INFORMIX PreparedStatements (overrides profiler.jdbc.tracesqlbindvalue) 
+#profiler.jdbc.informix.tracesqlbindvalue=true 
+
 #
 # DRUID
 #

--- a/plugins/informix-jdbc/pom.xml
+++ b/plugins/informix-jdbc/pom.xml
@@ -11,7 +11,7 @@
     <artifactId>pinpoint-informix-jdbc-driver-plugin</artifactId>
     <name>pinpoint-informix-jdbc-driver-plugin</name>
     <packaging>jar</packaging>
-
+    
     <dependencies>
         <dependency>
             <groupId>com.navercorp.pinpoint</groupId>
@@ -34,6 +34,12 @@
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.ibm.informix</groupId>
+            <artifactId>jdbc</artifactId>
+            <version>4.10.10.0</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 </project>

--- a/plugins/informix-jdbc/src/main/java/com/navercorp/pinpoint/plugin/jdbc/informix/interceptor/InformixPreparedStatementCreateInterceptor.java
+++ b/plugins/informix-jdbc/src/main/java/com/navercorp/pinpoint/plugin/jdbc/informix/interceptor/InformixPreparedStatementCreateInterceptor.java
@@ -30,10 +30,12 @@ import com.navercorp.pinpoint.bootstrap.util.InterceptorUtils;
 
 import java.util.Arrays;
 import java.util.Properties;
+import com.informix.util.AdvancedUppercaseProperties;
 
 import com.navercorp.pinpoint.plugin.jdbc.informix.InformixConstants;
-import com.navercorp.pinpoint.plugin.jdbc.informix.interceptor.getter.DatabaseNameGetter;
-import com.navercorp.pinpoint.plugin.jdbc.informix.interceptor.getter.ConnectionInfoGetter;
+import com.navercorp.pinpoint.plugin.jdbc.informix.interceptor.getter.InformixDatabaseNameGetter;
+import com.navercorp.pinpoint.plugin.jdbc.informix.interceptor.getter.InformixConnectionInfoGetter;
+import com.navercorp.pinpoint.plugin.jdbc.informix.interceptor.getter.Informix_4_50_ConnectionInfoGetter;
 
 /**
  * @author Guillermo Adrian Molina
@@ -124,15 +126,20 @@ public class InformixPreparedStatementCreateInterceptor extends SpanEventSimpleA
     }
 
     private String getDatabaseName(Object target) {
-        if (target instanceof DatabaseNameGetter) {
-            return ((DatabaseNameGetter) target)._$PINPOINT$_getDatabaseName();
+        if (target instanceof InformixDatabaseNameGetter) {
+            return ((InformixDatabaseNameGetter) target)._$PINPOINT$_getDatabaseName();
         }
         return null;
     }
 
     private String getURL(Object target) {
-        if (target instanceof ConnectionInfoGetter) {
-            Properties connInfo = ((ConnectionInfoGetter) target)._$PINPOINT$_getConnectionInfo();
+        if (target instanceof InformixConnectionInfoGetter) {
+            Properties connInfo = ((InformixConnectionInfoGetter) target)._$PINPOINT$_getConnectionInfo();
+            String url = connInfo.getProperty("IFXHOST") + ":" + connInfo.getProperty("PORTNO");
+            return url;
+        }
+        if (target instanceof Informix_4_50_ConnectionInfoGetter) {
+            AdvancedUppercaseProperties connInfo = ((Informix_4_50_ConnectionInfoGetter) target)._$PINPOINT$_getConnectionInfo();
             String url = connInfo.getProperty("IFXHOST") + ":" + connInfo.getProperty("PORTNO");
             return url;
         }

--- a/plugins/informix-jdbc/src/main/java/com/navercorp/pinpoint/plugin/jdbc/informix/interceptor/InformixStatementCreateInterceptor.java
+++ b/plugins/informix-jdbc/src/main/java/com/navercorp/pinpoint/plugin/jdbc/informix/interceptor/InformixStatementCreateInterceptor.java
@@ -29,10 +29,12 @@ import com.navercorp.pinpoint.bootstrap.util.InterceptorUtils;
 
 import java.util.Arrays;
 import java.util.Properties;
+import com.informix.util.AdvancedUppercaseProperties;
 
 import com.navercorp.pinpoint.plugin.jdbc.informix.InformixConstants;
-import com.navercorp.pinpoint.plugin.jdbc.informix.interceptor.getter.DatabaseNameGetter;
-import com.navercorp.pinpoint.plugin.jdbc.informix.interceptor.getter.ConnectionInfoGetter;
+import com.navercorp.pinpoint.plugin.jdbc.informix.interceptor.getter.InformixDatabaseNameGetter;
+import com.navercorp.pinpoint.plugin.jdbc.informix.interceptor.getter.InformixConnectionInfoGetter;
+import com.navercorp.pinpoint.plugin.jdbc.informix.interceptor.getter.Informix_4_50_ConnectionInfoGetter;
 
 /**
  * @author Guillermo Adrian Molina
@@ -95,15 +97,20 @@ public class InformixStatementCreateInterceptor implements AroundInterceptor {
     }
 
     private String getDatabaseName(Object target) {
-        if (target instanceof DatabaseNameGetter) {
-            return ((DatabaseNameGetter) target)._$PINPOINT$_getDatabaseName();
+        if (target instanceof InformixDatabaseNameGetter) {
+            return ((InformixDatabaseNameGetter) target)._$PINPOINT$_getDatabaseName();
         }
         return null;
     }
 
     private String getURL(Object target) {
-        if (target instanceof ConnectionInfoGetter) {
-            Properties connInfo = ((ConnectionInfoGetter) target)._$PINPOINT$_getConnectionInfo();
+        if (target instanceof InformixConnectionInfoGetter) {
+            Properties connInfo = ((InformixConnectionInfoGetter) target)._$PINPOINT$_getConnectionInfo();
+            String url = connInfo.getProperty("IFXHOST") + ":" + connInfo.getProperty("PORTNO");
+            return url;
+        }
+        if (target instanceof Informix_4_50_ConnectionInfoGetter) {
+            AdvancedUppercaseProperties connInfo = ((Informix_4_50_ConnectionInfoGetter) target)._$PINPOINT$_getConnectionInfo();
             String url = connInfo.getProperty("IFXHOST") + ":" + connInfo.getProperty("PORTNO");
             return url;
         }

--- a/plugins/informix-jdbc/src/main/java/com/navercorp/pinpoint/plugin/jdbc/informix/interceptor/getter/InformixConnectionInfoGetter.java
+++ b/plugins/informix-jdbc/src/main/java/com/navercorp/pinpoint/plugin/jdbc/informix/interceptor/getter/InformixConnectionInfoGetter.java
@@ -19,6 +19,6 @@ package com.navercorp.pinpoint.plugin.jdbc.informix.interceptor.getter;
 /**
  * @author Guillermo Adrian Molina
  */
-public interface ConnectionInfoGetter {
+public interface InformixConnectionInfoGetter {
     java.util.Properties _$PINPOINT$_getConnectionInfo();
 }

--- a/plugins/informix-jdbc/src/main/java/com/navercorp/pinpoint/plugin/jdbc/informix/interceptor/getter/InformixDatabaseNameGetter.java
+++ b/plugins/informix-jdbc/src/main/java/com/navercorp/pinpoint/plugin/jdbc/informix/interceptor/getter/InformixDatabaseNameGetter.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.plugin.jdbc.informix.interceptor.getter;
+
+/**
+ * @author Guillermo Adrian Molina
+ */
+public interface InformixDatabaseNameGetter {
+    String _$PINPOINT$_getDatabaseName();
+}

--- a/plugins/informix-jdbc/src/main/java/com/navercorp/pinpoint/plugin/jdbc/informix/interceptor/getter/Informix_4_50_ConnectionInfoGetter.java
+++ b/plugins/informix-jdbc/src/main/java/com/navercorp/pinpoint/plugin/jdbc/informix/interceptor/getter/Informix_4_50_ConnectionInfoGetter.java
@@ -16,9 +16,11 @@
 
 package com.navercorp.pinpoint.plugin.jdbc.informix.interceptor.getter;
 
+import com.informix.util.AdvancedUppercaseProperties;
+
 /**
  * @author Guillermo Adrian Molina
  */
-public interface DatabaseNameGetter {
-    String _$PINPOINT$_getDatabaseName();
+public interface Informix_4_50_ConnectionInfoGetter {
+    AdvancedUppercaseProperties _$PINPOINT$_getConnectionInfo();
 }


### PR DESCRIPTION
This is a patch for the [critical issue](https://github.com/naver/pinpoint/pull/6634#issuecomment-611832466) found. 
I've renamed the getters to be more like the others:

DatabaseNameGetter -> InformixDatabaseNameGetter
ConnectionInfoGetter -> InformixConnectionInfoGetter

And created a new getter for the driver 4.50.x:
Informix_4_50_ConnectionInfoGetter

I've patched the interceptors to choose the correct ConnectionInfoGetter and also patched InformixPlugin to create the right getter based on the type of the property. Now the plugin has a dependency on the driver.