### PR TITLE
Thread plugin support tracing multiple packages.

### DIFF
--- a/agent/src/main/resources/pinpoint.config
+++ b/agent/src/main/resources/pinpoint.config
@@ -283,5 +283,5 @@ profiler.plugin.disable=
 ###########################################################
 # which package of runnable(callable) instance can be thread plugin trace
 # Set the package name to track
-# eg) profiler.thread.match.package=com.company.shopping.cart
+# eg) profiler.thread.match.package=com.company.shopping.cart, com.company.payment
 profiler.thread.match.package=

--- a/agent/src/main/resources/profiles/local/pinpoint-env.config
+++ b/agent/src/main/resources/profiles/local/pinpoint-env.config
@@ -1096,5 +1096,5 @@ profiler.jdk.concurrent.completable-future=true
 ###########################################################
 # which package of runnable(callable) instance can be thread plugin trace
 # Set the package name to track
-# eg) profiler.thread.match.package=com.company.shopping.cart
+# eg) profiler.thread.match.package=com.company.shopping.cart, com.company.payment
 profiler.thread.match.package=

--- a/agent/src/main/resources/profiles/release/pinpoint-env.config
+++ b/agent/src/main/resources/profiles/release/pinpoint-env.config
@@ -1093,5 +1093,5 @@ profiler.jdk.concurrent.completable-future=true
 ###########################################################
 # which package of runnable(callable) instance can be thread plugin trace
 # Set the package name to track
-# eg) profiler.thread.match.package=com.company.shopping.cart
+# eg) profiler.thread.match.package=com.company.shopping.cart, com.company.payment
 profiler.thread.match.package=

--- a/plugins-it/thread-it/src/test/java/com/navercorp/test/pinpoint/plugin/thread/ThreadIT.java
+++ b/plugins-it/thread-it/src/test/java/com/navercorp/test/pinpoint/plugin/thread/ThreadIT.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.navercorp.test.pinpoint.plugin;
+package com.navercorp.test.pinpoint.plugin.thread;
 
 import com.navercorp.pinpoint.bootstrap.plugin.test.PluginTestVerifier;
 import com.navercorp.pinpoint.bootstrap.plugin.test.PluginTestVerifierHolder;
@@ -22,6 +22,7 @@ import com.navercorp.pinpoint.test.plugin.ImportPlugin;
 import com.navercorp.pinpoint.test.plugin.PinpointAgent;
 import com.navercorp.pinpoint.test.plugin.PinpointConfig;
 import com.navercorp.pinpoint.test.plugin.PinpointPluginTestSuite;
+import com.navercorp.test.pinpoint.plugin.thread.pkg.two.MockRunnable;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 

--- a/plugins-it/thread-it/src/test/java/com/navercorp/test/pinpoint/plugin/thread/Thread_multiple_base_packages_IT.java
+++ b/plugins-it/thread-it/src/test/java/com/navercorp/test/pinpoint/plugin/thread/Thread_multiple_base_packages_IT.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2020 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.test.pinpoint.plugin.thread;
+
+import com.navercorp.pinpoint.bootstrap.plugin.test.PluginTestVerifier;
+import com.navercorp.pinpoint.bootstrap.plugin.test.PluginTestVerifierHolder;
+import com.navercorp.pinpoint.pluginit.utils.AgentPath;
+import com.navercorp.pinpoint.test.plugin.ImportPlugin;
+import com.navercorp.pinpoint.test.plugin.PinpointAgent;
+import com.navercorp.pinpoint.test.plugin.PinpointConfig;
+import com.navercorp.pinpoint.test.plugin.PinpointPluginTestSuite;
+import com.navercorp.test.pinpoint.plugin.thread.pkg.one.MockCallable;
+import com.navercorp.test.pinpoint.plugin.thread.pkg.one.MockRunnable;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import static com.navercorp.pinpoint.bootstrap.plugin.test.Expectations.event;
+
+
+@RunWith(PinpointPluginTestSuite.class)
+@PinpointAgent(AgentPath.PATH)
+@ImportPlugin({"com.navercorp.pinpoint:pinpoint-thread-plugin"})
+@PinpointConfig("pinpoint-thread-test-multiple-pkg.config")
+public class Thread_multiple_base_packages_IT {
+
+    private static final String THREAD_ASYNC = "THREAD_ASYNC";
+
+    @Test
+    public void testRunnable() throws Exception {
+        Thread thread = new Thread(new MockRunnable());
+        thread.start();
+        thread.join(1000);
+
+        PluginTestVerifier verifier = PluginTestVerifierHolder.getInstance();
+        verifier.printCache();
+
+        verifier.verifyTrace(event(THREAD_ASYNC, MockRunnable.class.getConstructor()));
+        verifier.verifyTrace(event("ASYNC", "Asynchronous Invocation"));
+        verifier.verifyTrace(event(THREAD_ASYNC, MockRunnable.class.getMethod("run")));
+    }
+
+    @Test
+    public void testCallable() throws Exception {
+        ExecutorService executorService = Executors.newFixedThreadPool(2);
+        MockCallable mockCallable = new MockCallable("IT");
+        Future<String> callFuture = executorService.submit(mockCallable);
+        executorService.submit(mockCallable);
+        callFuture.get();
+
+        PluginTestVerifier verifier = PluginTestVerifierHolder.getInstance();
+        verifier.printCache();
+
+        verifier.verifyTrace(event(THREAD_ASYNC, MockCallable.class.getConstructor(String.class)));
+        verifier.verifyTrace(event("ASYNC", "Asynchronous Invocation"));
+        verifier.verifyTrace(event(THREAD_ASYNC, MockCallable.class.getMethod("call")));
+    }
+
+}

