### PR TITLE
[#6798] Parse max range of response time on filtering

### DIFF
--- a/web/src/main/angular/src/app/core/components/filter-transaction-wizard-popup/filter-transaction-wizard-popup.component.html
+++ b/web/src/main/angular/src/app/core/components/filter-transaction-wizard-popup/filter-transaction-wizard-popup.component.html
@@ -73,8 +73,8 @@
                 [step]="100" 
                 [format]="getTimeFormatter()" 
                 [tooltips]="[true, true]" 
-                [(ngModel)]="responseTimeRange"
-            ></nouislider>
+                [(ngModel)]="responseTimeRange">
+            </nouislider>
             <div class="l-range-info">
                 <span>{{responseTimeMin.toLocaleString()}} ms</span>
                 <span class="l-range-text">Range {{(responseTimeRange[1] - responseTimeRange[0]).toLocaleString()}} ms</span>

--- a/web/src/main/angular/src/app/core/components/filter-transaction-wizard-popup/filter-transaction-wizard-popup.component.ts
+++ b/web/src/main/angular/src/app/core/components/filter-transaction-wizard-popup/filter-transaction-wizard-popup.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit, Input, Output, EventEmitter, HostBinding } from '@angular/core';
 import { NouiFormatter } from 'ng2-nouislider';
 
-import { Filter } from 'app/core/models/';
+import { Filter, ResponseRange } from 'app/core/models/';
 
 export class TimeFormatter implements NouiFormatter {
     to(value: number): string {
@@ -37,9 +37,9 @@ export class FilterTransactionWizardPopupComponent implements OnInit {
     selectedFromAgent = AGENT_ALL;
     selectedToAgent = AGENT_ALL;
     urlPattern = '';
-    responseTimeMin = 0;
-    responseTimeMax = 30000;
-    responseTimeRange = [0, 30000];
+    responseTimeMin = ResponseRange.MIN;
+    responseTimeMax = ResponseRange.MAX;
+    responseTimeRange = [ResponseRange.MIN, ResponseRange.MAX];
 
     constructor() {}
     ngOnInit() {

--- a/web/src/main/angular/src/app/core/components/server-map/server-map-for-filtered-map-container.component.html
+++ b/web/src/main/angular/src/app/core/components/server-map/server-map-for-filtered-map-container.component.html
@@ -8,6 +8,7 @@
             (outContextClickBackground)="onContextClickBackground($event)"
             (outClickNode)="onClickNode($event)"
             (outClickLink)="onClickLink($event)"
+            (outContextClickNode)="onContextClickNode($event)"
             (outContextClickLink)="onContextClickLink($event)"
             (outRenderCompleted)="onRenderCompleted()">
         </pp-server-map>

--- a/web/src/main/angular/src/app/core/components/server-map/server-map-for-filtered-map-container.component.ts
+++ b/web/src/main/angular/src/app/core/components/server-map/server-map-for-filtered-map-container.component.ts
@@ -92,7 +92,7 @@ export class ServerMapForFilteredMapContainerComponent implements OnInit, OnDest
             this.mapData = new ServerMapData(
                 this.mergedNodeDataList,
                 this.mergedLinkDataList,
-                Filter.instanceFromString(this.newUrlStateNotificationService.hasValue(UrlQuery.FILTER) ? this.newUrlStateNotificationService.getPathValue(UrlQuery.FILTER) : '')
+                Filter.instanceFromString(this.newUrlStateNotificationService.hasValue(UrlQuery.FILTER) ? this.newUrlStateNotificationService.getQueryValue(UrlQuery.FILTER) : '')
             );
             this.isEmpty = this.mapData.getNodeCount() === 0;
             this.messageQueueService.sendMessage({
@@ -253,6 +253,7 @@ export class ServerMapForFilteredMapContainerComponent implements OnInit, OnDest
 
     onContextClickNode({key, coord}: {key: string, coord: ICoordinate}): void {
         const nodeData = this.mapData.getNodeData(key);
+
         if (nodeData.isWas) {
             this.dynamicPopupService.openPopup({
                 data: nodeData,


### PR DESCRIPTION
- Parse it as `max` when it sets as the max range
- Correct the comparing filter logic
- Add the missing callback on context clicking on node in filter page