### PR TITLE
[#noissue] Add Scatter Chart Link and Inspector Link to alarm mail

### DIFF
--- a/web/src/main/java/com/navercorp/pinpoint/web/alarm/checker/AgentChecker.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/alarm/checker/AgentChecker.java
@@ -73,11 +73,12 @@ public abstract class AgentChecker<T> extends AlarmChecker<T> {
         
         for (Entry<String, T> detected : detectedAgents.entrySet()) {
             message.append(String.format(" Value of agent(%s) is %s%s during the past 5 mins.(Threshold : %s%s)", detected.getKey(), detected.getValue(), unit, rule.getThreshold(), unit));
-            message.append("<br>");
         }
         
         return message.toString();
     }
+    
+    public Map<String, T> getDetectedAgents() { return detectedAgents; }
     
     protected abstract Map<String, T> getAgentValues();
     

--- a/web/src/main/java/com/navercorp/pinpoint/web/alarm/checker/DataSourceConnectionUsageRateChecker.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/alarm/checker/DataSourceConnectionUsageRateChecker.java
@@ -78,7 +78,6 @@ public class DataSourceConnectionUsageRateChecker extends AgentChecker<List<Data
             for (DataSourceAlarmVO dataSourceAlarmVO : detected.getValue()) {
                 if (decideResult0(dataSourceAlarmVO)) {
                     message.append(String.format(" Value of agent(%s) has %s%s(DataSource %s connection pool usage) during the past 5 mins.(Threshold : %s%s)", detected.getKey(), dataSourceAlarmVO.getConnectionUsedRate(), unit, dataSourceAlarmVO.getDatabaseName(), rule.getThreshold(), unit));
-                    message.append("<br>");
                 }
             }
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/alarm/checker/DeadlockChecker.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/alarm/checker/DeadlockChecker.java
@@ -61,7 +61,6 @@ public class DeadlockChecker extends AgentChecker<Boolean> {
         StringBuilder message = new StringBuilder();
         for (Map.Entry<String, Boolean> detected : detectedAgents.entrySet()) {
             message.append(String.format(" Value of agent(%s) has deadlocked thread during the past 5 mins.", detected.getKey()));
-            message.append("<br>");
         }
         return message.toString();
     }


### PR DESCRIPTION
I added the Scatter Chart Link and Inspector Link to Alarm Mail. Inspector Link is created only when an agent-related alarm occurs.
When Link is clicked, shows the Inspector of the Agent or the Scatter Chart of the Application at the time the alarm occurred.

### before:   
![image](https://user-images.githubusercontent.com/43126717/90595126-1577dc00-e227-11ea-882a-1bad2f06374e.png)     

### after:     
![after_scatter](https://user-images.githubusercontent.com/43126717/91664442-570f5d80-eb2a-11ea-8e97-d3427e650348.png)
![after_inspector](https://user-images.githubusercontent.com/43126717/91664444-58d92100-eb2a-11ea-809a-a57811d63851.png)



To use this feature, you must set `pinpoint.url` in the `batch-root.properties` file .
ex) pinpoint.url=http://localhost:8080

