### PR TITLE
[#7012] Add com.mysql.jbdc.ServerPreparedStatement to addPreparedStatementTransformer

### DIFF
--- a/plugins/mysql-jdbc/src/main/java/com/navercorp/pinpoint/plugin/jdbc/mysql/MySqlPlugin.java
+++ b/plugins/mysql-jdbc/src/main/java/com/navercorp/pinpoint/plugin/jdbc/mysql/MySqlPlugin.java
@@ -212,8 +212,8 @@ public class MySqlPlugin implements ProfilerPlugin, TransformTemplateAware {
     };
 
     private void addPreparedStatementTransformer(final MySqlConfig config) {
-
         transformTemplate.transform("com.mysql.jdbc.PreparedStatement", PreparedStatementTransform.class);
+        transformTemplate.transform("com.mysql.jdbc.ServerPreparedStatement", PreparedStatementTransform.class);
         // 6.x+
         transformTemplate.transform("com.mysql.cj.jdbc.PreparedStatement", PreparedStatementTransform.class);
         // 8.0.11+


### PR DESCRIPTION
Added com.mysql.jbdc.ServerPreparedStatement to addPreparedStatementTransformer.

Screenshot shows bind value correctly shown with mysql-connector-java:5.1.36 and useServerPrepStmts=true

![Screen Shot 2020-07-14 at 1 46 36 PM](https://user-images.githubusercontent.com/3798235/87385712-b694c680-c5d9-11ea-82d7-289df4015b46.png)
