### PR TITLE
[#noissue] fix typo : HbaseTableConstatns to HbaseTableConstants

### DIFF
--- a/collector/src/main/java/com/navercorp/pinpoint/collector/dao/hbase/HbaseAgentEventDao.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/dao/hbase/HbaseAgentEventDao.java
@@ -20,7 +20,7 @@ import com.navercorp.pinpoint.collector.dao.AgentEventDao;
 import com.navercorp.pinpoint.collector.util.CollectorUtils;
 import com.navercorp.pinpoint.common.hbase.HbaseColumnFamily;
 import com.navercorp.pinpoint.common.hbase.HbaseOperations2;
-import com.navercorp.pinpoint.common.hbase.HbaseTableConstatns;
+import com.navercorp.pinpoint.common.hbase.HbaseTableConstants;
 import com.navercorp.pinpoint.common.hbase.TableDescriptor;
 import com.navercorp.pinpoint.common.hbase.ValueMapper;
 import com.navercorp.pinpoint.common.server.bo.event.AgentEventBo;
@@ -84,6 +84,6 @@ public class HbaseAgentEventDao implements AgentEventDao {
     byte[] createRowKey(String agentId, long eventTimestamp) {
         byte[] agentIdKey = BytesUtils.toBytes(agentId);
         long reverseStartTimestamp = TimeUtils.reverseTimeMillis(eventTimestamp);
-        return RowKeyUtils.concatFixedByteAndLong(agentIdKey, HbaseTableConstatns.AGENT_NAME_MAX_LEN, reverseStartTimestamp);
+        return RowKeyUtils.concatFixedByteAndLong(agentIdKey, HbaseTableConstants.AGENT_NAME_MAX_LEN, reverseStartTimestamp);
     }
 }

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/dao/hbase/HbaseAgentInfoDao.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/dao/hbase/HbaseAgentInfoDao.java
@@ -20,7 +20,7 @@ import com.navercorp.pinpoint.collector.dao.AgentInfoDao;
 import com.navercorp.pinpoint.collector.util.CollectorUtils;
 import com.navercorp.pinpoint.common.hbase.HbaseColumnFamily;
 import com.navercorp.pinpoint.common.hbase.HbaseOperations2;
-import com.navercorp.pinpoint.common.hbase.HbaseTableConstatns;
+import com.navercorp.pinpoint.common.hbase.HbaseTableConstants;
 import com.navercorp.pinpoint.common.hbase.TableDescriptor;
 import com.navercorp.pinpoint.common.server.bo.AgentInfoBo;
 import com.navercorp.pinpoint.common.server.util.RowKeyUtils;
@@ -66,7 +66,7 @@ public class HbaseAgentInfoDao implements AgentInfoDao {
 
         final byte[] agentId = Bytes.toBytes(agentInfo.getAgentId());
         final long reverseKey = TimeUtils.reverseTimeMillis(agentInfo.getStartTime());
-        final byte[] rowKey = RowKeyUtils.concatFixedByteAndLong(agentId, HbaseTableConstatns.AGENT_NAME_MAX_LEN, reverseKey);
+        final byte[] rowKey = RowKeyUtils.concatFixedByteAndLong(agentId, HbaseTableConstants.AGENT_NAME_MAX_LEN, reverseKey);
         final Put put = new Put(rowKey);
 
         // should add additional agent informations. for now added only starttime for sqlMetaData

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/dao/hbase/HbaseAgentLifeCycleDao.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/dao/hbase/HbaseAgentLifeCycleDao.java
@@ -20,7 +20,7 @@ import com.navercorp.pinpoint.collector.dao.AgentLifeCycleDao;
 import com.navercorp.pinpoint.collector.util.CollectorUtils;
 import com.navercorp.pinpoint.common.hbase.HbaseColumnFamily;
 import com.navercorp.pinpoint.common.hbase.HbaseOperations2;
-import com.navercorp.pinpoint.common.hbase.HbaseTableConstatns;
+import com.navercorp.pinpoint.common.hbase.HbaseTableConstants;
 import com.navercorp.pinpoint.common.hbase.TableDescriptor;
 import com.navercorp.pinpoint.common.hbase.ValueMapper;
 import com.navercorp.pinpoint.common.server.bo.AgentLifeCycleBo;
@@ -81,9 +81,9 @@ public class HbaseAgentLifeCycleDao implements AgentLifeCycleDao {
         long reverseStartTimestamp = TimeUtils.reverseTimeMillis(startTimestamp);
         long reverseEventCounter = TimeUtils.reverseTimeMillis(eventIdentifier);
 
-        byte[] rowKey = new byte[HbaseTableConstatns.AGENT_NAME_MAX_LEN + BytesUtils.LONG_BYTE_LENGTH + BytesUtils.LONG_BYTE_LENGTH];
+        byte[] rowKey = new byte[HbaseTableConstants.AGENT_NAME_MAX_LEN + BytesUtils.LONG_BYTE_LENGTH + BytesUtils.LONG_BYTE_LENGTH];
         BytesUtils.writeBytes(rowKey, 0, agentIdKey);
-        int offset = HbaseTableConstatns.AGENT_NAME_MAX_LEN;
+        int offset = HbaseTableConstants.AGENT_NAME_MAX_LEN;
         BytesUtils.writeLong(reverseStartTimestamp, rowKey, offset);
         offset += BytesUtils.LONG_BYTE_LENGTH;
         BytesUtils.writeLong(reverseEventCounter, rowKey, offset);

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/dao/hbase/HbaseApplicationTraceIndexDao.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/dao/hbase/HbaseApplicationTraceIndexDao.java
@@ -22,7 +22,7 @@ import com.navercorp.pinpoint.common.buffer.AutomaticBuffer;
 import com.navercorp.pinpoint.common.buffer.Buffer;
 import com.navercorp.pinpoint.common.hbase.HbaseColumnFamily;
 import com.navercorp.pinpoint.common.hbase.HbaseOperations2;
-import com.navercorp.pinpoint.common.hbase.HbaseTableConstatns;
+import com.navercorp.pinpoint.common.hbase.HbaseTableConstants;
 import com.navercorp.pinpoint.common.hbase.TableDescriptor;
 import com.navercorp.pinpoint.common.server.bo.SpanBo;
 import com.navercorp.pinpoint.common.server.util.AcceptedTimeService;
@@ -79,7 +79,7 @@ public class HbaseApplicationTraceIndexDao implements ApplicationTraceIndexDao {
         // Assert applicationName
         CollectorUtils.checkApplicationName(span.getApplicationId());
 
-        final Buffer buffer = new AutomaticBuffer(10 + HbaseTableConstatns.AGENT_NAME_MAX_LEN);
+        final Buffer buffer = new AutomaticBuffer(10 + HbaseTableConstants.AGENT_NAME_MAX_LEN);
         buffer.putVInt(span.getElapsed());
         buffer.putSVInt(span.getErrCode());
         buffer.putPrefixedString(span.getAgentId());

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/dao/hbase/HbaseHostApplicationMapDao.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/dao/hbase/HbaseHostApplicationMapDao.java
@@ -23,7 +23,7 @@ import com.navercorp.pinpoint.common.buffer.AutomaticBuffer;
 import com.navercorp.pinpoint.common.buffer.Buffer;
 import com.navercorp.pinpoint.common.hbase.HbaseColumnFamily;
 import com.navercorp.pinpoint.common.hbase.HbaseOperations2;
-import com.navercorp.pinpoint.common.hbase.HbaseTableConstatns;
+import com.navercorp.pinpoint.common.hbase.HbaseTableConstants;
 import com.navercorp.pinpoint.common.hbase.TableDescriptor;
 import com.navercorp.pinpoint.common.server.util.AcceptedTimeService;
 import com.navercorp.pinpoint.common.server.util.TimeSlot;
@@ -139,13 +139,13 @@ public class HbaseHostApplicationMapDao implements HostApplicationMapDao {
 
         // even if  a agentId be added for additional specifications, it may be safe to scan rows.
         // But is it needed to add parentAgentServiceType?
-        final int SIZE = HbaseTableConstatns.APPLICATION_NAME_MAX_LEN + 2 + 8;
+        final int SIZE = HbaseTableConstants.APPLICATION_NAME_MAX_LEN + 2 + 8;
         final Buffer rowKeyBuffer = new AutomaticBuffer(SIZE);
-        rowKeyBuffer.putPadString(parentApplicationName, HbaseTableConstatns.APPLICATION_NAME_MAX_LEN);
+        rowKeyBuffer.putPadString(parentApplicationName, HbaseTableConstants.APPLICATION_NAME_MAX_LEN);
         rowKeyBuffer.putShort(parentServiceType);
         rowKeyBuffer.putLong(TimeUtils.reverseTimeMillis(statisticsRowSlot));
         // there is no parentAgentId for now.  if it added later, need to comment out below code for compatibility.
-//        rowKeyBuffer.putPadString(parentAgentId, HbaseTableConstatns.AGENT_NAME_MAX_LEN);
+//        rowKeyBuffer.putPadString(parentAgentId, HbaseTableConstants.AGENT_NAME_MAX_LEN);
         return rowKeyBuffer.getBuffer();
     }
 

--- a/collector/src/test/java/com/navercorp/pinpoint/collector/dao/hbase/HbaseHostApplicationMapDaoTest.java
+++ b/collector/src/test/java/com/navercorp/pinpoint/collector/dao/hbase/HbaseHostApplicationMapDaoTest.java
@@ -18,7 +18,7 @@ package com.navercorp.pinpoint.collector.dao.hbase;
 
 import com.navercorp.pinpoint.common.buffer.Buffer;
 import com.navercorp.pinpoint.common.buffer.FixedBuffer;
-import com.navercorp.pinpoint.common.hbase.HbaseTableConstatns;
+import com.navercorp.pinpoint.common.hbase.HbaseTableConstants;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.common.server.util.DefaultTimeSlot;
 import com.navercorp.pinpoint.common.server.util.TimeSlot;
@@ -43,7 +43,7 @@ public class HbaseHostApplicationMapDaoTest {
         logger.debug("rowKey size:{}", parentApps.length);
 
         Buffer readBuffer = new FixedBuffer(parentApps);
-        String appName = readBuffer.readPadStringAndRightTrim(HbaseTableConstatns.APPLICATION_NAME_MAX_LEN);
+        String appName = readBuffer.readPadStringAndRightTrim(HbaseTableConstants.APPLICATION_NAME_MAX_LEN);
         short code = readBuffer.readShort();
         long time = TimeUtils.recoveryTimeMillis(readBuffer.readLong());
 

--- a/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/HbaseTableConstants.java
+++ b/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/HbaseTableConstants.java
@@ -21,7 +21,7 @@ import com.navercorp.pinpoint.common.PinpointConstants;
 /**
  * @author Taejin Koo
  */
-public final class HbaseTableConstatns {
+public final class HbaseTableConstants {
 
     public static final int APPLICATION_NAME_MAX_LEN = PinpointConstants.APPLICATION_NAME_MAX_LEN;
     public static final int AGENT_NAME_MAX_LEN = PinpointConstants.AGENT_NAME_MAX_LEN;

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/stat/AgentStatRowKeyDecoder.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/stat/AgentStatRowKeyDecoder.java
@@ -23,7 +23,7 @@ import com.navercorp.pinpoint.common.util.TimeUtils;
 
 import org.springframework.stereotype.Component;
 
-import static com.navercorp.pinpoint.common.hbase.HbaseTableConstatns.AGENT_NAME_MAX_LEN;
+import static com.navercorp.pinpoint.common.hbase.HbaseTableConstants.AGENT_NAME_MAX_LEN;
 import static com.navercorp.pinpoint.common.server.bo.stat.AgentStatType.TYPE_CODE_BYTE_LENGTH;
 
 /**

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/stat/AgentStatRowKeyEncoder.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/stat/AgentStatRowKeyEncoder.java
@@ -22,7 +22,7 @@ import com.navercorp.pinpoint.common.util.TimeUtils;
 
 import org.springframework.stereotype.Component;
 
-import static com.navercorp.pinpoint.common.hbase.HbaseTableConstatns.AGENT_NAME_MAX_LEN;
+import static com.navercorp.pinpoint.common.hbase.HbaseTableConstants.AGENT_NAME_MAX_LEN;
 
 /**
  * @author HyunGil Jeong

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/stat/ApplicationStatRowKeyDecoder.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/stat/ApplicationStatRowKeyDecoder.java
@@ -22,7 +22,7 @@ import com.navercorp.pinpoint.common.util.TimeUtils;
 
 import org.springframework.stereotype.Component;
 
-import static com.navercorp.pinpoint.common.hbase.HbaseTableConstatns.APPLICATION_NAME_MAX_LEN;
+import static com.navercorp.pinpoint.common.hbase.HbaseTableConstants.APPLICATION_NAME_MAX_LEN;
 import static com.navercorp.pinpoint.common.server.bo.stat.join.StatType.TYPE_CODE_BYTE_LENGTH;
 
 

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/stat/ApplicationStatRowKeyEncoder.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/stat/ApplicationStatRowKeyEncoder.java
@@ -21,7 +21,7 @@ import com.navercorp.pinpoint.common.util.TimeUtils;
 
 import org.springframework.stereotype.Component;
 
-import static com.navercorp.pinpoint.common.hbase.HbaseTableConstatns.APPLICATION_NAME_MAX_LEN;
+import static com.navercorp.pinpoint.common.hbase.HbaseTableConstants.APPLICATION_NAME_MAX_LEN;
 
 /**
  * @author minwoo.jung

--- a/flink/src/main/java/com/navercorp/pinpoint/flink/process/ApplicationCache.java
+++ b/flink/src/main/java/com/navercorp/pinpoint/flink/process/ApplicationCache.java
@@ -15,7 +15,7 @@
  */
 package com.navercorp.pinpoint.flink.process;
 
-import com.navercorp.pinpoint.common.hbase.HbaseTableConstatns;
+import com.navercorp.pinpoint.common.hbase.HbaseTableConstants;
 import com.navercorp.pinpoint.common.hbase.HbaseTemplate2;
 import com.navercorp.pinpoint.common.hbase.TableNameProvider;
 import com.navercorp.pinpoint.common.server.util.RowKeyUtils;
@@ -58,7 +58,7 @@ public class ApplicationCache {
     public String findApplicationId(ApplicationKey application) {
         final String agentId = application.getAgentId();
         final long agentStartTimestamp = application.getAgentStartTime();
-        final byte[] rowKey = RowKeyUtils.concatFixedByteAndLong(Bytes.toBytes(agentId), HbaseTableConstatns.AGENT_NAME_MAX_LEN, TimeUtils.reverseTimeMillis(agentStartTimestamp));
+        final byte[] rowKey = RowKeyUtils.concatFixedByteAndLong(Bytes.toBytes(agentId), HbaseTableConstants.AGENT_NAME_MAX_LEN, TimeUtils.reverseTimeMillis(agentStartTimestamp));
 
         Get get = new Get(rowKey);
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/dao/hbase/HbaseAgentEventDao.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/dao/hbase/HbaseAgentEventDao.java
@@ -18,7 +18,7 @@ package com.navercorp.pinpoint.web.dao.hbase;
 
 import com.navercorp.pinpoint.common.hbase.HbaseColumnFamily;
 import com.navercorp.pinpoint.common.hbase.HbaseOperations2;
-import com.navercorp.pinpoint.common.hbase.HbaseTableConstatns;
+import com.navercorp.pinpoint.common.hbase.HbaseTableConstants;
 import com.navercorp.pinpoint.common.hbase.ResultsExtractor;
 import com.navercorp.pinpoint.common.hbase.RowMapper;
 import com.navercorp.pinpoint.common.hbase.TableDescriptor;
@@ -125,7 +125,7 @@ public class HbaseAgentEventDao implements AgentEventDao {
     private byte[] createRowKey(String agentId, long timestamp) {
         byte[] agentIdKey = BytesUtils.toBytes(agentId);
         long reverseTimestamp = TimeUtils.reverseTimeMillis(timestamp);
-        return RowKeyUtils.concatFixedByteAndLong(agentIdKey, HbaseTableConstatns.AGENT_NAME_MAX_LEN, reverseTimestamp);
+        return RowKeyUtils.concatFixedByteAndLong(agentIdKey, HbaseTableConstants.AGENT_NAME_MAX_LEN, reverseTimestamp);
     }
 
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/dao/hbase/HbaseAgentInfoDao.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/dao/hbase/HbaseAgentInfoDao.java
@@ -18,7 +18,7 @@ package com.navercorp.pinpoint.web.dao.hbase;
 
 import com.navercorp.pinpoint.common.hbase.HbaseColumnFamily;
 import com.navercorp.pinpoint.common.hbase.HbaseOperations2;
-import com.navercorp.pinpoint.common.hbase.HbaseTableConstatns;
+import com.navercorp.pinpoint.common.hbase.HbaseTableConstants;
 import com.navercorp.pinpoint.common.hbase.ResultsExtractor;
 import com.navercorp.pinpoint.common.hbase.TableDescriptor;
 import com.navercorp.pinpoint.common.server.util.RowKeyUtils;
@@ -91,7 +91,7 @@ public class HbaseAgentInfoDao implements AgentInfoDao {
     private Scan createScanForInitialAgentInfo(String agentId) {
         Scan scan = new Scan();
         byte[] agentIdBytes = Bytes.toBytes(agentId);
-        byte[] reverseStartKey = RowKeyUtils.concatFixedByteAndLong(agentIdBytes, HbaseTableConstatns.AGENT_NAME_MAX_LEN, Long.MAX_VALUE);
+        byte[] reverseStartKey = RowKeyUtils.concatFixedByteAndLong(agentIdBytes, HbaseTableConstants.AGENT_NAME_MAX_LEN, Long.MAX_VALUE);
         scan.setStartRow(reverseStartKey);
         scan.setReversed(true);
         scan.setMaxVersions(1);
@@ -136,8 +136,8 @@ public class HbaseAgentInfoDao implements AgentInfoDao {
 
         byte[] agentIdBytes = Bytes.toBytes(agentId);
         long startTime = TimeUtils.reverseTimeMillis(currentTime);
-        byte[] startKeyBytes = RowKeyUtils.concatFixedByteAndLong(agentIdBytes, HbaseTableConstatns.AGENT_NAME_MAX_LEN, startTime);
-        byte[] endKeyBytes = RowKeyUtils.concatFixedByteAndLong(agentIdBytes, HbaseTableConstatns.AGENT_NAME_MAX_LEN, Long.MAX_VALUE);
+        byte[] startKeyBytes = RowKeyUtils.concatFixedByteAndLong(agentIdBytes, HbaseTableConstants.AGENT_NAME_MAX_LEN, startTime);
+        byte[] endKeyBytes = RowKeyUtils.concatFixedByteAndLong(agentIdBytes, HbaseTableConstants.AGENT_NAME_MAX_LEN, Long.MAX_VALUE);
 
         scan.setStartRow(startKeyBytes);
         scan.setStopRow(endKeyBytes);

--- a/web/src/main/java/com/navercorp/pinpoint/web/dao/hbase/HbaseAgentLifeCycleDao.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/dao/hbase/HbaseAgentLifeCycleDao.java
@@ -18,7 +18,7 @@ package com.navercorp.pinpoint.web.dao.hbase;
 
 import com.navercorp.pinpoint.common.hbase.HbaseColumnFamily;
 import com.navercorp.pinpoint.common.hbase.HbaseOperations2;
-import com.navercorp.pinpoint.common.hbase.HbaseTableConstatns;
+import com.navercorp.pinpoint.common.hbase.HbaseTableConstants;
 import com.navercorp.pinpoint.common.hbase.ResultsExtractor;
 import com.navercorp.pinpoint.common.hbase.RowMapper;
 import com.navercorp.pinpoint.common.hbase.TableDescriptor;
@@ -128,8 +128,8 @@ public class HbaseAgentLifeCycleDao implements AgentLifeCycleDao {
         byte[] agentIdBytes = Bytes.toBytes(agentId);
         long reverseFromTimestamp = TimeUtils.reverseTimeMillis(fromTimestamp);
         long reverseToTimestamp = TimeUtils.reverseTimeMillis(toTimestamp);
-        byte[] startKeyBytes = RowKeyUtils.concatFixedByteAndLong(agentIdBytes, HbaseTableConstatns.AGENT_NAME_MAX_LEN, reverseToTimestamp);
-        byte[] endKeyBytes = RowKeyUtils.concatFixedByteAndLong(agentIdBytes, HbaseTableConstatns.AGENT_NAME_MAX_LEN, reverseFromTimestamp);
+        byte[] startKeyBytes = RowKeyUtils.concatFixedByteAndLong(agentIdBytes, HbaseTableConstants.AGENT_NAME_MAX_LEN, reverseToTimestamp);
+        byte[] endKeyBytes = RowKeyUtils.concatFixedByteAndLong(agentIdBytes, HbaseTableConstants.AGENT_NAME_MAX_LEN, reverseFromTimestamp);
 
         Scan scan = new Scan(startKeyBytes, endKeyBytes);
         scan.addColumn(descriptor.getColumnFamilyName(), descriptor.getColumnFamily().QUALIFIER_STATES);

--- a/web/src/main/java/com/navercorp/pinpoint/web/dao/hbase/HbaseHostApplicationMapDao.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/dao/hbase/HbaseHostApplicationMapDao.java
@@ -20,7 +20,7 @@ import com.navercorp.pinpoint.common.buffer.AutomaticBuffer;
 import com.navercorp.pinpoint.common.buffer.Buffer;
 import com.navercorp.pinpoint.common.hbase.HbaseOperations2;
 import com.navercorp.pinpoint.common.hbase.HbaseTable;
-import com.navercorp.pinpoint.common.hbase.HbaseTableConstatns;
+import com.navercorp.pinpoint.common.hbase.HbaseTableConstants;
 import com.navercorp.pinpoint.common.hbase.RowMapper;
 import com.navercorp.pinpoint.common.hbase.TableNameProvider;
 import com.navercorp.pinpoint.common.server.util.TimeSlot;
@@ -125,7 +125,7 @@ public class HbaseHostApplicationMapDao implements HostApplicationMapDao {
 
     private byte[] createKey(Application parentApplication, long time) {
         Buffer buffer = new AutomaticBuffer();
-        buffer.putPadString(parentApplication.getName(), HbaseTableConstatns.APPLICATION_NAME_MAX_LEN);
+        buffer.putPadString(parentApplication.getName(), HbaseTableConstants.APPLICATION_NAME_MAX_LEN);
         buffer.putShort(parentApplication.getServiceTypeCode());
         buffer.putLong(time);
         return buffer.getBuffer();

--- a/web/src/main/java/com/navercorp/pinpoint/web/mapper/AgentInfoMapper.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/mapper/AgentInfoMapper.java
@@ -19,7 +19,7 @@ package com.navercorp.pinpoint.web.mapper;
 import com.navercorp.pinpoint.common.PinpointConstants;
 import com.navercorp.pinpoint.common.buffer.Buffer;
 import com.navercorp.pinpoint.common.buffer.FixedBuffer;
-import com.navercorp.pinpoint.common.hbase.HbaseTableConstatns;
+import com.navercorp.pinpoint.common.hbase.HbaseTableConstants;
 import com.navercorp.pinpoint.common.hbase.RowMapper;
 import com.navercorp.pinpoint.common.server.bo.AgentInfoBo;
 import com.navercorp.pinpoint.common.server.bo.JvmInfoBo;
@@ -45,7 +45,7 @@ public class AgentInfoMapper implements RowMapper<AgentInfo> {
 
         byte[] rowKey = result.getRow();
         String agentId = BytesUtils.safeTrim(BytesUtils.toString(rowKey, 0, PinpointConstants.AGENT_NAME_MAX_LEN));
-        long reverseStartTime = BytesUtils.bytesToLong(rowKey, HbaseTableConstatns.AGENT_NAME_MAX_LEN);
+        long reverseStartTime = BytesUtils.bytesToLong(rowKey, HbaseTableConstants.AGENT_NAME_MAX_LEN);
         long startTime = TimeUtils.recoveryTimeMillis(reverseStartTime);
 
         byte[] serializedAgentInfo = result.getValue(AGENTINFO_INFO.getName(), AGENTINFO_INFO.QUALIFIER_IDENTIFIER);

--- a/web/src/main/java/com/navercorp/pinpoint/web/mapper/HostApplicationMapper.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/mapper/HostApplicationMapper.java
@@ -16,7 +16,7 @@
 
 package com.navercorp.pinpoint.web.mapper;
 
-import com.navercorp.pinpoint.common.hbase.HbaseTableConstatns;
+import com.navercorp.pinpoint.common.hbase.HbaseTableConstants;
 import com.navercorp.pinpoint.common.hbase.RowMapper;
 import com.navercorp.pinpoint.web.service.ApplicationFactory;
 import com.navercorp.pinpoint.web.vo.Application;
@@ -50,12 +50,12 @@ public class HostApplicationMapper implements RowMapper<Application> {
         }
         byte[] value = result.value();
 
-        if (value.length != HbaseTableConstatns.APPLICATION_NAME_MAX_LEN + 2) {
+        if (value.length != HbaseTableConstants.APPLICATION_NAME_MAX_LEN + 2) {
             logger.warn("Invalid value. {}", Arrays.toString(value));
         }
 
-        String applicationName = Bytes.toString(value, 0, HbaseTableConstatns.APPLICATION_NAME_MAX_LEN - 1).trim();
-        short serviceTypeCode = Bytes.toShort(value, HbaseTableConstatns.APPLICATION_NAME_MAX_LEN);
+        String applicationName = Bytes.toString(value, 0, HbaseTableConstants.APPLICATION_NAME_MAX_LEN - 1).trim();
+        short serviceTypeCode = Bytes.toShort(value, HbaseTableConstants.APPLICATION_NAME_MAX_LEN);
         return this.applicationFactory.createApplication(applicationName, serviceTypeCode);
     }
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/mapper/TraceIndexScatterMapper.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/mapper/TraceIndexScatterMapper.java
@@ -19,7 +19,7 @@ package com.navercorp.pinpoint.web.mapper;
 import com.navercorp.pinpoint.common.buffer.Buffer;
 import com.navercorp.pinpoint.common.buffer.OffsetFixedBuffer;
 import com.navercorp.pinpoint.common.hbase.HbaseColumnFamily;
-import com.navercorp.pinpoint.common.hbase.HbaseTableConstatns;
+import com.navercorp.pinpoint.common.hbase.HbaseTableConstants;
 import com.navercorp.pinpoint.common.hbase.RowMapper;
 import com.navercorp.pinpoint.common.util.BytesUtils;
 import com.navercorp.pinpoint.common.util.TimeUtils;
@@ -64,7 +64,7 @@ public class TraceIndexScatterMapper implements RowMapper<List<Dot>> {
         int exceptionCode = valueBuffer.readSVInt();
         String agentId = valueBuffer.readPrefixedString();
 
-        final int acceptTimeOffset = cell.getRowOffset() + HbaseTableConstatns.APPLICATION_NAME_MAX_LEN + HbaseColumnFamily.APPLICATION_TRACE_INDEX_TRACE.ROW_DISTRIBUTE_SIZE;
+        final int acceptTimeOffset = cell.getRowOffset() + HbaseTableConstants.APPLICATION_NAME_MAX_LEN + HbaseColumnFamily.APPLICATION_TRACE_INDEX_TRACE.ROW_DISTRIBUTE_SIZE;
         long reverseAcceptedTime = BytesUtils.bytesToLong(cell.getRowArray(), acceptTimeOffset);
         long acceptedTime = TimeUtils.recoveryTimeMillis(reverseAcceptedTime);
 


### PR DESCRIPTION
fix typo : HbaseTableConstatns to HbaseTableConstants and HbaseTableConstatns.java to HbaseTableConstants.java