### PR TITLE
Clarify milliseconds is a 13 digit number

### DIFF
--- a/doc/proxy-http-header.md
+++ b/doc/proxy-http-header.md
@@ -79,10 +79,10 @@ http {
 **t=$msec is required value.**
 
 ### App
-Milliseconds since epoch and app information.
+Milliseconds since epoch (13 digits) and app information.
 
 Add HTTP header.
 ~~~
-Pinpoint-ProxyApp: t=1502861340 app=foo-bar
+Pinpoint-ProxyApp: t=1594316309407 app=foo-bar
 ~~~
 **t=epoch is required value.**


### PR DESCRIPTION
The 10 digit example did not work, and after research found that an epoch in milliseconds is 13 digits, updated the documentation to reflect a 13 digit example