### PR TITLE
[#6760] add system property config support

### DIFF
--- a/bootstrap-core/src/test/java/com/navercorp/pinpoint/bootstrap/resolver/condition/MainClassConditionTest.java
+++ b/bootstrap-core/src/test/java/com/navercorp/pinpoint/bootstrap/resolver/condition/MainClassConditionTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.*;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 import org.junit.Test;
 
@@ -133,6 +134,11 @@ public class MainClassConditionTest {
                 } else {
                     return defaultValue;
                 }
+            }
+
+            @Override
+            public Set<String> stringPropertyNames() {
+                return this.properties.keySet();
             }
         };
     }

--- a/bootstrap-core/src/test/java/com/navercorp/pinpoint/bootstrap/resolver/condition/MainClassConditionTest.java
+++ b/bootstrap-core/src/test/java/com/navercorp/pinpoint/bootstrap/resolver/condition/MainClassConditionTest.java
@@ -18,10 +18,9 @@ package com.navercorp.pinpoint.bootstrap.resolver.condition;
 
 import static org.junit.Assert.*;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
+import java.util.Properties;
 
+import com.navercorp.pinpoint.common.util.PropertySnapshot;
 import org.junit.Test;
 
 import com.navercorp.pinpoint.common.util.SimpleProperty;
