### PR TITLE
agent, use SizeBasedTriggeringPolicy for logging

### DIFF
--- a/agent/src/main/resources/profiles/release/log4j2.xml
+++ b/agent/src/main/resources/profiles/release/log4j2.xml
@@ -16,12 +16,12 @@
         </Console>
 
         <RollingFile name="rollingFile" filename="${logging_dir}/pinpoint.log"
-                     filepattern="${logging_dir}/pinpoint-${rolling-date-format}-%i.log">
+                     filepattern="${logging_dir}/pinpoint-%i.log">
             <PatternLayout>
                 <Pattern>${file_message_pattern}</Pattern>
             </PatternLayout>
             <Policies>
-                <TimeBasedTriggeringPolicy interval="1" modulate="true"/>
+                <SizeBasedTriggeringPolicy size="${backupsize}" />
             </Policies>
             <DefaultRolloverStrategy max="20"/>
         </RollingFile>


### PR DESCRIPTION
I found out that the version of log2j is 2.3 (log4j-api-2.3 and log4j-core-2.3) from the released agent of version 2.1.0.

> jar tvf log4j-core-2.3.jar|grep SizeBasedTriggeringPolicy
 > 4443 Sun May 10 14:13:02 CST 2015 org/apache/logging/log4j/core/appender/rolling/SizeBasedTriggeringPolicy.class