### PR TITLE
[#6952] Fixed GrpcCommandDispatcher closing in wrong situation

### DIFF
--- a/profiler/src/main/java/com/navercorp/pinpoint/profiler/receiver/grpc/GrpcCommandService.java
+++ b/profiler/src/main/java/com/navercorp/pinpoint/profiler/receiver/grpc/GrpcCommandService.java
@@ -151,7 +151,6 @@ public class GrpcCommandService {
                 requestStream.onError(t);
             }
 
-            commandDispatcher.close();
             reserveReconnect();
         }
 
@@ -159,7 +158,6 @@ public class GrpcCommandService {
         public void onCompleted() {
             logger.info("onCompleted");
             StreamUtils.close(requestStream);
-            commandDispatcher.close();
             // TODO : needs to check whether needs new action
             reserveReconnect();
         }


### PR DESCRIPTION
I changed to reuse GrpcCommandDispatcher via #6952 issue.
But whenever Grpc's stream is disconnected, I leaved the logic to close GrpcCommandDispatcher.
So the problem occurred after the stream was terminated.
For solving this issue, I am going to change to close GrpcCommandDispatcher only when the agent shutdown.