@@ -113,34 +112,7 @@ public class MainClassConditionTest {
     }
     
     private static SimpleProperty createTestProperty() {
-        return new SimpleProperty() {
-            
-            private final Map<String, String> properties = new HashMap<String, String>();
-            
-            @Override
-            public void setProperty(String key, String value) {
-                this.properties.put(key, value);
-            }
-            
-            @Override
-            public String getProperty(String key) {
-                return this.properties.get(key);
-            }
-            
-            @Override
-            public String getProperty(String key, String defaultValue) {
-                if (this.properties.containsKey(key)) {
-                    return this.properties.get(key);
-                } else {
-                    return defaultValue;
-                }
-            }
-
-            @Override
-            public Set<String> stringPropertyNames() {
-                return this.properties.keySet();
-            }
-        };
+        return new PropertySnapshot(new Properties());
     }
     
     private static SimpleProperty createTestProperty(String testMainClass) {

--- a/bootstrap/src/main/java/com/navercorp/pinpoint/bootstrap/config/ProfilePropertyLoader.java
+++ b/bootstrap/src/main/java/com/navercorp/pinpoint/bootstrap/config/ProfilePropertyLoader.java
@@ -18,6 +18,7 @@ package com.navercorp.pinpoint.bootstrap.config;
 
 import com.navercorp.pinpoint.bootstrap.BootLogger;
 import com.navercorp.pinpoint.bootstrap.agentdir.Assert;
+import com.navercorp.pinpoint.common.annotations.VisibleForTesting;
 import com.navercorp.pinpoint.common.util.PropertyUtils;
 import com.navercorp.pinpoint.common.util.SimpleProperty;
 
@@ -27,6 +28,7 @@ import java.util.Properties;
 import java.util.Set;
 
 /**
+ * @author yjqg6666
  * @author Woonduk Kang(emeroad)
  */
 class ProfilePropertyLoader implements PropertyLoader {
@@ -40,6 +42,8 @@ class ProfilePropertyLoader implements PropertyLoader {
     private final String profilesPath;
 
     private final String[] supportedProfiles;
+
+    public static final String[] ALLOWED_PROPERTY_PREFIX = new String[]{"bytecode.", "profiler.", "pinpoint."};
 
     public ProfilePropertyLoader(SimpleProperty systemProperty, String agentRootPath, String profilesPath, String[] supportedProfiles) {
         this.systemProperty = Assert.requireNonNull(systemProperty, "systemProperty");
@@ -124,12 +128,21 @@ class ProfilePropertyLoader implements PropertyLoader {
     private void loadSystemProperties(Properties dstProperties) {
         Set<String> stringPropertyNames = this.systemProperty.stringPropertyNames();
         for (String propertyName : stringPropertyNames) {
-            boolean isPinpointProperty = propertyName.startsWith("bytecode.") || propertyName.startsWith("profiler.") || propertyName.startsWith("pinpoint.");
-            if (isPinpointProperty) {
+            if (isAllowPinpointProperty(propertyName)) {
                 String val = this.systemProperty.getProperty(propertyName);
                 dstProperties.setProperty(propertyName, val);
             }
         }
+    }
+
+    @VisibleForTesting
+    boolean isAllowPinpointProperty(String propertyName) {
+        for (String prefix : ALLOWED_PROPERTY_PREFIX) {
+            if (propertyName.startsWith(prefix)) {
+                return true;
+            }
+        }
+        return false;
     }
 
 }

--- a/bootstrap/src/main/java/com/navercorp/pinpoint/bootstrap/config/ProfilePropertyLoader.java
+++ b/bootstrap/src/main/java/com/navercorp/pinpoint/bootstrap/config/ProfilePropertyLoader.java
@@ -24,6 +24,7 @@ import com.navercorp.pinpoint.common.util.SimpleProperty;
 import java.io.File;
 import java.io.IOException;
 import java.util.Properties;
+import java.util.Set;
 
 /**
  * @author Woonduk Kang(emeroad)
@@ -74,6 +75,7 @@ class ProfilePropertyLoader implements PropertyLoader {
             loadFileProperties(defaultProperties, externalConfig);
         }
         // ?? 4. systemproperty -Dkey=value?
+        loadSystemProperties(defaultProperties);
 
         // log path
         saveLogConfigLocation(activeProfile, defaultProperties);
@@ -116,6 +118,17 @@ class ProfilePropertyLoader implements PropertyLoader {
         } catch (IOException e) {
             logger.info(String.format("%s load fail Caused by:%s", filePath, e.getMessage()));
             throw new IllegalStateException(String.format("%s load fail Caused by:%s", filePath, e.getMessage()));
+        }
+    }
+
+    private void loadSystemProperties(Properties dstProperties) {
+        Set<String> stringPropertyNames = this.systemProperty.stringPropertyNames();
+        for (String propertyName : stringPropertyNames) {
+            boolean isPinpointProperty = propertyName.startsWith("bytecode.") || propertyName.startsWith("profiler.") || propertyName.startsWith("pinpoint.");
+            if (isPinpointProperty) {
+                String val = this.systemProperty.getProperty(propertyName);
+                dstProperties.setProperty(propertyName, val);
+            }
         }
     }
 

--- a/bootstrap/src/main/java/com/navercorp/pinpoint/bootstrap/config/SimplePropertyLoader.java
+++ b/bootstrap/src/main/java/com/navercorp/pinpoint/bootstrap/config/SimplePropertyLoader.java
@@ -24,6 +24,7 @@ import com.navercorp.pinpoint.common.util.SimpleProperty;
 import java.io.File;
 import java.io.IOException;
 import java.util.Properties;
+import java.util.Set;
 
 /**
  * @author Woonduk Kang(emeroad)
@@ -59,6 +60,7 @@ class SimplePropertyLoader implements PropertyLoader {
             logger.info(String.format("load default config:%s", defaultConfigPath));
             loadFileProperties(defaultProperties, defaultConfigPath);
         }
+        loadSystemProperties(defaultProperties);
         saveLogConfigLocation(defaultProperties);
         return defaultProperties;
     }
@@ -82,6 +84,17 @@ class SimplePropertyLoader implements PropertyLoader {
         } catch (IOException e) {
             logger.info(String.format("%s load fail Caused by:%s", filePath, e.getMessage()));
             throw new IllegalStateException(String.format("%s load fail Caused by:%s", filePath, e.getMessage()));
+        }
+    }
+
+    private void loadSystemProperties(Properties dstProperties) {
+        Set<String> stringPropertyNames = this.systemProperty.stringPropertyNames();
+        for (String propertyName : stringPropertyNames) {
+            boolean isPinpointProperty = propertyName.startsWith("bytecode.") || propertyName.startsWith("profiler.") || propertyName.startsWith("pinpoint.");
+            if (isPinpointProperty) {
+                String val = this.systemProperty.getProperty(propertyName);
+                dstProperties.setProperty(propertyName, val);
+            }
         }
     }
 

--- a/bootstrap/src/test/java/com/navercorp/pinpoint/bootstrap/config/ProfilePropertyLoaderTest.java
+++ b/bootstrap/src/test/java/com/navercorp/pinpoint/bootstrap/config/ProfilePropertyLoaderTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.bootstrap.config;
+
+import com.navercorp.pinpoint.common.util.PropertySnapshot;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.util.Properties;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author Woonduk Kang(emeroad)
+ */
+public class ProfilePropertyLoaderTest {
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    @Test
+    public void isAllowPinpointProperty() {
+        PropertySnapshot properties = new PropertySnapshot(new Properties());
+
+        properties.setProperty("pinpoint.test", "a");
+        File root = folder.getRoot();
+        ProfilePropertyLoader loader = new ProfilePropertyLoader(properties, root.getPath(), "test", new String[]{"test"});
+        Assert.assertTrue(loader.isAllowPinpointProperty("pinpoint.test"));
+
+        Assert.assertFalse(loader.isAllowPinpointProperty("unknown.test"));
+
+    }
+}

--- a/commons/src/main/java/com/navercorp/pinpoint/common/util/PropertySnapshot.java
+++ b/commons/src/main/java/com/navercorp/pinpoint/common/util/PropertySnapshot.java
@@ -55,4 +55,9 @@ public class PropertySnapshot implements SimpleProperty {
     public String getProperty(String key, String defaultValue) {
         return this.properties.getProperty(key, defaultValue);
     }
+
+    @Override
+    public Set<String> stringPropertyNames() {
+        return this.properties.stringPropertyNames();
+    }
 }

--- a/commons/src/main/java/com/navercorp/pinpoint/common/util/SimpleProperty.java
+++ b/commons/src/main/java/com/navercorp/pinpoint/common/util/SimpleProperty.java
@@ -16,6 +16,8 @@
 
 package com.navercorp.pinpoint.common.util;
 
+import java.util.Set;
+
 /**
  * @author emeroad
  */
@@ -25,4 +27,6 @@ public interface SimpleProperty {
     String getProperty(String key);
 
     String getProperty(String key, String defaultValue);
+
+    Set<String> stringPropertyNames();
 }

--- a/commons/src/main/java/com/navercorp/pinpoint/common/util/SystemProperty.java
+++ b/commons/src/main/java/com/navercorp/pinpoint/common/util/SystemProperty.java
@@ -17,6 +17,8 @@
 package com.navercorp.pinpoint.common.util;
 
 
+import java.util.Set;
+
 /**
  * @author emeroad
  */
@@ -38,6 +40,12 @@ public class SystemProperty implements SimpleProperty {
     public String getProperty(String key, String defaultValue) {
         return System.getProperty(key, defaultValue);
     }
+
+    @Override
+    public Set<String> stringPropertyNames() {
+        return System.getProperties().stringPropertyNames();
+    }
+
 
     public String getEnv(String name) {
         return System.getenv(name);


### PR DESCRIPTION
System property take higher priority than the config file for the specified profile.
From the source code https://github.com/naver/pinpoint/blob/c5e6b7e33343ad8122823600f5977ba8927b6fe6/bootstrap/src/main/java/com/navercorp/pinpoint/bootstrap/config/ProfilePropertyLoader.java#L76, i see the comment  and the feature not implemented. Should i consider something additional for that?