### PR TITLE
[#7161] Add server config

### DIFF
--- a/agent/src/main/resources/pinpoint-root.config
+++ b/agent/src/main/resources/pinpoint-root.config
@@ -278,7 +278,7 @@ profiler.http.status.code.errors=5xx
 #profiler.http.record.request.cookies=
 
 ###########################################################
-# application type                                        # 
+# Application Type                                        #
 ###########################################################
 #profiler.applicationservertype=TOMCAT
 #profiler.applicationservertype=BLOC
@@ -287,6 +287,30 @@ profiler.http.status.code.errors=5xx
 # Ex: com.navercorp.pinpoint:pinpoint-tomcat-plugin, com.navercorp.pinpoint:pinpoint-jboss-plugin
 profiler.plugin.load.order=
 profiler.plugin.disable=
+
+###########################################################
+# SERVER                                                  #
+###########################################################
+# Server integration settings.
+# TOMCAT, JETTY, UNDERTOW, REACTOR-NETTY, JBOSS, RESIN, WEBLOGIC, VERT.X, WEBSPHERE, AKKA
+# Individual settings take precedence.
+# For example, setting "profiler.tomcat.excludeurl=A" takes precedence over setting "profiler.server.excludeurl=B".
+
+# Hide pinpoint headers.
+profiler.server.hidepinpointheader=true
+# URLs to exclude from tracing.
+# Support ant style pattern. e.g. /aa/*.html, /??/exclude.html
+profiler.server.excludeurl=
+# HTTP Request methods to exclude from tracing.
+# e.g. POST, PUT
+profiler.server.excludemethod=
+# Trace request param.
+profiler.server.tracerequestparam=true
+# Original IP address header. e.g. X-Forwarded-For or X-Real-IP
+# https://en.wikipedia.org/wiki/X-Forwarded-For
+profiler.server.realipheader=
+# optional parameter, If the header value is ${profiler.server.realipemptyvalue}, Ignore header value.
+profiler.server.realipemptyvalue=
 
 ###########################################################
 # Thread

--- a/agent/src/main/resources/profiles/release/pinpoint.config
+++ b/agent/src/main/resources/profiles/release/pinpoint.config
@@ -262,12 +262,10 @@ profiler.tomcat.bootstrap.main=org.apache.catalina.startup.Bootstrap
 profiler.tomcat.hidepinpointheader=true
 # URLs to exclude from tracing.
 # Support ant style pattern. e.g. /aa/*.html, /??/exclude.html
-profiler.tomcat.excludeurl=/aa/test.html, /bb/exclude.html
-# HTTP Request methods to exclude from tracing
-#profiler.tomcat.excludemethod=
-profiler.tomcat.tracerequestparam=true
+profiler.tomcat.excludeurl=
 # HTTP Request methods to exclude from tracing
 #profiler.tomcat.excludemethod=POST,PUT
+profiler.tomcat.tracerequestparam=true
 
 # original IP address header
 # https://en.wikipedia.org/wiki/X-Forwarded-For

--- a/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/config/ServerConfig.java
+++ b/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/config/ServerConfig.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2020 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.bootstrap.config;
+
+/**
+ * @author jaehong.kim
+ */
+public class ServerConfig {
+    static final String TRACE_REQUEST_PARAM_PROPERTY_NAME = "profiler.server.tracerequestparam";
+    static final String HIDE_PINPOINT_HEADER_PROPERTY_NAME = "profiler.server.hidepinpointheader";
+    static final String EXCLUDE_URL_PROPERTY_NAME = "profiler.server.excludeurl";
+    static final String REAL_IP_HEADER_PROPERTY_NAME = "profiler.server.realipheader";
+    static final String REAL_IP_EMPTY_VALUE_PROPERTY_NAME = "profiler.server.realipemptyvalue";
+    static final String EXCLUDE_METHOD_PROPERTY_NAME = "profiler.server.excludemethod";
+
+    private ProfilerConfig config;
+
+    public ServerConfig(final ProfilerConfig config) {
+        if (config == null) {
+            throw new NullPointerException("config");
+        }
+        this.config = config;
+    }
+
+    public boolean isHidePinpointHeader(final String propertyName) {
+        if (propertyName == null) {
+            throw new NullPointerException("propertyName");
+        }
+
+        final String propertyValue = config.readString(propertyName, "");
+        if (!propertyValue.isEmpty()) {
+            // Individual settings take precedence.
+            return config.readBoolean(propertyName, true);
+        }
+
+        return config.readBoolean(HIDE_PINPOINT_HEADER_PROPERTY_NAME, true);
+    }
+
+    public boolean isTraceRequestParam(final String propertyName) {
+        if (propertyName == null) {
+            throw new NullPointerException("propertyName");
+        }
+
+        final String propertyValue = config.readString(propertyName, "");
+        if (!propertyValue.isEmpty()) {
+            // Individual settings take precedence.
+            return config.readBoolean(propertyName, true);
+        }
+
+        return config.readBoolean(TRACE_REQUEST_PARAM_PROPERTY_NAME, true);
+    }
+
+    public Filter<String> getExcludeUrlFilter(final String propertyName) {
+        if (propertyName == null) {
+            throw new NullPointerException("propertyName");
+        }
+
+        final String excludeUrlPropertyValue = config.readString(propertyName, "");
+        if (!excludeUrlPropertyValue.isEmpty()) {
+            // Individual settings take precedence.
+            return new ExcludePathFilter(excludeUrlPropertyValue);
+        }
+        final String serverExcludeUrlPropertyValue = config.readString(EXCLUDE_URL_PROPERTY_NAME, "");
+        if (!serverExcludeUrlPropertyValue.isEmpty()) {
+            return new ExcludePathFilter(serverExcludeUrlPropertyValue);
+        }
+
+        return new SkipFilter<String>();
+    }
+
+    public String getRealIpHeader(final String propertyName) {
+        if (propertyName == null) {
+            throw new NullPointerException("propertyName");
+        }
+
+        final String propertyValue = config.readString(propertyName, "");
+        if (!propertyValue.isEmpty()) {
+            // Individual settings take precedence.
+            return propertyValue;
+        }
+
+        return config.readString(REAL_IP_HEADER_PROPERTY_NAME, "");
+    }
+
+    public String getRealIpEmptyValue(final String propertyName) {
+        if (propertyName == null) {
+            throw new NullPointerException("propertyName");
+        }
+
+        final String propertyValue = config.readString(propertyName, "");
+        if (!propertyValue.isEmpty()) {
+            // Individual settings take precedence.
+            return propertyValue;
+        }
+
+        return config.readString(REAL_IP_EMPTY_VALUE_PROPERTY_NAME, "");
+    }
+
+    public Filter<String> getExcludeMethodFilter(final String propertyName) {
+        if (propertyName == null) {
+            throw new NullPointerException("propertyName");
+        }
+
+        final String propertyValue = config.readString(propertyName, "");
+        if (!propertyValue.isEmpty()) {
+            // Individual settings take precedence.
+            return new ExcludeMethodFilter(propertyValue);
+        }
+        final String serverExcludeUrlPropertyValue = config.readString(EXCLUDE_METHOD_PROPERTY_NAME, "");
+        if (!serverExcludeUrlPropertyValue.isEmpty()) {
+            return new ExcludeMethodFilter(serverExcludeUrlPropertyValue);
+        }
+
+        return new SkipFilter<String>();
+    }
+}

--- a/bootstrap-core/src/test/java/com/navercorp/pinpoint/bootstrap/config/ServerConfigTest.java
+++ b/bootstrap-core/src/test/java/com/navercorp/pinpoint/bootstrap/config/ServerConfigTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2020 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.bootstrap.config;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Properties;
+
+/**
+ * @author jaehong.kim
+ */
+public class ServerConfigTest {
+
+    @Test
+    public void isHidePinpointHeader() {
+        final String propertyName = "profiler.tomcat.hidepinpointheader";
+        Properties properties = new Properties();
+        properties.setProperty(ServerConfig.HIDE_PINPOINT_HEADER_PROPERTY_NAME, "true");
+        properties.setProperty(propertyName, "false");
+
+        ProfilerConfig profilerConfig = new DefaultProfilerConfig(properties);
+        ServerConfig serverConfig = new ServerConfig(profilerConfig);
+
+        Assert.assertFalse(serverConfig.isHidePinpointHeader(propertyName));
+    }
+
+    @Test
+    public void isTraceRequestParam() {
+        final String propertyName = "profiler.tomcat.tracerequestparam";
+        Properties properties = new Properties();
+        properties.setProperty(ServerConfig.TRACE_REQUEST_PARAM_PROPERTY_NAME, "true");
+        properties.setProperty(propertyName, "false");
+
+        ProfilerConfig profilerConfig = new DefaultProfilerConfig(properties);
+        ServerConfig serverConfig = new ServerConfig(profilerConfig);
+
+        Assert.assertFalse(serverConfig.isTraceRequestParam(propertyName));
+    }
+
+    @Test
+    public void getExcludeUrlFilter() {
+        final String propertyName = "profiler.tomcat.excludeurl";
+        Properties properties = new Properties();
+        properties.setProperty(ServerConfig.EXCLUDE_URL_PROPERTY_NAME, "/l7check");
+        properties.setProperty(propertyName, "/healthcheck");
+
+        ProfilerConfig profilerConfig = new DefaultProfilerConfig(properties);
+        ServerConfig serverConfig = new ServerConfig(profilerConfig);
+
+        Filter<String> filter = serverConfig.getExcludeUrlFilter(propertyName);
+        Assert.assertTrue(filter.filter("/healthcheck"));
+        Assert.assertFalse(filter.filter("/l7check"));
+    }
+
+    @Test
+    public void getRealIpHeader() {
+        final String propertyName = "profiler.tomcat.realipheader";
+        Properties properties = new Properties();
+        properties.setProperty(ServerConfig.REAL_IP_HEADER_PROPERTY_NAME, "X-Forwarded-For");
+        properties.setProperty(propertyName, "");
+
+        ProfilerConfig profilerConfig = new DefaultProfilerConfig(properties);
+        ServerConfig serverConfig = new ServerConfig(profilerConfig);
+
+        Assert.assertEquals("X-Forwarded-For", serverConfig.getRealIpHeader(propertyName));
+    }
+
+    @Test
+    public void getRealIpEmptyValue() {
+        final String propertyName = "profiler.tomcat.realipemptyvalue";
+        Properties properties = new Properties();
+        properties.setProperty(ServerConfig.REAL_IP_HEADER_PROPERTY_NAME, "");
+        properties.setProperty(propertyName, "UNKNOWN");
+
+        ProfilerConfig profilerConfig = new DefaultProfilerConfig(properties);
+        ServerConfig serverConfig = new ServerConfig(profilerConfig);
+
+        Assert.assertEquals("UNKNOWN", serverConfig.getRealIpEmptyValue(propertyName));
+    }
+
+    @Test
+    public void getExcludeMethodFilter() {
+        final String propertyName = "profiler.tomcat.excludemethod";
+        Properties properties = new Properties();
+        properties.setProperty(ServerConfig.EXCLUDE_METHOD_PROPERTY_NAME, "POST");
+        properties.setProperty(propertyName, "HEAD");
+
+        ProfilerConfig profilerConfig = new DefaultProfilerConfig(properties);
+        ServerConfig serverConfig = new ServerConfig(profilerConfig);
+
+        Filter<String> filter = serverConfig.getExcludeMethodFilter(propertyName);
+        Assert.assertTrue(filter.filter("HEAD"));
+        Assert.assertFalse(filter.filter("POST"));
+    }
+}

--- a/plugins/jboss/src/main/java/com/navercorp/pinpoint/plugin/jboss/JbossConfig.java
+++ b/plugins/jboss/src/main/java/com/navercorp/pinpoint/plugin/jboss/JbossConfig.java
@@ -16,11 +16,9 @@
 
 package com.navercorp.pinpoint.plugin.jboss;
 
-import com.navercorp.pinpoint.bootstrap.config.ExcludeMethodFilter;
-import com.navercorp.pinpoint.bootstrap.config.ExcludePathFilter;
 import com.navercorp.pinpoint.bootstrap.config.Filter;
 import com.navercorp.pinpoint.bootstrap.config.ProfilerConfig;
-import com.navercorp.pinpoint.bootstrap.config.SkipFilter;
+import com.navercorp.pinpoint.bootstrap.config.ServerConfig;
 
 import java.util.List;
 
@@ -32,24 +30,11 @@ import java.util.List;
  */
 public class JbossConfig {
 
-    /**
-     * The jboss hide pinpoint header.
-     */
     private final boolean hidePinpointHeader;
-
-    /**
-     * The jboss exclude url filter.
-     */
     private final Filter<String> excludeUrlFilter;
-
-    /**
-     * The jboss trace ejb.
-     */
     private final boolean traceEjb;
     private final boolean enable;
-
     private final List<String> bootstrapMains;
-
     private final String realIpHeader;
     private final String realIpEmptyValue;
     private final boolean traceRequestParam;
@@ -63,26 +48,15 @@ public class JbossConfig {
     public JbossConfig(final ProfilerConfig config) {
         this.enable = config.readBoolean("profiler.jboss.enable", true);
         this.traceEjb = config.readBoolean("profiler.jboss.traceEjb", false);
-
         this.bootstrapMains = config.readList("profiler.jboss.bootstrap.main");
-        this.hidePinpointHeader = config.readBoolean("profiler.jboss.hidepinpointheader", true);
-
-        this.traceRequestParam = config.readBoolean("profiler.jboss.tracerequestparam", true);
-        final String jbossExcludeURL = config.readString("profiler.jboss.excludeurl", "");
-        if (!jbossExcludeURL.isEmpty()) {
-            this.excludeUrlFilter = new ExcludePathFilter(jbossExcludeURL);
-        } else {
-            this.excludeUrlFilter = new SkipFilter<String>();
-        }
-        this.realIpHeader = config.readString("profiler.jboss.realipheader", null);
-        this.realIpEmptyValue = config.readString("profiler.jboss.realipemptyvalue", null);
-
-        final String jbossExcludeProfileMethod = config.readString("profiler.jboss.excludemethod", "");
-        if (!jbossExcludeProfileMethod.isEmpty()) {
-            this.excludeProfileMethodFilter = new ExcludeMethodFilter(jbossExcludeProfileMethod);
-        } else {
-            this.excludeProfileMethodFilter = new SkipFilter<String>();
-        }
+        // Server
+        final ServerConfig serverConfig = new ServerConfig(config);
+        this.hidePinpointHeader = serverConfig.isHidePinpointHeader("profiler.jboss.hidepinpointheader");
+        this.traceRequestParam = serverConfig.isTraceRequestParam("profiler.jboss.tracerequestparam");
+        this.excludeUrlFilter = serverConfig.getExcludeUrlFilter("profiler.jboss.excludeurl");
+        this.realIpHeader = serverConfig.getRealIpHeader("profiler.jboss.realipheader");
+        this.realIpEmptyValue = serverConfig.getRealIpEmptyValue("profiler.jboss.realipemptyvalue");
+        this.excludeProfileMethodFilter = serverConfig.getExcludeMethodFilter("profiler.jboss.excludemethod");
     }
 
     public boolean isEnable() {

--- a/plugins/jetty/src/main/java/com/navercorp/pinpoint/plugin/jetty/JettyConfiguration.java
+++ b/plugins/jetty/src/main/java/com/navercorp/pinpoint/plugin/jetty/JettyConfiguration.java
@@ -14,11 +14,9 @@
  */
 package com.navercorp.pinpoint.plugin.jetty;
 
-import com.navercorp.pinpoint.bootstrap.config.ExcludeMethodFilter;
-import com.navercorp.pinpoint.bootstrap.config.ExcludePathFilter;
 import com.navercorp.pinpoint.bootstrap.config.Filter;
 import com.navercorp.pinpoint.bootstrap.config.ProfilerConfig;
-import com.navercorp.pinpoint.bootstrap.config.SkipFilter;
+import com.navercorp.pinpoint.bootstrap.config.ServerConfig;
 
 import java.util.List;
 
@@ -38,29 +36,17 @@ public class JettyConfiguration {
     private final Filter<String> excludeProfileMethodFilter;
 
     public JettyConfiguration(ProfilerConfig config) {
+        // Plugin
         this.enable = config.readBoolean("profiler.jetty.enable", true);
         this.bootstrapMains = config.readList("profiler.jetty.bootstrap.main");
-        final String jettyExcludeURL = config.readString("profiler.jetty.excludeurl", "");
-
-        if (!jettyExcludeURL.isEmpty()) {
-            this.excludeUrlFilter = new ExcludePathFilter(jettyExcludeURL);
-        } else {
-            this.excludeUrlFilter = new SkipFilter<String>();
-        }
-        boolean hidePinpointHeader = config.readBoolean("profiler.jetty.hide-pinpoint-header", true);
-        if (hidePinpointHeader) {
-            hidePinpointHeader = config.readBoolean("profiler.jetty.hidepinpointheader", true);
-        }
-        this.hidePinpointHeader = hidePinpointHeader;
-        final String excludeProfileMethod = config.readString("profiler.jetty.excludemethod", "");
-        if (!excludeProfileMethod.isEmpty()) {
-            this.excludeProfileMethodFilter = new ExcludeMethodFilter(excludeProfileMethod);
-        } else {
-            this.excludeProfileMethodFilter = new SkipFilter<String>();
-        }
-        this.traceRequestParam = config.readBoolean("profiler.jetty.tracerequestparam", true);
-        this.realIpHeader = config.readString("profiler.jetty.realipheader", null);
-        this.realIpEmptyValue = config.readString("profiler.jetty.realipemptyvalue", null);
+        // Server
+        final ServerConfig serverConfig = new ServerConfig(config);
+        this.excludeUrlFilter = serverConfig.getExcludeUrlFilter("profiler.jetty.excludeurl");
+        this.hidePinpointHeader = serverConfig.isHidePinpointHeader("profiler.jetty.hide-pinpoint-header");
+        this.excludeProfileMethodFilter = serverConfig.getExcludeMethodFilter("profiler.jetty.excludemethod");
+        this.traceRequestParam = serverConfig.isTraceRequestParam("profiler.jetty.tracerequestparam");
+        this.realIpHeader = serverConfig.getRealIpHeader("profiler.jetty.realipheader");
+        this.realIpEmptyValue = serverConfig.getRealIpEmptyValue("profiler.jetty.realipemptyvalue");
     }
 
     public boolean isEnable() {

--- a/plugins/reactor-netty/src/main/java/com/navercorp/pinpoint/plugin/reactor/netty/ReactorNettyPluginConfig.java
+++ b/plugins/reactor-netty/src/main/java/com/navercorp/pinpoint/plugin/reactor/netty/ReactorNettyPluginConfig.java
@@ -16,11 +16,9 @@
 
 package com.navercorp.pinpoint.plugin.reactor.netty;
 
-import com.navercorp.pinpoint.bootstrap.config.ExcludeMethodFilter;
-import com.navercorp.pinpoint.bootstrap.config.ExcludePathFilter;
 import com.navercorp.pinpoint.bootstrap.config.Filter;
 import com.navercorp.pinpoint.bootstrap.config.ProfilerConfig;
-import com.navercorp.pinpoint.bootstrap.config.SkipFilter;
+import com.navercorp.pinpoint.bootstrap.config.ServerConfig;
 
 import java.util.List;
 
@@ -48,24 +46,13 @@ public class ReactorNettyPluginConfig {
         this.enable = config.readBoolean("profiler.reactor-netty.enable", true);
         this.bootstrapMains = config.readList("profiler.reactor-netty.server.bootstrap.main");
         this.enableAsyncEndPoint = config.readBoolean("profiler.reactor-netty.server.end-point.async.enable", true);
-
-        // runtime
-        this.traceRequestParam = config.readBoolean("profiler.reactor-netty.server.tracerequestparam", true);
-        final String tomcatExcludeURL = config.readString("profiler.reactor-netty.server.excludeurl", "");
-        if (!tomcatExcludeURL.isEmpty()) {
-            this.excludeUrlFilter = new ExcludePathFilter(tomcatExcludeURL);
-        } else {
-            this.excludeUrlFilter = new SkipFilter<String>();
-        }
-        this.realIpHeader = config.readString("profiler.reactor-netty.server.realipheader", null);
-        this.realIpEmptyValue = config.readString("profiler.reactor-netty.server.realipemptyvalue", null);
-
-        final String tomcatExcludeProfileMethod = config.readString("profiler.reactor-netty.server.excludemethod", "");
-        if (!tomcatExcludeProfileMethod.isEmpty()) {
-            this.excludeProfileMethodFilter = new ExcludeMethodFilter(tomcatExcludeProfileMethod);
-        } else {
-            this.excludeProfileMethodFilter = new SkipFilter<String>();
-        }
+        // Server
+        final ServerConfig serverConfig = new ServerConfig(config);
+        this.traceRequestParam = serverConfig.isTraceRequestParam("profiler.reactor-netty.server.tracerequestparam");
+        this.excludeUrlFilter = serverConfig.getExcludeUrlFilter("profiler.reactor-netty.server.excludeurl");
+        this.realIpHeader = serverConfig.getRealIpHeader("profiler.reactor-netty.server.realipheader");
+        this.realIpEmptyValue = serverConfig.getRealIpEmptyValue("profiler.reactor-netty.server.realipemptyvalue");
+        this.excludeProfileMethodFilter = serverConfig.getExcludeMethodFilter("profiler.reactor-netty.server.excludemethod");
         // Reactor
         this.traceSubscribeError = config.readBoolean("profiler.reactor-netty.trace.subscribe.error", true);
         this.traceSubscribeErrorExcludeMessageList = config.readList("profiler.reactor-netty.trace.subscribe.error.exclude.message");

--- a/plugins/resin/src/main/java/com/navercorp/pinpoint/plugin/resin/ResinConfig.java
+++ b/plugins/resin/src/main/java/com/navercorp/pinpoint/plugin/resin/ResinConfig.java
@@ -1,9 +1,8 @@
 package com.navercorp.pinpoint.plugin.resin;
 
-import com.navercorp.pinpoint.bootstrap.config.ExcludeMethodFilter;
-import com.navercorp.pinpoint.bootstrap.config.ExcludePathFilter;
 import com.navercorp.pinpoint.bootstrap.config.Filter;
 import com.navercorp.pinpoint.bootstrap.config.ProfilerConfig;
+import com.navercorp.pinpoint.bootstrap.config.ServerConfig;
 
 /**
  * @author huangpengjie@fang.com
@@ -11,24 +10,15 @@ import com.navercorp.pinpoint.bootstrap.config.ProfilerConfig;
 public class ResinConfig {
 
     private final boolean enable;
-
     private final String bootstrapMains;
-
     private final boolean hidePinpointHeader;
-
     private final boolean traceRequestParam;
-
     private final Filter<String> excludeUrlFilter;
-
     private final String realIpHeader;
-
     private final String realIpEmptyValue;
-
     private final Filter<String> excludeProfileMethodFilter;
 
-
     public ResinConfig(ProfilerConfig config) {
-
         if (config == null) {
             throw new NullPointerException("config");
         }
@@ -36,25 +26,14 @@ public class ResinConfig {
         // plugin
         this.enable = config.readBoolean("profiler.resin.enable", true);
         this.bootstrapMains = config.readString("profiler.resin.bootstrap.main", "");
-
-        // runtime
-        this.traceRequestParam = config.readBoolean("profiler.resin.tracerequestparam", true);
-        final String resinExcludeURL = config.readString("profiler.resin.excludeurl", "");
-        if (!resinExcludeURL.isEmpty()) {
-            this.excludeUrlFilter = new ExcludePathFilter(resinExcludeURL);
-        } else {
-            this.excludeUrlFilter = new ExcludePathFilter("");
-        }
-        this.realIpHeader = config.readString("profiler.resin.realipheader", null);
-        this.realIpEmptyValue = config.readString("profiler.resin.realipemptyvalue", null);
-
-        final String resinExcludeProfileMethod = config.readString("profiler.resin.excludemethod", "");
-        if (!resinExcludeProfileMethod.isEmpty()) {
-            this.excludeProfileMethodFilter = new ExcludeMethodFilter(resinExcludeProfileMethod);
-        } else {
-            this.excludeProfileMethodFilter = new ExcludeMethodFilter("");
-        }
-        this.hidePinpointHeader = config.readBoolean("profiler.resin.hidepinpointheader", true);
+        // Server
+        final ServerConfig serverConfig = new ServerConfig(config);
+        this.traceRequestParam = serverConfig.isTraceRequestParam("profiler.resin.tracerequestparam");
+        this.excludeUrlFilter = serverConfig.getExcludeUrlFilter("profiler.resin.excludeurl");
+        this.realIpHeader = serverConfig.getRealIpHeader("profiler.resin.realipheader");
+        this.realIpEmptyValue = serverConfig.getRealIpEmptyValue("profiler.resin.realipemptyvalue");
+        this.excludeProfileMethodFilter = serverConfig.getExcludeMethodFilter("profiler.resin.excludemethod");
+        this.hidePinpointHeader = serverConfig.isHidePinpointHeader("profiler.resin.hidepinpointheader");
     }
 
     public boolean isEnable() {

--- a/plugins/tomcat/src/main/java/com/navercorp/pinpoint/plugin/tomcat/TomcatConfig.java
+++ b/plugins/tomcat/src/main/java/com/navercorp/pinpoint/plugin/tomcat/TomcatConfig.java
@@ -17,11 +17,9 @@
 
 package com.navercorp.pinpoint.plugin.tomcat;
 
-import com.navercorp.pinpoint.bootstrap.config.ExcludeMethodFilter;
-import com.navercorp.pinpoint.bootstrap.config.ExcludePathFilter;
 import com.navercorp.pinpoint.bootstrap.config.Filter;
 import com.navercorp.pinpoint.bootstrap.config.ProfilerConfig;
-import com.navercorp.pinpoint.bootstrap.config.SkipFilter;
+import com.navercorp.pinpoint.bootstrap.config.ServerConfig;
 
 import java.util.List;
 
@@ -48,25 +46,14 @@ public class TomcatConfig {
         // plugin
         this.enable = config.readBoolean("profiler.tomcat.enable", true);
         this.bootstrapMains = config.readList("profiler.tomcat.bootstrap.main");
-        this.hidePinpointHeader = config.readBoolean("profiler.tomcat.hidepinpointheader", true);
-
-        // runtime
-        this.traceRequestParam = config.readBoolean("profiler.tomcat.tracerequestparam", true);
-        final String tomcatExcludeURL = config.readString("profiler.tomcat.excludeurl", "");
-        if (!tomcatExcludeURL.isEmpty()) {
-            this.excludeUrlFilter = new ExcludePathFilter(tomcatExcludeURL);
-        } else {
-            this.excludeUrlFilter = new SkipFilter<String>();
-        }
-        this.realIpHeader = config.readString("profiler.tomcat.realipheader", null);
-        this.realIpEmptyValue = config.readString("profiler.tomcat.realipemptyvalue", null);
-
-        final String tomcatExcludeProfileMethod = config.readString("profiler.tomcat.excludemethod", "");
-        if (!tomcatExcludeProfileMethod.isEmpty()) {
-            this.excludeProfileMethodFilter = new ExcludeMethodFilter(tomcatExcludeProfileMethod);
-        } else {
-            this.excludeProfileMethodFilter = new SkipFilter<String>();
-        }
+        // Server
+        final ServerConfig serverConfig = new ServerConfig(config);
+        this.hidePinpointHeader = serverConfig.isHidePinpointHeader("profiler.tomcat.hidepinpointheader");
+        this.traceRequestParam = serverConfig.isTraceRequestParam("profiler.tomcat.tracerequestparam");
+        this.excludeUrlFilter = serverConfig.getExcludeUrlFilter("profiler.tomcat.excludeurl");
+        this.realIpHeader = serverConfig.getRealIpHeader("profiler.tomcat.realipheader");
+        this.realIpEmptyValue = serverConfig.getRealIpEmptyValue("profiler.tomcat.realipemptyvalue");
+        this.excludeProfileMethodFilter = serverConfig.getExcludeMethodFilter("profiler.tomcat.excludemethod");
     }
 
     public boolean isEnable() {

--- a/plugins/undertow/src/main/java/com/navercorp/pinpoint/plugin/undertow/UndertowConfig.java
+++ b/plugins/undertow/src/main/java/com/navercorp/pinpoint/plugin/undertow/UndertowConfig.java
@@ -16,11 +16,10 @@
 
 package com.navercorp.pinpoint.plugin.undertow;
 
-import com.navercorp.pinpoint.bootstrap.config.ExcludeMethodFilter;
 import com.navercorp.pinpoint.bootstrap.config.ExcludePathFilter;
 import com.navercorp.pinpoint.bootstrap.config.Filter;
 import com.navercorp.pinpoint.bootstrap.config.ProfilerConfig;
-import com.navercorp.pinpoint.bootstrap.config.SkipFilter;
+import com.navercorp.pinpoint.bootstrap.config.ServerConfig;
 
 import java.util.List;
 
@@ -32,7 +31,6 @@ public class UndertowConfig {
     private final boolean enable;
     private final List<String> bootstrapMains;
     private final boolean hidePinpointHeader;
-
     private final boolean traceRequestParam;
     private final Filter<String> excludeUrlFilter;
     private final String realIpHeader;
@@ -40,7 +38,6 @@ public class UndertowConfig {
     private final Filter<String> excludeProfileMethodFilter;
     private final boolean deployServlet;
     private final Filter<String> httpHandlerClassNameFilter;
-
 
     public UndertowConfig(ProfilerConfig config) {
         if (config == null) {
@@ -51,25 +48,14 @@ public class UndertowConfig {
         this.enable = config.readBoolean("profiler.undertow.enable", true);
         this.deployServlet = config.readBoolean("profiler.undertow.deploy.servlet", true);
         this.bootstrapMains = config.readList("profiler.undertow.bootstrap.main");
-        this.hidePinpointHeader = config.readBoolean("profiler.undertow.hidepinpointheader", true);
-
-        // runtime
-        this.traceRequestParam = config.readBoolean("profiler.undertow.tracerequestparam", true);
-        final String tomcatExcludeURL = config.readString("profiler.undertow.excludeurl", "");
-        if (!tomcatExcludeURL.isEmpty()) {
-            this.excludeUrlFilter = new ExcludePathFilter(tomcatExcludeURL);
-        } else {
-            this.excludeUrlFilter = new SkipFilter<String>();
-        }
-        this.realIpHeader = config.readString("profiler.undertow.realipheader", null);
-        this.realIpEmptyValue = config.readString("profiler.undertow.realipemptyvalue", null);
-
-        final String tomcatExcludeProfileMethod = config.readString("profiler.undertow.excludemethod", "");
-        if (!tomcatExcludeProfileMethod.isEmpty()) {
-            this.excludeProfileMethodFilter = new ExcludeMethodFilter(tomcatExcludeProfileMethod);
-        } else {
-            this.excludeProfileMethodFilter = new SkipFilter<String>();
-        }
+        // Server
+        final ServerConfig serverConfig = new ServerConfig(config);
+        this.hidePinpointHeader = serverConfig.isHidePinpointHeader("profiler.undertow.hidepinpointheader");
+        this.traceRequestParam = serverConfig.isTraceRequestParam("profiler.undertow.tracerequestparam");
+        this.excludeUrlFilter = serverConfig.getExcludeUrlFilter("profiler.undertow.excludeurl");
+        this.realIpHeader = serverConfig.getRealIpHeader("profiler.undertow.realipheader");
+        this.realIpEmptyValue = serverConfig.getRealIpEmptyValue("profiler.undertow.realipemptyvalue");
+        this.excludeProfileMethodFilter = serverConfig.getExcludeMethodFilter("profiler.undertow.excludemethod");
 
         final String httpHandlerClassName = config.readString("profiler.undertow.http-handler.class.name", "");
         if (!httpHandlerClassName.isEmpty()) {

--- a/plugins/vertx/src/main/java/com/navercorp/pinpoint/plugin/vertx/VertxHttpServerConfig.java
+++ b/plugins/vertx/src/main/java/com/navercorp/pinpoint/plugin/vertx/VertxHttpServerConfig.java
@@ -15,11 +15,9 @@
  */
 package com.navercorp.pinpoint.plugin.vertx;
 
-import com.navercorp.pinpoint.bootstrap.config.ExcludeMethodFilter;
-import com.navercorp.pinpoint.bootstrap.config.ExcludePathFilter;
 import com.navercorp.pinpoint.bootstrap.config.Filter;
 import com.navercorp.pinpoint.bootstrap.config.ProfilerConfig;
-import com.navercorp.pinpoint.bootstrap.config.SkipFilter;
+import com.navercorp.pinpoint.bootstrap.config.ServerConfig;
 
 /**
  * @author jaehong.kim
@@ -39,25 +37,15 @@ public class VertxHttpServerConfig {
             throw new NullPointerException("config");
         }
 
-        // runtime
-        this.traceRequestParam = config.readBoolean("profiler.vertx.http.server.tracerequestparam", true);
-        final String tomcatExcludeURL = config.readString("profiler.vertx.http.server.excludeurl", "");
-        if (!tomcatExcludeURL.isEmpty()) {
-            this.excludeUrlFilter = new ExcludePathFilter(tomcatExcludeURL);
-        } else {
-            this.excludeUrlFilter = new SkipFilter<String>();
-        }
-        this.realIpHeader = config.readString("profiler.vertx.http.server.realipheader", null);
-        this.realIpEmptyValue = config.readString("profiler.vertx.http.server.realipemptyvalue", null);
-
-        final String tomcatExcludeProfileMethod = config.readString("profiler.vertx.http.server.excludemethod", "");
-        if (!tomcatExcludeProfileMethod.isEmpty()) {
-            this.excludeProfileMethodFilter = new ExcludeMethodFilter(tomcatExcludeProfileMethod);
-        } else {
-            this.excludeProfileMethodFilter = new SkipFilter<String>();
-        }
-        this.hidePinpointHeader = config.readBoolean("profiler.vertx.http.server.hidepinpointheader", true);
         this.requestHandlerMethodName = config.readString("profiler.vertx.http.server.request-handler.method.name", "io.vertx.ext.web.impl.RouterImpl.accept");
+        // Server
+        final ServerConfig serverConfig = new ServerConfig(config);
+        this.traceRequestParam = serverConfig.isTraceRequestParam("profiler.vertx.http.server.tracerequestparam");
+        this.excludeUrlFilter = serverConfig.getExcludeUrlFilter("profiler.vertx.http.server.excludeurl");
+        this.realIpHeader = serverConfig.getRealIpHeader("profiler.vertx.http.server.realipheader");
+        this.realIpEmptyValue = serverConfig.getRealIpEmptyValue("profiler.vertx.http.server.realipemptyvalue");
+        this.excludeProfileMethodFilter = serverConfig.getExcludeMethodFilter("profiler.vertx.http.server.excludemethod");
+        this.hidePinpointHeader = serverConfig.isHidePinpointHeader("profiler.vertx.http.server.hidepinpointheader");
     }
 
     public boolean isTraceRequestParam() {

--- a/plugins/vertx/src/test/java/com/navercorp/pinpoint/plugin/vertx/VertxHttpServerConfigTest.java
+++ b/plugins/vertx/src/test/java/com/navercorp/pinpoint/plugin/vertx/VertxHttpServerConfigTest.java
@@ -61,5 +61,18 @@ public class VertxHttpServerConfigTest {
         assertEquals("", config.getRealIpHeader());
         assertEquals("", config.getRealIpEmptyValue());
         assertEquals(false, config.getExcludeProfileMethodFilter().filter("CHUNK"));
+
+        properties = new Properties();
+        properties.setProperty("profiler.vertx.http.server.tracerequestparam", "true");
+        properties.setProperty("profiler.server.tracerequestparam", "false");
+        properties.setProperty("profiler.vertx.http.server.excludeurl", "/l7/check");
+        properties.setProperty("profiler.server.excludeurl", "/health");
+        properties.setProperty("profiler.vertx.http.server.realipheader", "RealIp");
+        properties.setProperty("profiler.server.realipheader", "X-Forward-Ip");
+        properties.setProperty("profiler.vertx.http.server.realipemptyvalue", "unknown");
+        properties.setProperty("profiler.server.realipemptyvalue", "UFO");
+        properties.setProperty("profiler.vertx.http.server.excludemethod", "chunk, continue");
+        properties.setProperty("profiler.server.excludemethod", "POST, PUT");
+
     }
 }

--- a/plugins/weblogic/src/main/java/com/navercorp/pinpoint/plugin/weblogic/WeblogicConfiguration.java
+++ b/plugins/weblogic/src/main/java/com/navercorp/pinpoint/plugin/weblogic/WeblogicConfiguration.java
@@ -17,11 +17,9 @@ package com.navercorp.pinpoint.plugin.weblogic;
 
 import java.util.List;
 
-import com.navercorp.pinpoint.bootstrap.config.ExcludeMethodFilter;
-import com.navercorp.pinpoint.bootstrap.config.ExcludePathFilter;
 import com.navercorp.pinpoint.bootstrap.config.Filter;
 import com.navercorp.pinpoint.bootstrap.config.ProfilerConfig;
-import com.navercorp.pinpoint.bootstrap.config.SkipFilter;
+import com.navercorp.pinpoint.bootstrap.config.ServerConfig;
 
 /**
  * @author andyspan
@@ -40,23 +38,14 @@ public class WeblogicConfiguration {
     public WeblogicConfiguration(ProfilerConfig config) {
         this.enable = config.readBoolean("profiler.weblogic.enable", true);
         this.bootstrapMains = config.readList("profiler.weblogic.bootstrap.main");
-        final String weblogicExcludeURL = config.readString("profiler.weblogic.excludeurl", "");
-
-        this.realIpHeader = config.readString("profiler.weblogic.realipheader", null);
-        this.realIpEmptyValue = config.readString("profiler.weblogic.realipemptyvalue", null);
-        if (!weblogicExcludeURL.isEmpty()) {
-            this.excludeUrlFilter = new ExcludePathFilter(weblogicExcludeURL);
-        } else {
-            this.excludeUrlFilter = new SkipFilter<String>();
-        }
-        final String excludeProfileMethod = config.readString("profiler.weblogic.excludemethod", "");
-        if (!excludeProfileMethod.isEmpty()) {
-            this.excludeProfileMethodFilter = new ExcludeMethodFilter(excludeProfileMethod);
-        } else {
-            this.excludeProfileMethodFilter = new SkipFilter<String>();
-        }
-        this.traceRequestParam = config.readBoolean("profiler.weblogic.tracerequestparam", true);
-        this.hidePinpointHeader = config.readBoolean("profiler.weblogic.hidepinpointheader", true);
+        // Server
+        final ServerConfig serverConfig = new ServerConfig(config);
+        this.excludeUrlFilter = serverConfig.getExcludeUrlFilter("profiler.weblogic.excludeurl");
+        this.realIpHeader = serverConfig.getRealIpHeader("profiler.weblogic.realipheader");
+        this.realIpEmptyValue = serverConfig.getRealIpEmptyValue("profiler.weblogic.realipemptyvalue");
+        this.excludeProfileMethodFilter = serverConfig.getExcludeMethodFilter("profiler.weblogic.excludemethod");
+        this.traceRequestParam = serverConfig.isTraceRequestParam("profiler.weblogic.tracerequestparam");
+        this.hidePinpointHeader = serverConfig.isHidePinpointHeader("profiler.weblogic.hidepinpointheader");
     }
 
     public Filter<String> getExcludeUrlFilter() {

--- a/plugins/websphere/src/main/java/com/navercorp/pinpoint/plugin/websphere/WebsphereConfiguration.java
+++ b/plugins/websphere/src/main/java/com/navercorp/pinpoint/plugin/websphere/WebsphereConfiguration.java
@@ -14,11 +14,9 @@
  */
 package com.navercorp.pinpoint.plugin.websphere;
 
-import com.navercorp.pinpoint.bootstrap.config.ExcludeMethodFilter;
-import com.navercorp.pinpoint.bootstrap.config.ExcludePathFilter;
 import com.navercorp.pinpoint.bootstrap.config.Filter;
 import com.navercorp.pinpoint.bootstrap.config.ProfilerConfig;
-import com.navercorp.pinpoint.bootstrap.config.SkipFilter;
+import com.navercorp.pinpoint.bootstrap.config.ServerConfig;
 import com.navercorp.pinpoint.common.util.Assert;
 
 import java.util.List;
@@ -46,23 +44,14 @@ public class WebsphereConfiguration {
         // plugin
         this.enable = config.readBoolean("profiler.websphere.enable", true);
         this.bootstrapMains = config.readList("profiler.websphere.bootstrap.main");
-        // runtime
-        this.traceRequestParam = config.readBoolean("profiler.websphere.tracerequestparam", true);
-        this.realIpHeader = config.readString("profiler.websphere.realipheader", null);
-        this.realIpEmptyValue = config.readString("profiler.websphere.realipemptyvalue", null);
-        final String excludeURL = config.readString("profiler.websphere.excludeurl", "");
-        if (!excludeURL.isEmpty()) {
-            this.excludeUrlFilter = new ExcludePathFilter(excludeURL);
-        } else {
-            this.excludeUrlFilter = new SkipFilter<String>();
-        }
-        final String excludeProfileMethod = config.readString("profiler.websphere.excludemethod", "");
-        if (!excludeProfileMethod.isEmpty()) {
-            this.excludeProfileMethodFilter = new ExcludeMethodFilter(excludeProfileMethod);
-        } else {
-            this.excludeProfileMethodFilter = new SkipFilter<String>();
-        }
-        this.hidePinpointHeader = config.readBoolean("profiler.websphere.hidepinpointheader", true);
+        // Server
+        final ServerConfig serverConfig = new ServerConfig(config);
+        this.traceRequestParam = serverConfig.isTraceRequestParam("profiler.websphere.tracerequestparam");
+        this.realIpHeader = serverConfig.getRealIpHeader("profiler.websphere.realipheader");
+        this.realIpEmptyValue = serverConfig.getRealIpEmptyValue("profiler.websphere.realipemptyvalue");
+        this.excludeUrlFilter = serverConfig.getExcludeUrlFilter("profiler.websphere.excludeurl");
+        this.excludeProfileMethodFilter = serverConfig.getExcludeMethodFilter("profiler.websphere.excludemethod");
+        this.hidePinpointHeader = serverConfig.isHidePinpointHeader("profiler.websphere.hidepinpointheader");
     }
 
     public boolean isEnable() {


### PR DESCRIPTION
#7161 


pinpoint-root.config
~~~
###########################################################
# SERVER                                                  #
###########################################################
# Server integration settings.
# TOMCAT, JETTY, UNDERTOW, REACTOR-NETTY, JBOSS, RESIN, WEBLOGIC, VERT.X, WEBSPHERE, AKKA
# Individual settings take precedence.
# For example, setting "profiler.tomcat.excludeurl=A" takes precedence over setting "profiler.server.excludeurl=B".

# Hide pinpoint headers.
profiler.server.hidepinpointheader=true
# URLs to exclude from tracing.
# Support ant style pattern. e.g. /aa/*.html, /??/exclude.html
profiler.server.excludeurl=
# HTTP Request methods to exclude from tracing.
# e.g. POST, PUT
profiler.server.excludemethod=
# Trace request param.
profiler.server.tracerequestparam=true
# Original IP address header. e.g. X-Forwarded-For or X-Real-IP
# https://en.wikipedia.org/wiki/X-Forwarded-For
profiler.server.realipheader=
# optional parameter, If the header value is ${profiler.server.realipemptyvalue}, Ignore header value.
profiler.server.realipemptyvalue=
~~~