### PR TITLE
[#noissue] Add the scatter chart link and inspector link to the alarm mail

### DIFF
--- a/web/src/main/java/com/navercorp/pinpoint/web/alarm/AlarmMailTemplate.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/alarm/AlarmMailTemplate.java
@@ -16,6 +16,7 @@
 
 package com.navercorp.pinpoint.web.alarm;
 
+import com.navercorp.pinpoint.web.alarm.checker.AgentChecker;
 import com.navercorp.pinpoint.web.alarm.checker.AlarmChecker;
 import com.navercorp.pinpoint.web.alarm.vo.Rule;
 import java.text.SimpleDateFormat;
@@ -28,6 +29,7 @@ public class AlarmMailTemplate {
     private static final String LINE_FEED = "<br>";
     private static final String LINK_FORMAT = "<a href=\"%s\" >%s</a>";
     private static final String SCATTER_CHART_LINK_FORMAT = "<a href=\"%s/main/%s@%s/5m/%s\" >Scatter Chart Link</a>";
+    private static final String INSPECTOR_LINK_FORMAT = "<a href=\"%s/inspector/%s@%s/5m/%s/%s\" >Inspector Link</a>";
 
     private final String pinpointUrl;
     private final AlarmChecker checker;
@@ -64,6 +66,14 @@ public class AlarmMailTemplate {
         body.append(String.format(LINK_FORMAT, pinpointUrl, pinpointUrl));
         body.append(LINE_FEED);
         body.append(String.format(SCATTER_CHART_LINK_FORMAT, pinpointUrl, rule.getApplicationId(), rule.getServiceType(),getCurrentTime()));
+        body.append(LINE_FEED);
+        if(checker instanceof AgentChecker) {
+            checker.getDetectedAgents().forEach((key, value) -> {
+                body.append(String.format(INSPECTOR_LINK_FORMAT, pinpointUrl, rule.getApplicationId(), rule.getServiceType(), getCurrentTime(), key));
+                body.append(LINE_FEED);
+            });
+        }
+
 
         return body.toString();
     }

--- a/web/src/main/java/com/navercorp/pinpoint/web/alarm/AlarmMailTemplate.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/alarm/AlarmMailTemplate.java
@@ -18,6 +18,7 @@ package com.navercorp.pinpoint.web.alarm;
 
 import com.navercorp.pinpoint.web.alarm.checker.AlarmChecker;
 import com.navercorp.pinpoint.web.alarm.vo.Rule;
+import java.text.SimpleDateFormat;
 
 /**
  * @author minwoo.jung
@@ -26,6 +27,7 @@ public class AlarmMailTemplate {
 
     private static final String LINE_FEED = "<br>";
     private static final String LINK_FORMAT = "<a href=\"%s\" >%s</a>";
+    private static final String SCATTER_CHART_LINK_FORMAT = "<a href=\"%s/main/%s@%s/5m/%s\" >Scatter Chart Link</a>";
 
     private final String pinpointUrl;
     private final AlarmChecker checker;
@@ -44,6 +46,11 @@ public class AlarmMailTemplate {
         return String.format("[PINPOINT-" + batchEnv + "] %s Alarm for %s Service. #%d", rule.getCheckerName(), rule.getApplicationId(), sequenceCount);
     }
 
+    public String getCurrentTime() {
+        SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd-HH-mm-ss");
+        return format.format(System.currentTimeMillis());
+    }
+
     public String createBody() {
         Rule rule = checker.getRule();
 
@@ -55,7 +62,9 @@ public class AlarmMailTemplate {
         body.append(LINE_FEED);
         body.append(checker.getEmailMessage());
         body.append(String.format(LINK_FORMAT, pinpointUrl, pinpointUrl));
-        
+        body.append(LINE_FEED);
+        body.append(String.format(SCATTER_CHART_LINK_FORMAT, pinpointUrl, rule.getApplicationId(), rule.getServiceType(),getCurrentTime()));
+
         return body.toString();
     }
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/alarm/checker/AgentChecker.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/alarm/checker/AgentChecker.java
@@ -78,6 +78,11 @@ public abstract class AgentChecker<T> extends AlarmChecker<T> {
         
         return message.toString();
     }
+
+    @Override
+    public Map<String, T> getDetectedAgents() {
+        return detectedAgents;
+    }
     
     protected abstract Map<String, T> getAgentValues();
     

--- a/web/src/main/java/com/navercorp/pinpoint/web/alarm/checker/AlarmChecker.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/alarm/checker/AlarmChecker.java
@@ -24,6 +24,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 
 /**
  * @author koo.taejin
@@ -86,5 +87,7 @@ public abstract class AlarmChecker<T> {
     }
     
     protected abstract T getDetectedValue();
-
+    public Map<String, T> getDetectedAgents(){
+        throw new UnsupportedOperationException(this.getClass() + "is not support getDetectedAgents function. you should use getDetectedValue");
+    };
 }


### PR DESCRIPTION
I added the Scatter Chart Link and Inspector Link to Alarm Mail. Inspector Link is created only when an agent-related alarm occurs.
When Link is clicked, shows the Inspector of the Agent or the Scatter Chart of the Application at the time the alarm occurred.

before:
![before](https://user-images.githubusercontent.com/43126717/90506044-9fc03180-e18e-11ea-9476-00655f9ce569.png)   

after:
![after_scatter](https://user-images.githubusercontent.com/43126717/90506067-a5b61280-e18e-11ea-81e6-776389600022.png)   
![after_inspector](https://user-images.githubusercontent.com/43126717/90506072-a8186c80-e18e-11ea-8db2-e2e7d350bfe0.png)   
