### PR TITLE
fix period-selector maxPeriodTime issue

### DIFF
--- a/web/src/main/angular/src/app/core/components/period-selector/period-selector-container.component.ts
+++ b/web/src/main/angular/src/app/core/components/period-selector/period-selector-container.component.ts
@@ -51,7 +51,7 @@ export class PeriodSelectorContainerComponent implements OnInit, OnDestroy {
 
     ngOnInit() {
         this.periodList = this.webAppSettingDataService.getPeriodList(this.newUrlStateNotificationService.getStartPath());
-        this.maxPeriod = this.periodList[this.periodList.length - 1].getValue();
+        this.maxPeriod = this.webAppSettingDataService.getMaxPeriodTime();
         this.getI18NText();
         this.newUrlStateNotificationService.onUrlStateChange$.pipe(
             takeUntil(this.unsubscribe),


### PR DESCRIPTION
1. Change the MAX_SEARCH_PERIOD hint message from days unit to hours unit. Please verify that the I18n text(hours= 시간) is correct. Using hours may be more convenient.
2. The maxPeriod value could be read from getMaxPeriodTime config, it was the last value of periodList.