### PR TITLE
[#noissue] Fix Typo in Rule

### DIFF
--- a/web/src/main/java/com/navercorp/pinpoint/web/alarm/vo/Rule.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/alarm/vo/Rule.java
@@ -81,7 +81,7 @@ public class Rule {
         return userGroupId;
     }
 
-    public void setuserGroupId(String userGroupId) {
+    public void setUserGroupId(String userGroupId) {
         this.userGroupId = userGroupId;
     }
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/dao/memory/MemoryAlarmDao.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/dao/memory/MemoryAlarmDao.java
@@ -112,7 +112,7 @@ public class MemoryAlarmDao implements AlarmDao {
         List<Rule> ruleList = selectRuleByUserGroupId(beforeUserGroupId);
         
         for (Rule rule : ruleList) {
-            rule.setuserGroupId(updatedUserGroup.getId());
+            rule.setUserGroupId(updatedUserGroup.getId());
         }
     }
 


### PR DESCRIPTION
I fix method name in Rule Class
(setuserGroupId -> setUserGroupId)

I think setUserGroupId is more proper than setuserGroupId by the camel case