### PR TITLE
[#noissue] Fix log4j lib of agent

### DIFF
--- a/agent/pom.xml
+++ b/agent/pom.xml
@@ -120,6 +120,24 @@
             <scope>runtime</scope>
         </dependency>
 
+        <!-- Logging dependencies -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+        </dependency>
+
     </dependencies>
 
     <build>


### PR DESCRIPTION
Add log4j2 related libraries to pinpoint-aget-2.1.0-SNAPSHOT.tar.gz.