--- a/plugins-it/thread-it/src/test/java/com/navercorp/test/pinpoint/plugin/thread/pkg/one/MockCallable.java
+++ b/plugins-it/thread-it/src/test/java/com/navercorp/test/pinpoint/plugin/thread/pkg/one/MockCallable.java
@@ -1,0 +1,18 @@
+package com.navercorp.test.pinpoint.plugin.thread.pkg.one;
+
+import java.util.concurrent.Callable;
+
+public class MockCallable implements Callable<String> {
+
+    private String name;
+
+    public MockCallable(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String call() {
+        System.out.println("callable-----------------");
+        return this.name;
+    }
+};

--- a/plugins-it/thread-it/src/test/java/com/navercorp/test/pinpoint/plugin/thread/pkg/one/MockRunnable.java
+++ b/plugins-it/thread-it/src/test/java/com/navercorp/test/pinpoint/plugin/thread/pkg/one/MockRunnable.java
@@ -1,4 +1,4 @@
-package com.navercorp.test.pinpoint.plugin;
+package com.navercorp.test.pinpoint.plugin.thread.pkg.one;
 
 public class MockRunnable implements Runnable {
     public MockRunnable() {

--- a/plugins-it/thread-it/src/test/java/com/navercorp/test/pinpoint/plugin/thread/pkg/two/MockRunnable.java
+++ b/plugins-it/thread-it/src/test/java/com/navercorp/test/pinpoint/plugin/thread/pkg/two/MockRunnable.java
@@ -1,0 +1,11 @@
+package com.navercorp.test.pinpoint.plugin.thread.pkg.two;
+
+public class MockRunnable implements Runnable {
+    public MockRunnable() {
+    }
+
+    @Override
+    public void run() {
+        System.out.println("runnable-----------------");
+    }
+};

--- a/plugins-it/thread-it/src/test/resources/pinpoint-thread-test-multiple-pkg.config
+++ b/plugins-it/thread-it/src/test/resources/pinpoint-thread-test-multiple-pkg.config
@@ -380,4 +380,4 @@ profiler.netty.http=false
 
 
 #which package of runnable instance can be thread plugin trace.
-profiler.thread.match.package=com.navercorp.test.pinpoint.plugin.thread
+profiler.thread.match.package=com.navercorp.test.pinpoint.plugin.thread.pkg.one,com.navercorp.test.pinpoint.plugin.thread.pkg.two

--- a/plugins/thread/src/main/java/com/navercorp/pinpoint/plugin/thread/ThreadPlugin.java
+++ b/plugins/thread/src/main/java/com/navercorp/pinpoint/plugin/thread/ThreadPlugin.java
@@ -45,11 +45,8 @@ public class ThreadPlugin implements ProfilerPlugin, MatchableTransformTemplateA
         }
         List<String> threadMatchPackageList = StringUtils.tokenizeToStringList(threadMatchPackages, ",");
         for (String threadMatchPackage : threadMatchPackageList) {
-            String trimmedMatchPackage = threadMatchPackage.trim();
-            if(trimmedMatchPackage.length() > 0) {
-                addRunnableInterceptor(trimmedMatchPackage);
-                addCallableInterceptor(trimmedMatchPackage);
-            }
+            addRunnableInterceptor(threadMatchPackage);
+            addCallableInterceptor(threadMatchPackage);
         }
     }
 
@@ -63,8 +60,7 @@ public class ThreadPlugin implements ProfilerPlugin, MatchableTransformTemplateA
         public byte[] doInTransform(Instrumentor instrumentor, ClassLoader classLoader, String className, Class<?> classBeingRedefined, ProtectionDomain protectionDomain, byte[] classfileBuffer) throws InstrumentException {
             final InstrumentClass target = instrumentor.getInstrumentClass(classLoader, className, protectionDomain, classfileBuffer);
             List<InstrumentMethod> allConstructor = target.getDeclaredConstructors();
-            for (int i = 0; i < allConstructor.size(); i++) {
-                InstrumentMethod instrumentMethod = allConstructor.get(i);
+            for (InstrumentMethod instrumentMethod : allConstructor) {
                 instrumentMethod.addScopedInterceptor(ThreadConstructorInterceptor.class, ThreadConstants.SCOPE_NAME);
             }
             target.addField(AsyncContextAccessor.class);
@@ -86,8 +82,7 @@ public class ThreadPlugin implements ProfilerPlugin, MatchableTransformTemplateA
         public byte[] doInTransform(Instrumentor instrumentor, ClassLoader classLoader, String className, Class<?> classBeingRedefined, ProtectionDomain protectionDomain, byte[] classfileBuffer) throws InstrumentException {
             final InstrumentClass target = instrumentor.getInstrumentClass(classLoader, className, protectionDomain, classfileBuffer);
             List<InstrumentMethod> allConstructor = target.getDeclaredConstructors();
-            for (int i = 0; i < allConstructor.size(); i++) {
-                InstrumentMethod instrumentMethod = allConstructor.get(i);
+            for (InstrumentMethod instrumentMethod : allConstructor) {
                 instrumentMethod.addScopedInterceptor(ThreadConstructorInterceptor.class, ThreadConstants.SCOPE_NAME);
             }
             target.addField(AsyncContextAccessor.class);

--- a/plugins/thread/src/main/java/com/navercorp/pinpoint/plugin/thread/ThreadPlugin.java
+++ b/plugins/thread/src/main/java/com/navercorp/pinpoint/plugin/thread/ThreadPlugin.java
@@ -38,16 +38,23 @@ public class ThreadPlugin implements ProfilerPlugin, MatchableTransformTemplateA
         ThreadConfig threadConfig = new ThreadConfig(context.getConfig());
 
         logger.info("init {},config:{}", this.getClass().getSimpleName(), threadConfig);
-        if (StringUtils.isEmpty(threadConfig.getThreadMatchPackage())) {
+        String threadMatchPackages = threadConfig.getThreadMatchPackage();
+        if (StringUtils.isEmpty(threadMatchPackages)) {
             logger.info("thread plugin package is empty,skip it");
             return;
         }
-        addRunnableInterceptor(threadConfig);
-        addCallableInterceptor(threadConfig);
+        List<String> threadMatchPackageList = StringUtils.tokenizeToStringList(threadMatchPackages, ",");
+        for (String threadMatchPackage : threadMatchPackageList) {
+            String trimmedMatchPackage = threadMatchPackage.trim();
+            if(trimmedMatchPackage.length() > 0) {
+                addRunnableInterceptor(trimmedMatchPackage);
+                addCallableInterceptor(trimmedMatchPackage);
+            }
+        }
     }
 
-    private void addRunnableInterceptor(ThreadConfig threadConfig) {
-        Matcher matcher = Matchers.newPackageBasedMatcher(threadConfig.getThreadMatchPackage(), new InterfaceInternalNameMatcherOperand("java.lang.Runnable", true));
+    private void addRunnableInterceptor(String threadMatchPackage) {
+        Matcher matcher = Matchers.newPackageBasedMatcher(threadMatchPackage, new InterfaceInternalNameMatcherOperand("java.lang.Runnable", true));
         transformTemplate.transform(matcher, RunnableTransformCallback.class);
     }
 
@@ -69,8 +76,8 @@ public class ThreadPlugin implements ProfilerPlugin, MatchableTransformTemplateA
         }
     }
 
-    private void addCallableInterceptor(ThreadConfig threadConfig) {
-        Matcher matcher = Matchers.newPackageBasedMatcher(threadConfig.getThreadMatchPackage(), new InterfaceInternalNameMatcherOperand("java.util.concurrent.Callable", true));
+    private void addCallableInterceptor(String threadMatchPackage) {
+        Matcher matcher = Matchers.newPackageBasedMatcher(threadMatchPackage, new InterfaceInternalNameMatcherOperand("java.util.concurrent.Callable", true));
         transformTemplate.transform(matcher, CallableTransformCallback.class);
     }
 


### PR DESCRIPTION
- Feature
The config profiler.thread.match.package can now be configured with multiple package names, instead of one package name which includes all subpackages.
- Why do we need this feature?
Current profiler.thread.match.package config entity only support one package. If we want to trace com.example.bizA.async and com.example.bizB.async, the config value can only be com.example(which may matches too many packages, com.example.bizC would be included).
