### PR TITLE
Copy the quickstart window guide file to doc directory for the follow…

### DIFF
--- a/doc/quickstart.Win.en.md
+++ b/doc/quickstart.Win.en.md
@@ -1,0 +1,46 @@
+# Running QuickStart on Windows
+
+## Starting
+Download Pinpoint with `git clone https://github.com/naver/pinpoint.git` or [download](https://github.com/naver/pinpoint/archive/master.zip) the project as a zip file and unzip.
+
+Install Pinpoint by running `mvnw.cmd install -DskipTests=true`
+
+### Notice
+If you run QuickStart's cmd file on Windows, you must run it at `quickstart\bin` directory.
+
+If you want to run it in a different directory, you need to set the absolute path of the `quickstart\bin` directory in the `QUICKSTART_BIN_PATH` environment variable.
+
+### Install & Start HBase
+Download `HBase-1.0.x-bin.tar.gz` from [Apache download site](http://apache.mirror.cdnetworks.com/hbase/)) and unzip it to `quickstart\hbase` directory.
+
+Rename the unzipped directory to `hbase` so that the final HBase directory looks like `quickstart\hbase\hbase`.
+
+**Start HBase** - Run `start-hbase.cmd`
+
+**Initialize Tables** - Run `init-hbase.cmd`
+
+### Start Pinpoint Daemons
+
+**Collector** - Run `start-collector.cmd`
+
+**TestApp** - Run `start-testapp.cmd`
+
+**Web UI** - Run `start-web.cmd`
+
+### Check Status
+Once HBase and the 3 daemons are running, you may visit the following addresses to test out your very own Pinpoint instance.
+
+* Web UI - http://localhost:28080
+* TestApp - http://localhost:28081
+
+You can feed trace data to Pinpoint using the TestApp UI, and check them using Pinpoint Web UI. TestApp registers itself as *test-agent* under *TESTAPP*.
+
+## Stopping
+
+**Web UI** - Run `stop-web.cmd`
+
+**TestApp** - Run `stop-testapp.cmd`
+
+**Collector** - Run `stop-collector.cmd`
+
+**HBase** - Run `stop-hbase.cmd`

--- a/doc/quickstart.Win.ko.md
+++ b/doc/quickstart.Win.ko.md
@@ -1,0 +1,48 @@
+# Windows 환경에서 QuickStart 실행하기
+Pinpoint는 공식적으로는 Linux와 OS X를 지원한다. 하지만 Pinpoint와 HBase 모두 Java 기술을 사용하고 있기 때문에 QuickStart를 Windows에서도 실행할 수 있다. 여기에서는 Windows 환경에서 Cygwin을 사용하지 않고 HBase와 Pinpoint를 실행하는 것에 대해 설명한다.
+
+## 시작하기
+
+`git clone https://github.com/naver/pinpoint.git`로 Pinpoint를 다운로드 하거나 zip 파일로 프로젝트를 [다운로드](https://github.com/naver/pinpoint/archive/master.zip)하고 압축을 해제한다.
+
+`mvnw.cmd install -DskipTests=true`를 실행하여 Pinpoint를 설치한다.
+
+### 주의사항
+윈도우에서 QuickStart의 cmd파일을 실행할 경우 반드시, `quickstart\bin` 디렉토리의 위치에서 실행해야 한다.
+
+만약 다른 디렉토리에서 실행하고 싶다면, `QUICKSTART_BIN_PATH` 환경변수에 `quickstart\bin` 디렉토리의 절대 경로를 설정 해야 한다.
+
+### 설치 및 HBase 시작하기
+**[Apache 다운로드 사이트](http://apache.mirror.cdnetworks.com/hbase/)에서 HBase 1.0.x 버전을 다운로드 받는다.
+
+**다운로드 받은 파일을 quickstart\hbase 디렉토리에 압축을 풀고 디렉토리 이름을 hbase로 변경하여 `quickstart\hbase\hbase`로 만든다.
+
+**HBase 시작** - `start-hbase.cmd` 실행
+
+**테이블 초기화** - `init-hbase.cmd` 실행
+
+### Pinpoint 데몬 시작하기
+
+**Collector** - `start-collector.cmd` 실행
+
+**TestApp** - `start-testapp.cmd` 실행
+
+**Web UI** - `start-web.cmd` 실행
+
+### 상태 확인
+HBase와 3개 데몬이 실행한 후 Pinpoint 인스턴스를 테스트하려면 아래 주소로 접속한다.
+
+* Web UI - http://localhost:28080
+* TestApp - http://localhost:28081
+
+TestApp UI를 사용하여 Pinpoint로 추적 데이터를 전송하고, Pinpoint Web UI를 통해 해당 데이터들을 확인할 수 있다. TestApp은 *TESTAPP*에 *test-agent*로 등록된다.
+
+## 종료하기
+
+**Web UI** - `stop-web.cmd` 실행
+
+**TestApp** - `stop-testapp.cmd` 실행
+
+**Collector** - `stop-collector.cmd` 실행
+
+**HBase** - `stop-hbase.cmd` 실행

--- a/doc/quickstart.md
+++ b/doc/quickstart.md
@@ -42,12 +42,6 @@ Install Pinpoint by running `./mvnw install -DskipTests=true`
 
 The following script downloads HBase standalone from [Apache download site](http://apache.mirror.cdnetworks.com/hbase/).
 
-> Download `HBase-1.0.3-bin.tar.gz` and unzip it.
-> 
-> Rename the directory to `hbase` so that the final HBase directory looks like `quickstart\hbase\hbase`.
-> 
-> Also note that you should run the scripts below by their corresponding `.cmd` files.
-
 **Download & Start** - Run `quickstart/bin/start-hbase.sh`
 
 **Initialize Tables** - Run `quickstart/bin/init-hbase.sh`
@@ -98,7 +92,7 @@ You can feed trace data to Pinpoint using the TestApp UI, and check them using P
 ## Extra
 
 ### Running in Windows 
-Please ref this [link](../quickstart/README.Win.en.md)
+Please ref this [link](./quickstart.Win.en.md)
 
 ### Using mysql
 Pinpoint Web uses Mysql to persist users, user groups, and alarm configurations.<br/>

--- a/quickstart/README.md
+++ b/quickstart/README.md
@@ -26,14 +26,6 @@ Install Pinpoint by running `./mvnw install -DskipTests=true`
 
 The following script downloads HBase standalone from [Apache download site](http://apache.mirror.cdnetworks.com/hbase/).
 
-> **For Windows**, you'll have to download HBase manually from [Apache download site](http://apache.mirror.cdnetworks.com/hbase/).
-> 
-> Download `HBase-1.0.3-bin.tar.gz` and unzip it.
-> 
-> Rename the directory to `hbase` so that the final HBase directory looks like `quickstart\hbase\hbase`.
-> 
-> Also note that you should run the scripts below by their corresponding `.cmd` files.
-
 **Download & Start** - Run `quickstart/bin/start-hbase.sh`
 
 **Initialize Tables** - Run `quickstart/bin/init-hbase.sh`
@@ -76,6 +68,10 @@ You can feed trace data to Pinpoint using the TestApp UI, and check them using P
 
 ## Extra
 
+### Running in Windows 
+Please ref this [link](./README.Win.en.md)
+
+### Using mysql
 Pinpoint Web uses Mysql to persist users, user groups, and alarm configurations.<br/>
 However Quickstart uses MockDAO to reduce memory usage.<br/>
 Therefore if you want to use Mysql for Quickstart, please refer to Pinpoint Web's [applicationContext-dao-config.xml


### PR DESCRIPTION
…ing reasons:

 - In `naver.github.io/pinpoint`, Only internal guides inside the doc directory are allowed.
 - It is difficult to know all the windows quickstart guides using only the quickstart.READEME file.