### PR TITLE
[#7067] Fix incorrectly selecting node when acquiring CallStack

### DIFF
--- a/web/src/main/java/com/navercorp/pinpoint/web/calltree/span/LinkMap.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/calltree/span/LinkMap.java
@@ -69,7 +69,7 @@ public class LinkMap {
                     if (span.getCollectorAcceptTime() == collectorAcceptTime) {
                         // replace value
                         spanToLinkMap.put(spanIdPairKey, Collections.singletonList(node));
-                        duplicatedNodeList.add(node);
+                        duplicatedNodeList.add(firstNode);
                         logger.warn("Duplicated span - choose focus {}", node);
                     } else {
                         // add remove list


### PR DESCRIPTION
Change the nodes to include as duplicates
((bug)currentNode -> existNode)