### PR TITLE
fix Filter Transaction Wizard transaction result filter

### DIFF
--- a/web/src/main/angular/src/app/core/components/filter-transaction-wizard-popup/filter-transaction-wizard-popup.component.ts
+++ b/web/src/main/angular/src/app/core/components/filter-transaction-wizard-popup/filter-transaction-wizard-popup.component.ts
@@ -52,9 +52,9 @@ export class FilterTransactionWizardPopupComponent implements OnInit {
             this.responseTimeRange = [this.filterInfo.responseFrom, this.filterInfo.responseTo];
             this.urlPattern = this.filterInfo.urlPattern || '';
             if (this.filterInfo.transactionResult === true) {
-                this.selectedResultType = RESULT_TYPE.SUCCESS_ONLY;
-            } else if (this.filterInfo.transactionResult === false) {
                 this.selectedResultType = RESULT_TYPE.FAIL_ONLY;
+            } else if (this.filterInfo.transactionResult === false) {
+                this.selectedResultType = RESULT_TYPE.SUCCESS_ONLY;
             } else {
                 this.selectedResultType = RESULT_TYPE.SUCCESS_AND_FAIL;
             }
@@ -79,7 +79,7 @@ export class FilterTransactionWizardPopupComponent implements OnInit {
             urlPattern: this.urlPattern,
             responseFrom: this.responseTimeRange[0],
             responseTo: this.responseTimeRange[1],
-            transactionResult: this.selectedResultType === 0 ? null : this.selectedResultType === 1 ? true : false,
+            transactionResult: this.selectedResultType === 0 ? null : (this.selectedResultType === 2 ? true : false),
             filterTargetRpcList : this.link.sourceInfo.isWas && this.link.targetInfo.isWas ? this.link.filterTargetRpcList : []
         });
         this.onClickClose();

--- a/web/src/main/angular/src/app/core/models/filter.ts
+++ b/web/src/main/angular/src/app/core/models/filter.ts
@@ -105,9 +105,9 @@ export class Filter {
 
     getTransactionResultStr(): string {
         if (this.transactionResult === true) {
-            return 'Success Only';
-        } else if (this.transactionResult === false) {
             return 'Failed Only';
+        } else if (this.transactionResult === false) {
+            return 'Success Only';
         }
         return 'Success + Failed';
     }


### PR DESCRIPTION
If filtering transactions via "Filter Transaction Wizard" and select "Failed-only" will get failed transaction, and "success-only" will get successful transactions.
![image](https://user-images.githubusercontent.com/1879641/81916800-e558e580-9606-11ea-8156-9efe3644f0ff.png)


From the java source: https://github.com/naver/pinpoint/blob/fce1f86acc6d406ea82174a72a018611aac5d031/web/src/main/java/com/navercorp/pinpoint/web/filter/FilterDescriptor.java#L146-L153

https://github.com/naver/pinpoint/blob/ce0c257122a621f64d578b6258627c7d75c91333/web/src/main/java/com/navercorp/pinpoint/web/filter/LinkFilter.java#L146-L155

So the truth value of the filter.ie means failed-only transactions, false means success-only transactions, and null means all.


From the angular source code:
The filter.ie is from https://github.com/naver/pinpoint/blob/14761a77eac08a3563db6c3f8296ff2bd14d3d4b/web/src/main/angular/src/app/core/models/filter.ts#L121 
https://github.com/naver/pinpoint/blob/14761a77eac08a3563db6c3f8296ff2bd14d3d4b/web/src/main/angular/src/app/core/models/filter.ts#L106-L113

The true value of transactionResult should be failed-only.

