### PR TITLE
Reduce memory usage of getAgentList

### DIFF
--- a/web/src/main/java/com/navercorp/pinpoint/web/batch/job/AgentCountReader.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/batch/job/AgentCountReader.java
@@ -17,6 +17,7 @@
 package com.navercorp.pinpoint.web.batch.job;
 
 import com.navercorp.pinpoint.web.service.AgentInfoService;
+import com.navercorp.pinpoint.web.vo.AgentInfoFilter;
 import com.navercorp.pinpoint.web.vo.ApplicationAgentsList;
 import org.springframework.batch.core.ExitStatus;
 import org.springframework.batch.core.StepExecution;
@@ -43,7 +44,7 @@ public class AgentCountReader implements ItemReader<ApplicationAgentsList>, Step
     @Override
     public void beforeStep(StepExecution stepExecution) {
         long timestamp = System.currentTimeMillis();
-        ApplicationAgentsList applicationAgentList = agentInfoService.getAllApplicationAgentsList(ApplicationAgentsList.Filter.NONE, timestamp);
+        ApplicationAgentsList applicationAgentList = agentInfoService.getAllApplicationAgentsList(AgentInfoFilter::accept, timestamp);
         queue.add(applicationAgentList);
     }
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/controller/AgentInfoController.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/controller/AgentInfoController.java
@@ -67,8 +67,21 @@ public class AgentInfoController {
     public ApplicationAgentsList getAgentList(
             @RequestParam("from") long from,
             @RequestParam("to") long to) {
+        ApplicationAgentsList.Filter filter = agentInfo -> {
+            AgentStatus agentStatus = agentInfo.getStatus();
+            if (agentStatus == null) {
+                return ApplicationAgentsList.Filter.REJECT;
+            }
+            if (agentStatus.getState() == AgentLifeCycleState.RUNNING) {
+                return ApplicationAgentsList.Filter.ACCEPT;
+            }
+            if (agentStatus.getEventTimestamp() >= from) {
+                return ApplicationAgentsList.Filter.ACCEPT;
+            }
+            return ApplicationAgentsList.Filter.REJECT;
+        };
         long timestamp = to;
-        return this.agentInfoService.getAllApplicationAgentsList(ApplicationAgentsList.Filter.NONE, timestamp);
+        return this.agentInfoService.getAllApplicationAgentsList(filter, timestamp);
     }
 
     @PreAuthorize("hasPermission(#applicationName, 'application', 'inspector')")

--- a/web/src/main/java/com/navercorp/pinpoint/web/dao/hbase/HbaseAgentLifeCycleDao.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/dao/hbase/HbaseAgentLifeCycleDao.java
@@ -141,11 +141,9 @@ public class HbaseAgentLifeCycleDao implements AgentLifeCycleDao {
 
     private AgentStatus createAgentStatus(String agentId, AgentLifeCycleBo agentLifeCycle) {
         if (agentLifeCycle == null) {
-            AgentStatus agentStatus = new AgentStatus(agentId);
-            agentStatus.setState(AgentLifeCycleState.UNKNOWN);
-            return agentStatus;
+            return new AgentStatus(agentId, AgentLifeCycleState.UNKNOWN, 0);
         } else {
-            return new AgentStatus(agentLifeCycle);
+            return new AgentStatus(agentLifeCycle.getAgentId(), agentLifeCycle.getAgentLifeCycleState(), agentLifeCycle.getEventTimestamp());
         }
     }
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/AgentInfoService.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/AgentInfoService.java
@@ -18,6 +18,7 @@ package com.navercorp.pinpoint.web.service;
 
 import com.navercorp.pinpoint.web.vo.AgentDownloadInfo;
 import com.navercorp.pinpoint.web.vo.AgentInfo;
+import com.navercorp.pinpoint.web.vo.AgentInfoFilter;
 import com.navercorp.pinpoint.web.vo.AgentStatus;
 import com.navercorp.pinpoint.web.vo.ApplicationAgentHostList;
 import com.navercorp.pinpoint.web.vo.ApplicationAgentsList;
@@ -33,9 +34,9 @@ import java.util.Set;
  */
 public interface AgentInfoService {
 
-    ApplicationAgentsList getAllApplicationAgentsList(ApplicationAgentsList.Filter filter, long timestamp);
+    ApplicationAgentsList getAllApplicationAgentsList(AgentInfoFilter filter, long timestamp);
 
-    ApplicationAgentsList getApplicationAgentsList(ApplicationAgentsList.GroupBy key, ApplicationAgentsList.Filter filter, String applicationName, long timestamp);
+    ApplicationAgentsList getApplicationAgentsList(ApplicationAgentsList.GroupBy key, AgentInfoFilter filter, String applicationName, long timestamp);
 
     ApplicationAgentHostList getApplicationAgentHostList(int offset, int limit);
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/AgentInfoServiceImpl.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/AgentInfoServiceImpl.java
@@ -31,6 +31,7 @@ import com.navercorp.pinpoint.web.service.stat.AgentWarningStatService;
 import com.navercorp.pinpoint.web.vo.AgentDownloadInfo;
 import com.navercorp.pinpoint.web.vo.AgentEvent;
 import com.navercorp.pinpoint.web.vo.AgentInfo;
+import com.navercorp.pinpoint.web.vo.AgentInfoFilter;
 import com.navercorp.pinpoint.web.vo.AgentStatus;
 import com.navercorp.pinpoint.web.vo.Application;
 import com.navercorp.pinpoint.web.vo.ApplicationAgentHostList;
@@ -96,7 +97,9 @@ public class AgentInfoServiceImpl implements AgentInfoService {
     }
 
     @Override
-    public ApplicationAgentsList getAllApplicationAgentsList(ApplicationAgentsList.Filter filter, long timestamp) {
+    public ApplicationAgentsList getAllApplicationAgentsList(AgentInfoFilter filter, long timestamp) {
+        Objects.requireNonNull(filter, "filter");
+
         ApplicationAgentsList.GroupBy groupBy = ApplicationAgentsList.GroupBy.APPLICATION_NAME;
         ApplicationAgentsList applicationAgentList = new ApplicationAgentsList(groupBy, filter);
         List<Application> applications = applicationIndexDao.selectAllApplicationNames();
@@ -107,9 +110,10 @@ public class AgentInfoServiceImpl implements AgentInfoService {
     }
 
     @Override
-    public ApplicationAgentsList getApplicationAgentsList(ApplicationAgentsList.GroupBy groupBy, ApplicationAgentsList.Filter filter, String applicationName, long timestamp) {
-        Objects.requireNonNull(applicationName, "applicationName");
+    public ApplicationAgentsList getApplicationAgentsList(ApplicationAgentsList.GroupBy groupBy, AgentInfoFilter filter, String applicationName, long timestamp) {
         Objects.requireNonNull(groupBy, "groupBy");
+        Objects.requireNonNull(filter, "filter");
+        Objects.requireNonNull(applicationName, "applicationName");
 
         ApplicationAgentsList applicationAgentsList = new ApplicationAgentsList(groupBy, filter);
         Set<AgentInfo> agentInfos = getAgentsByApplicationName(applicationName, timestamp);
@@ -213,7 +217,6 @@ public class AgentInfoServiceImpl implements AgentInfoService {
     @Override
     public Set<AgentInfo> getAgentsByApplicationNameWithoutStatus(String applicationName, long timestamp) {
         Objects.requireNonNull(applicationName, "applicationName");
-
         if (timestamp < 0) {
             throw new IllegalArgumentException("timestamp must not be less than 0");
         }

--- a/web/src/main/java/com/navercorp/pinpoint/web/vo/AgentInfoFilter.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/vo/AgentInfoFilter.java
@@ -1,0 +1,24 @@
+package com.navercorp.pinpoint.web.vo;
+
+public interface AgentInfoFilter {
+    boolean ACCEPT = true;
+    boolean REJECT = false;
+
+    boolean filter(AgentInfo agentInfo);
+
+    static boolean accept(AgentInfo agentInfo) {
+        return ACCEPT;
+    }
+
+    static boolean reject(AgentInfo agentInfo) {
+        return REJECT;
+    }
+
+    static boolean filterServer(AgentInfo agentInfo) {
+        if (!agentInfo.isContainer()) {
+            return ACCEPT;
+        }
+        return REJECT;
+    }
+
+}

--- a/web/src/main/java/com/navercorp/pinpoint/web/vo/AgentInfoFilterChain.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/vo/AgentInfoFilterChain.java
@@ -1,0 +1,21 @@
+package com.navercorp.pinpoint.web.vo;
+
+import java.util.Objects;
+
+public class AgentInfoFilterChain implements AgentInfoFilter {
+    private final AgentInfoFilter[] agentInfoFilters;
+
+    public AgentInfoFilterChain(AgentInfoFilter... agentInfoFilters) {
+        this.agentInfoFilters = Objects.requireNonNull(agentInfoFilters, "agentFilters");
+    }
+
+    @Override
+    public boolean filter(AgentInfo agentInfo) {
+        for (AgentInfoFilter agentFilter : this.agentInfoFilters) {
+            if (agentFilter.filter(agentInfo) == ACCEPT) {
+                return ACCEPT;
+            }
+        }
+        return REJECT;
+    }
+}

--- a/web/src/main/java/com/navercorp/pinpoint/web/vo/AgentStatus.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/vo/AgentStatus.java
@@ -17,9 +17,10 @@
 package com.navercorp.pinpoint.web.vo;
 
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.navercorp.pinpoint.common.server.bo.AgentLifeCycleBo;
 import com.navercorp.pinpoint.common.server.util.AgentLifeCycleState;
 import com.navercorp.pinpoint.web.view.AgentLifeCycleStateSerializer;
+
+import java.util.Objects;
 
 /**
  * 
@@ -33,16 +34,12 @@ public class AgentStatus {
     private long eventTimestamp;
 
     @JsonSerialize(using = AgentLifeCycleStateSerializer.class)
-    private AgentLifeCycleState state = AgentLifeCycleState.UNKNOWN;
+    private final AgentLifeCycleState state;
 
-    public AgentStatus(String agentId) {
-        this.agentId = agentId;
-    }
-
-    public AgentStatus(AgentLifeCycleBo agentLifeCycleBo) {
-        this.agentId = agentLifeCycleBo.getAgentId();
-        this.eventTimestamp = agentLifeCycleBo.getEventTimestamp();
-        this.state = agentLifeCycleBo.getAgentLifeCycleState();
+    public AgentStatus(String agentId, AgentLifeCycleState state, long eventTimestamp) {
+        this.agentId = Objects.requireNonNull(agentId, "agentId");
+        this.state = Objects.requireNonNull(state, "state");
+        this.eventTimestamp = eventTimestamp;
     }
 
     public String getAgentId() {
@@ -53,47 +50,28 @@ public class AgentStatus {
         return eventTimestamp;
     }
 
-    public void setEventTimestamp(long eventTimestamp) {
-        this.eventTimestamp = eventTimestamp;
-    }
-
     public AgentLifeCycleState getState() {
         return state;
     }
 
-    public void setState(AgentLifeCycleState state) {
-        this.state = state;
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        AgentStatus that = (AgentStatus) o;
+
+        if (eventTimestamp != that.eventTimestamp) return false;
+        if (!agentId.equals(that.agentId)) return false;
+        return state == that.state;
     }
 
     @Override
     public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + ((agentId == null) ? 0 : agentId.hashCode());
-        result = prime * result + (int)(eventTimestamp ^ (eventTimestamp >>> 32));
-        result = prime * result + ((state == null) ? 0 : state.hashCode());
+        int result = agentId.hashCode();
+        result = 31 * result + (int) (eventTimestamp ^ (eventTimestamp >>> 32));
+        result = 31 * result + state.hashCode();
         return result;
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        AgentStatus other = (AgentStatus)obj;
-        if (agentId == null) {
-            if (other.agentId != null)
-                return false;
-        } else if (!agentId.equals(other.agentId))
-            return false;
-        if (eventTimestamp != other.eventTimestamp)
-            return false;
-        if (state != other.state)
-            return false;
-        return true;
     }
 
     @Override

--- a/web/src/main/java/com/navercorp/pinpoint/web/vo/ApplicationAgentsList.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/vo/ApplicationAgentsList.java
@@ -88,27 +88,18 @@ public class ApplicationAgentsList {
         String value();
     }
 
-    public interface Filter {
-
-        boolean ACCEPT = true;
-        boolean REJECT = false;
-
-        boolean filter(AgentInfo agentInfo);
-
-        Filter NONE = agentInfo -> ACCEPT;
-    }
 
     private final GroupBy groupBy;
-    private final Filter filter;
+    private final AgentInfoFilter filter;
     private final SortedMap<GroupingKey, List<AgentInfo>> agentsMap = new TreeMap<>();
 
-    public ApplicationAgentsList(GroupBy groupBy, Filter filter) {
+    public ApplicationAgentsList(GroupBy groupBy, AgentInfoFilter filter) {
         this.groupBy = Objects.requireNonNull(groupBy, "groupBy");
         this.filter = Objects.requireNonNull(filter, "filter");
     }
 
     public void add(AgentInfo agentInfo) {
-        if (filter.filter(agentInfo) == Filter.REJECT) {
+        if (filter.filter(agentInfo) == AgentInfoFilter.REJECT) {
             return;
         }
         GroupingKey key = groupBy.extractKey(agentInfo);

--- a/web/src/main/java/com/navercorp/pinpoint/web/vo/DefaultAgentInfoFilter.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/vo/DefaultAgentInfoFilter.java
@@ -1,0 +1,26 @@
+package com.navercorp.pinpoint.web.vo;
+
+import com.navercorp.pinpoint.common.server.util.AgentLifeCycleState;
+
+public class DefaultAgentInfoFilter implements AgentInfoFilter {
+    private final long from;
+
+    public DefaultAgentInfoFilter(long from) {
+        this.from = from;
+    }
+
+    @Override
+    public boolean filter(AgentInfo agentInfo) {
+        final AgentStatus agentStatus = agentInfo.getStatus();
+        if (agentStatus == null) {
+            return REJECT;
+        }
+        if (agentStatus.getState() == AgentLifeCycleState.RUNNING) {
+            return ACCEPT;
+        }
+        if (agentStatus.getEventTimestamp() >= from) {
+            return ACCEPT;
+        }
+        return REJECT;
+    }
+};

--- a/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/ApplicationMapBuilderTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/ApplicationMapBuilderTest.java
@@ -105,8 +105,7 @@ public class ApplicationMapBuilderTest {
             public Set<AgentInfo> answer(InvocationOnMock invocation) throws Throwable {
                 String applicationName = invocation.getArgument(0);
                 AgentInfo agentInfo = ApplicationMapBuilderTestHelper.createAgentInfoFromApplicationName(applicationName);
-                AgentStatus agentStatus = new AgentStatus(agentInfo.getAgentId());
-                agentStatus.setState(AgentLifeCycleState.RUNNING);
+                AgentStatus agentStatus = new AgentStatus(agentInfo.getAgentId(), AgentLifeCycleState.RUNNING, 0);
                 agentInfo.setStatus(agentStatus);
                 Set<AgentInfo> agentInfos = new HashSet<>();
                 agentInfos.add(agentInfo);
@@ -127,9 +126,7 @@ public class ApplicationMapBuilderTest {
             @Override
             public AgentStatus answer(InvocationOnMock invocation) throws Throwable {
                 String agentId = invocation.getArgument(0);
-                AgentStatus agentStatus = new AgentStatus(agentId);
-                agentStatus.setEventTimestamp(System.currentTimeMillis());
-                agentStatus.setState(AgentLifeCycleState.RUNNING);
+                AgentStatus agentStatus = new AgentStatus(agentId, AgentLifeCycleState.RUNNING, System.currentTimeMillis());
                 return agentStatus;
             }
         });
@@ -138,9 +135,7 @@ public class ApplicationMapBuilderTest {
             public Void answer(InvocationOnMock invocation) throws Throwable {
                 Collection<AgentInfo> agentInfos = invocation.getArgument(0);
                 for (AgentInfo agentInfo : agentInfos) {
-                    AgentStatus agentStatus = new AgentStatus(agentInfo.getAgentId());
-                    agentStatus.setEventTimestamp(System.currentTimeMillis());
-                    agentStatus.setState(AgentLifeCycleState.RUNNING);
+                    AgentStatus agentStatus = new AgentStatus(agentInfo.getAgentId(), AgentLifeCycleState.RUNNING, System.currentTimeMillis());
                     agentInfo.setStatus(agentStatus);
                 }
                 return null;

--- a/web/src/test/java/com/navercorp/pinpoint/web/vo/AgentInfoFilterChainTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/vo/AgentInfoFilterChainTest.java
@@ -1,0 +1,66 @@
+package com.navercorp.pinpoint.web.vo;
+
+import com.navercorp.pinpoint.common.server.util.AgentLifeCycleState;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class AgentInfoFilterChainTest {
+
+    @Test
+    public void filter_server() {
+
+        AgentInfoFilter chain = new AgentInfoFilterChain(
+                AgentInfoFilter::filterServer,
+                AgentInfoFilter::reject
+        );
+
+        AgentInfo info = new AgentInfo();
+        info.setContainer(false);
+
+        Assert.assertEquals(AgentInfoFilter.ACCEPT, chain.filter(info));
+    }
+
+    @Test
+    public void filter_container() {
+
+        AgentInfoFilter chain = new AgentInfoFilterChain(
+                AgentInfoFilter::filterServer,
+                AgentInfoFilter::reject
+        );
+
+        AgentInfo info = new AgentInfo();
+        info.setContainer(true);
+
+        Assert.assertEquals(AgentInfoFilter.REJECT, chain.filter(info));
+    }
+
+    @Test
+    public void filter_from_accept() {
+        final long current = System.currentTimeMillis();
+
+        AgentInfoFilter chain = new AgentInfoFilterChain(
+                new DefaultAgentInfoFilter(current)
+        );
+
+        AgentStatus status = new AgentStatus("testAgent", AgentLifeCycleState.RUNNING, current);
+        AgentInfo info = new AgentInfo();
+        info.setStatus(status);
+
+        Assert.assertEquals(AgentInfoFilter.ACCEPT, chain.filter(info));
+    }
+
+    @Test
+    public void filter_from_reject() {
+        final long current = System.currentTimeMillis();
+
+        AgentInfoFilter chain = new AgentInfoFilterChain(
+                new DefaultAgentInfoFilter(Long.MAX_VALUE)
+        );
+
+        AgentStatus status = new AgentStatus("testAgent", AgentLifeCycleState.RUNNING, current);
+        AgentInfo info = new AgentInfo();
+        info.setStatus(status);
+
+        Assert.assertEquals(AgentInfoFilter.ACCEPT, chain.filter(info));
+    }
+}

--- a/web/src/test/java/com/navercorp/pinpoint/web/vo/ApplicationAgentsListTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/vo/ApplicationAgentsListTest.java
@@ -30,7 +30,7 @@ public class ApplicationAgentsListTest {
 
     @Test
     public void groupByApplicationName() {
-        ApplicationAgentsList applicationAgentsList = new ApplicationAgentsList(ApplicationAgentsList.GroupBy.APPLICATION_NAME, ApplicationAgentsList.Filter.NONE);
+        ApplicationAgentsList applicationAgentsList = new ApplicationAgentsList(ApplicationAgentsList.GroupBy.APPLICATION_NAME, AgentInfoFilter::accept);
         AgentInfo app1Agent1 = createAgentInfo("APP_1", "app1-agent1", "Host11", true);
         AgentInfo app1Agent2 = createAgentInfo("APP_1", "app1-agent2", "Host12", false);
         AgentInfo app2Agent1 = createAgentInfo("APP_2", "app2-agent1", "Host21", false);
@@ -58,7 +58,7 @@ public class ApplicationAgentsListTest {
 
     @Test
     public void groupByHostNameShouldHaveContainersFirstAndGroupedSeparatelyByAgentStartTimestampDescendingOrder() {
-        ApplicationAgentsList applicationAgentsList = new ApplicationAgentsList(ApplicationAgentsList.GroupBy.HOST_NAME, ApplicationAgentsList.Filter.NONE);
+        ApplicationAgentsList applicationAgentsList = new ApplicationAgentsList(ApplicationAgentsList.GroupBy.HOST_NAME, AgentInfoFilter::accept);
         AgentInfo host1Agent1 = createAgentInfo("APP_1", "host1-agent1", "Host1", false);
         AgentInfo host2Agent1 = createAgentInfo("APP_1", "host2-agent1", "Host2", false);
         AgentInfo containerAgent1 = createAgentInfo("APP_1", "container-agent1", "Host3", true, 1);
@@ -97,9 +97,9 @@ public class ApplicationAgentsListTest {
         AgentInfo containerAgent2 = createAgentInfo("APP_1", "container-agent2", "Host4", true, 2);
         List<AgentInfo> agentInfos = shuffleAgentInfos(containerAgent1, host1Agent1, host2Agent1, containerAgent2);
 
-        ApplicationAgentsList applicationAgentsList = new ApplicationAgentsList(ApplicationAgentsList.GroupBy.HOST_NAME, ApplicationAgentsList.Filter.NONE);
+        ApplicationAgentsList applicationAgentsList = new ApplicationAgentsList(ApplicationAgentsList.GroupBy.HOST_NAME, AgentInfoFilter::accept);
         applicationAgentsList.addAll(agentInfos.subList(0, agentInfos.size() / 2));
-        ApplicationAgentsList applicationAgentsListToMerge = new ApplicationAgentsList(ApplicationAgentsList.GroupBy.HOST_NAME, ApplicationAgentsList.Filter.NONE);
+        ApplicationAgentsList applicationAgentsListToMerge = new ApplicationAgentsList(ApplicationAgentsList.GroupBy.HOST_NAME, AgentInfoFilter::accept);
         applicationAgentsListToMerge.addAll(agentInfos.subList(agentInfos.size() / 2, agentInfos.size()));
 
         applicationAgentsList.merge(applicationAgentsListToMerge);
@@ -132,9 +132,9 @@ public class ApplicationAgentsListTest {
         AgentInfo agent1 = createAgentInfo("APP_1", "app1-agent1", "Host1", false);
         AgentInfo agent2 = createAgentInfo("APP_2", "app2-agent1", "Host2", false);
         AgentInfo agent3 = createAgentInfo("APP_2", "app2-agent2", "Host2", true);
-        ApplicationAgentsList groupedByHostnameList = new ApplicationAgentsList(ApplicationAgentsList.GroupBy.HOST_NAME, ApplicationAgentsList.Filter.NONE);
+        ApplicationAgentsList groupedByHostnameList = new ApplicationAgentsList(ApplicationAgentsList.GroupBy.HOST_NAME, AgentInfoFilter::accept);
         groupedByHostnameList.add(agent1);
-        ApplicationAgentsList groupedByApplicationNameList = new ApplicationAgentsList(ApplicationAgentsList.GroupBy.APPLICATION_NAME, ApplicationAgentsList.Filter.NONE);
+        ApplicationAgentsList groupedByApplicationNameList = new ApplicationAgentsList(ApplicationAgentsList.GroupBy.APPLICATION_NAME, AgentInfoFilter::accept);
         groupedByApplicationNameList.add(agent2);
         groupedByApplicationNameList.add(agent3);
 

--- a/web/src/test/java/com/navercorp/pinpoint/web/vo/timeline/inspector/AgentStatusTimelineBuilderTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/vo/timeline/inspector/AgentStatusTimelineBuilderTest.java
@@ -204,9 +204,7 @@ public class AgentStatusTimelineBuilderTest {
     }
 
     private static AgentStatus createAgentStatus(long timestamp, AgentLifeCycleState state) {
-        AgentStatus agentStatus = new AgentStatus("testAgent");
-        agentStatus.setEventTimestamp(timestamp);
-        agentStatus.setState(state);
+        AgentStatus agentStatus = new AgentStatus("testAgent", state, timestamp);
         return agentStatus;
     }
 

--- a/web/src/test/java/com/navercorp/pinpoint/web/vo/timeline/inspector/AgentStatusTimelineTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/vo/timeline/inspector/AgentStatusTimelineTest.java
@@ -417,9 +417,7 @@ public class AgentStatusTimelineTest {
     }
 
     private AgentStatus createAgentStatus(long timestamp, AgentLifeCycleState state) {
-        AgentStatus agentStatus = new AgentStatus("testAgent");
-        agentStatus.setEventTimestamp(timestamp);
-        agentStatus.setState(state);
+        AgentStatus agentStatus = new AgentStatus("testAgent", state, timestamp);
         return agentStatus;
     }
 


### PR DESCRIPTION
The from query parameter is not used to filter agent.

And the default getAgentList API for the agent statistics should use the from/to version for better performance. The current one will return too much data, in our case, 800MB data returned from /getAgentList.pinpoint and unable to be displayed.