### PR TITLE
[#noissue] fix typo in AlarmChecker

### DIFF
--- a/web/src/main/java/com/navercorp/pinpoint/web/alarm/SpringSmtpMailSender.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/alarm/SpringSmtpMailSender.java
@@ -63,7 +63,7 @@ public class SpringSmtpMailSender implements MailSender {
 
     @Override
     public void sendEmail(AlarmChecker checker, int sequenceCount, StepExecution stepExecution) {
-        List<String> receivers = userGroupService.selectEmailOfMember(checker.getuserGroupId());
+        List<String> receivers = userGroupService.selectEmailOfMember(checker.getUserGroupId());
 
         if (receivers.size() == 0) {
             return;

--- a/web/src/main/java/com/navercorp/pinpoint/web/alarm/checker/AlarmChecker.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/alarm/checker/AlarmChecker.java
@@ -59,7 +59,7 @@ public abstract class AlarmChecker<T> {
         return rule.isEmailSend();
     }
     
-    public String getuserGroupId() {
+    public String getUserGroupId() {
         return rule.getUserGroupId();
     }
     


### PR DESCRIPTION
I fix method name in AlarmChecker class
(getuserGroupId -> getUserGroupId)

I think getUserGroupId is more proper than getUserGroupId by the camel case