### PR TITLE
Fix DB URL null:null

### DIFF
--- a/plugins/informix-jdbc/src/main/java/com/navercorp/pinpoint/plugin/jdbc/informix/interceptor/InformixPreparedStatementCreateInterceptor.java
+++ b/plugins/informix-jdbc/src/main/java/com/navercorp/pinpoint/plugin/jdbc/informix/interceptor/InformixPreparedStatementCreateInterceptor.java
@@ -61,7 +61,12 @@ public class InformixPreparedStatementCreateInterceptor extends SpanEventSimpleA
 
     @Override
     public void doInBeforeTrace(SpanEventRecorder recorder, Object target, Object[] args)  {
-        final DatabaseInfo databaseInfo = getDatabaseInfo(target);
+        DatabaseInfo databaseInfo = (target instanceof DatabaseInfoAccessor) ? ((DatabaseInfoAccessor)target)._$PINPOINT$_getDatabaseInfo() : null;  
+        
+        if(databaseInfo == null) {
+            databaseInfo = getDatabaseInfo(target);
+        }
+
         if (target instanceof DatabaseInfoAccessor) {
             ((DatabaseInfoAccessor) target)._$PINPOINT$_setDatabaseInfo(databaseInfo);
         }


### PR DESCRIPTION
InformixPreparedStatementCreateInterceptor now tries to access databaseInfo from the previously recorded info, and creating new info when this info is not available. Before the patch, It always tried to create the info from the class, but sometimes the URL was not available, leaving a connection to null:null.

![Screenshot_20200721_123620](https://user-images.githubusercontent.com/16609390/88045969-a63b9900-cb4f-11ea-8604-63ba75ba4a76.png)
