### PR TITLE
Fix the incorrect behavior of collecting old gen gc info in DetailedG…

### DIFF
--- a/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/provider/stat/jvmgc/DetailedGarbageCollectorMetricProvider.java
+++ b/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/provider/stat/jvmgc/DetailedGarbageCollectorMetricProvider.java
@@ -48,8 +48,8 @@ public class DetailedGarbageCollectorMetricProvider implements Provider<Detailed
         DetailedGarbageCollectorMetric detailedGarbageCollectorMetric = null;
         Map<String, GarbageCollectorMXBean> garbageCollectorMap = createGarbageCollectorMap();
         for (GarbageCollectorType garbageCollectorType : GarbageCollectorType.values()) {
-            if (garbageCollectorMap.containsKey(garbageCollectorType.oldGenName())) {
-                GarbageCollectorMXBean garbageCollectorMXBean = garbageCollectorMap.get(garbageCollectorType.oldGenName());
+            if (garbageCollectorMap.containsKey(garbageCollectorType.newGenName())) {
+                GarbageCollectorMXBean garbageCollectorMXBean = garbageCollectorMap.get(garbageCollectorType.newGenName());
                 detailedGarbageCollectorMetric = new DefaultDetailedGarbageCollectorMetric(garbageCollectorType, garbageCollectorMXBean);
                 break;
             }


### PR DESCRIPTION
…arbageCollectorMetricProvider

According to the [DetailedGarbageCollectorMetricSnapshot.java](https://github.com/naver/pinpoint/blob/master/profiler/src/main/java/com/navercorp/pinpoint/profiler/monitor/metric/gc/DetailedGarbageCollectorMetricSnapshot.java), the DetailedGarbageCollectorMetricProvider should collect the young gen gc info.
```
public class DetailedGarbageCollectorMetricSnapshot {

    private final long gcNewCount;
    private final long gcNewTime;

}
```

 And the old gen gc info is collected by GarbageCollectorMetricProvider.
```
public class GarbageCollectorMetricProvider implements Provider<GarbageCollectorMetric> {

    private final Logger logger = LoggerFactory.getLogger(this.getClass());

    @Inject
    public GarbageCollectorMetricProvider() {
    }

    @Override
    public GarbageCollectorMetric get() {
        GarbageCollectorMetric garbageCollectorMetric = null;
        Map<String, GarbageCollectorMXBean> garbageCollectorMap = createGarbageCollectorMap();
        for (GarbageCollectorType garbageCollectorType : GarbageCollectorType.values()) {
            if (garbageCollectorMap.containsKey(garbageCollectorType.oldGenName())) {
                GarbageCollectorMXBean garbageCollectorMXBean = garbageCollectorMap.get(garbageCollectorType.oldGenName());
                garbageCollectorMetric = new DefaultGarbageCollectorMetric(garbageCollectorType, garbageCollectorMXBean);
                break;
            }
        }
        if (garbageCollectorMetric == null) {
            garbageCollectorMetric = new UnknownGarbageCollectorMetric();
        }
        logger.info("loaded : {}", garbageCollectorMetric);
        return garbageCollectorMetric;
    }
}
```