### PR TITLE
[#7268] Add exception option to call stack search

### DIFF
--- a/web/src/main/angular/src/app/core/components/call-tree/call-tree.component.ts
+++ b/web/src/main/angular/src/app/core/components/call-tree/call-tree.component.ts
@@ -472,6 +472,11 @@ export class CallTreeComponent implements OnInit, OnChanges, AfterViewInit {
                 return +data.selp >= +value;
             case 'argument':
                 return data.argument.indexOf(value) !== -1;
+            case 'exception':
+                return data.hasException && (
+                    (data.method && data.method.indexOf(value) !== -1) ||
+                    (data.argument && data.argument.indexOf(value) !== -1)
+                )
         }
     }
 

--- a/web/src/main/angular/src/app/core/components/transaction-search/transaction-search.component.html
+++ b/web/src/main/angular/src/app/core/components/transaction-search/transaction-search.component.html
@@ -3,6 +3,7 @@
         <select class="font-opensans" #searchType>
             <option value="self">Self &gt;=</option>
             <option value="argument" [attr.disabled]="useArgument ? null : ''">Argument</option>
+            <option value="exception" [attr.disabled]="useArgument ? null : ''">Exception</option>
             <option value="all" [attr.disabled]="useArgument ? null : ''">All</option>
         </select>
         <span class="fas fa-angle-down"></span>


### PR DESCRIPTION
### issue : #7268
### description
- Added **_exception_** option to search button on call tree component. 
- It is only searched if the node has exceptions.
- before option : Self, Argument, All / after option : Self, Argument, Exception, All
### screenshot
<img width="1439" alt="Screen Shot 2020-09-18 at 9 43 26 PM" src="https://user-images.githubusercontent.com/19302597/93601130-ae9f3b80-f9fb-11ea-9b42-a6b2cc22021d.png">

Thank you!