### PR TITLE
Change DefaultProfilerConfig to a SingleTon

### DIFF
--- a/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/config/DefaultProfilerConfig.java
+++ b/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/config/DefaultProfilerConfig.java
@@ -75,6 +75,7 @@ public class DefaultProfilerConfig implements ProfilerConfig {
         }
     }
 
+    // For test
     public static ProfilerConfig load(String pinpointConfigFileName) throws IOException {
         final Properties properties = loadProperties(pinpointConfigFileName);
         return new DefaultProfilerConfig(properties);
@@ -168,12 +169,30 @@ public class DefaultProfilerConfig implements ProfilerConfig {
 
     private boolean customMetricEnable = false;
     private int customMetricLimitSize = 10;
+    private static DefaultProfilerConfig defaultProfilerConfig;
 
+    public static DefaultProfilerConfig getInstance () {
+        return getInstance(null);
+    }
+
+    public static DefaultProfilerConfig getInstance (Properties properties) {
+        if (defaultProfilerConfig == null) {
+            synchronized(DefaultProfilerConfig.class) {
+                if (defaultProfilerConfig == null) {
+                    defaultProfilerConfig = new DefaultProfilerConfig(properties);
+                }
+            }
+        }
+        return defaultProfilerConfig;
+    }
+
+    // For test
     public DefaultProfilerConfig() {
         this.properties = new Properties();
         this.thriftTransportConfig = new DefaultThriftTransportConfig();
     }
 
+    // For test
     public DefaultProfilerConfig(Properties properties) {
         if (properties == null) {
             throw new NullPointerException("properties");

--- a/bootstrap/src/main/java/com/navercorp/pinpoint/bootstrap/PinpointStarter.java
+++ b/bootstrap/src/main/java/com/navercorp/pinpoint/bootstrap/PinpointStarter.java
@@ -109,7 +109,8 @@ class PinpointStarter {
         try {
             final Properties properties = loadProperties();
 
-            ProfilerConfig profilerConfig = new DefaultProfilerConfig(properties);
+            // ProfilerConfig profilerConfig = new DefaultProfilerConfig(properties);
+            ProfilerConfig profilerConfig = DefaultProfilerConfig.getInstance(properties);
 
             // set the path of log file as a system property
             saveLogFilePath(agentDirectory);


### PR DESCRIPTION
Change DefaultProfilerConfig to a SingleTon,
So I can use DefaultProfilerConfig in AbstractRecorder.recordException method for record detailed exception with config。
